### PR TITLE
chore: use codeframe formatter (refs SFKUI-6500)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "lerna run build",
     "build:docs": "node generate-docs.mjs && lerna run build:docs && npm run build:public",
-    "build:public": "node scripts/postbuild.js && html-validate --config .htmlvalidate-public.js public",
+    "build:public": "node scripts/postbuild.js && html-validate --formatter stylish,codeframe --config .htmlvalidate-public.js public",
     "preclean": "rimraf -g .eslintcache *.tgz public temp test-results",
     "clean": "npm run --workspaces --if-present clean",
     "css-variables": "npm run --workspace packages/css-variables --",
@@ -30,7 +30,7 @@
     "design": "npm run --workspace packages/design --",
     "eslint": "eslint --cache .",
     "eslint:fix": "eslint --fix .",
-    "html-validate": "html-validate --ext md,html,vue docs packages/*/src internal/*/src",
+    "html-validate": "html-validate --formatter stylish,codeframe --ext md,html,vue docs packages/*/src internal/*/src",
     "labs": "npm run --workspace packages/vue-labs --",
     "lerna": "lerna",
     "link-all": "lerna exec npm link",


### PR DESCRIPTION
**EDIT**: nu körs både stylish OCH codeframe, så det blir dubbel output. Men det kanske är OK?

Då syns det tydligare i loggen eftersom den också visar raden som strular.

Då ser det ut så här istället:

```
/home/runner/work/designsystem/designsystem/packages/vue/src/components/FTooltip/FTooltip.vue
Error:   5:17  error  element id must not be empty         valid-id
Error:   5:17  error  Attribute "id" has invalid value ""  attribute-allowed-values
✖ 2 problems (2 errors, 0 warnings)
More information:
  https://html-validate.org/rules/valid-id.html
  https://html-validate.org/rules/attribute-allowed-values.html
error: element id must not be empty (valid-id) at /home/runner/work/designsystem/designsystem/packages/vue/src/components/FTooltip/FTooltip.vue:5:17:
  3 |         <div class="tooltip__container">
  4 |             <button
> 5 |                 id=""
    |                 ^^^^^
  6 |                 class="tooltip__button"
  7 |                 type="button"
  8 |                 :aria-expanded="isOpen ? 'true' : 'false'"
Details: https://html-validate.org/rules/valid-id.html
error: Attribute "id" has invalid value "" (attribute-allowed-values) at /home/runner/work/designsystem/designsystem/packages/vue/src/components/FTooltip/FTooltip.vue:5:[17](https://github.com/Forsakringskassan/designsystem/actions/runs/10815130212/job/30003251800?pr=27#step:8:18):
  3 |         <div class="tooltip__container">
  4 |             <button
> 5 |                 id=""
    |                 ^^
  6 |                 class="tooltip__button"
  7 |                 type="button"
  8 |                 :aria-expanded="isOpen ? 'true' : 'false'"
Details: https://html-validate.org/rules/attribute-allowed-values.html
2 errors found.
```
