### PR TITLE
chore(deps): bump peerDependencies (refs SFKUI-6500)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28340,7 +28340,7 @@
         "npm": ">= 7"
       },
       "peerDependencies": {
-        "@fkui/css-variables": "^5",
+        "@fkui/css-variables": "^5.36.0",
         "sass": "^1.40",
         "stylelint": ">= 14"
       },
@@ -28405,7 +28405,7 @@
         "npm": ">= 7"
       },
       "peerDependencies": {
-        "@fkui/date": "^5"
+        "@fkui/date": "^5.36.0"
       }
     },
     "packages/test-utils": {
@@ -28462,9 +28462,9 @@
       },
       "peerDependencies": {
         "@babel/runtime": "^7",
-        "@fkui/date": "^5",
-        "@fkui/design": "^5",
-        "@fkui/logic": "^5",
+        "@fkui/date": "^5.36.0",
+        "@fkui/design": "^5.36.0",
+        "@fkui/logic": "^5.36.0",
         "core-js": "^3.24",
         "fk-icons": "^4.30.1",
         "html-validate": ">= 7.9.0",
@@ -28507,10 +28507,10 @@
         "npm": ">= 7"
       },
       "peerDependencies": {
-        "@fkui/date": "^5",
-        "@fkui/design": "^5",
-        "@fkui/logic": "^5",
-        "@fkui/vue": "^5",
+        "@fkui/date": "^5.36.0",
+        "@fkui/design": "^5.36.0",
+        "@fkui/logic": "^5.36.0",
+        "@fkui/vue": "^5.36.0",
         "core-js": "^3.24",
         "html-validate": ">= 7.9.0",
         "vue": "^3"

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -50,7 +50,7 @@
     "svgo": "3.3.2"
   },
   "peerDependencies": {
-    "@fkui/css-variables": "^5",
+    "@fkui/css-variables": "^5.36.0",
     "sass": "^1.40",
     "stylelint": ">= 14"
   },

--- a/packages/logic/package.json
+++ b/packages/logic/package.json
@@ -83,7 +83,7 @@
     "rollup-plugin-dts": "6.1.1"
   },
   "peerDependencies": {
-    "@fkui/date": "^5"
+    "@fkui/date": "^5.36.0"
   },
   "engines": {
     "node": ">= 20",

--- a/packages/vue-labs/package.json
+++ b/packages/vue-labs/package.json
@@ -76,10 +76,10 @@
     "vue-router": "4.4.3"
   },
   "peerDependencies": {
-    "@fkui/date": "^5",
-    "@fkui/design": "^5",
-    "@fkui/logic": "^5",
-    "@fkui/vue": "^5",
+    "@fkui/date": "^5.36.0",
+    "@fkui/design": "^5.36.0",
+    "@fkui/logic": "^5.36.0",
+    "@fkui/vue": "^5.36.0",
     "core-js": "^3.24",
     "html-validate": ">= 7.9.0",
     "vue": "^3"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -89,9 +89,9 @@
   },
   "peerDependencies": {
     "@babel/runtime": "^7",
-    "@fkui/date": "^5",
-    "@fkui/design": "^5",
-    "@fkui/logic": "^5",
+    "@fkui/date": "^5.36.0",
+    "@fkui/design": "^5.36.0",
+    "@fkui/logic": "^5.36.0",
     "core-js": "^3.24",
     "fk-icons": "^4.30.1",
     "html-validate": ">= 7.9.0",


### PR DESCRIPTION
Så blir vi av med varningarna om att v5.0.0 inte är publicerad.