### PR TITLE
feat: use single `skipLink` prop on `FPageHeader` (refs SFKUI-6500)

### DIFF
--- a/docs/components/sidlayout/FPageHeader.md
+++ b/docs/components/sidlayout/FPageHeader.md
@@ -23,6 +23,26 @@ Sidhuvudet kan också visa sekundär information till höger.
 FPageHeaderCustomLogo.vue
 ```
 
+## Skiplink
+
+Skiplink är en särskild länk som fungerar som det första tabbningsbara elementet och visas endast när det fokuserats.
+Syftet är att snabbt låta en tangenbordsnavigerande användare hoppa till det primära innehållet utan att navigera genom navigeringsmenyer osv.
+
+Skiplink aktiveras genom att sätta`skipLink` till det id som innehåller det primära innehållet:
+
+```diff
+ <header>
+     <f-page-header
++        skip-link="awesome-id"
+     </f-page-header>
+ </header>
++<main>
++    <h1 id="awesome-id" tabindex="-1">
++</main>
+```
+
+Notera att elementet måste vara fokuserbart.
+
 ## API
 
 :::api

--- a/docs/components/sidlayout/FPageHeader.md
+++ b/docs/components/sidlayout/FPageHeader.md
@@ -28,7 +28,7 @@ FPageHeaderCustomLogo.vue
 Skiplink är en särskild länk som fungerar som det första tabbningsbara elementet och visas endast när det fokuserats.
 Syftet är att snabbt låta en tangenbordsnavigerande användare hoppa till det primära innehållet utan att navigera genom navigeringsmenyer osv.
 
-Skiplink aktiveras genom att sätta`skipLink` till det id som innehåller det primära innehållet:
+Skiplink aktiveras genom att sätta `skipLink` till det id som innehåller det primära innehållet:
 
 ```diff
  <header>

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -4062,9 +4062,9 @@ required: false;
 validator(value: string): boolean;
 };
 skipLink: {
-type: BooleanConstructor;
+type: PropType<string | boolean>;
 required: false;
-default: boolean;
+default: string;
 };
 skipLinkHref: {
 type: StringConstructor;
@@ -4095,6 +4095,7 @@ default: string;
 logoClass(): string;
 hasRouterLink(): boolean;
 routerLinkTo(): RouteLocationPathRaw | RouteLocationNamedRaw | null;
+skipLinkAnchor(): string | null;
 altLogoText(): string;
 }, {}, ComponentOptions, ComponentOptionsMixin, {}, string, PublicProps, Readonly<ExtractPropTypes<    {
 logoSize: {
@@ -4104,9 +4105,9 @@ required: false;
 validator(value: string): boolean;
 };
 skipLink: {
-type: BooleanConstructor;
+type: PropType<string | boolean>;
 required: false;
-default: boolean;
+default: string;
 };
 skipLinkHref: {
 type: StringConstructor;
@@ -4136,7 +4137,7 @@ default: string;
 }>>, {
 headerTag: string;
 logoSize: string;
-skipLink: boolean;
+skipLink: string | boolean;
 skipLinkHref: string;
 routerLinkPath: string;
 routerLinkName: string;

--- a/packages/vue/htmlvalidate/elements/components.js
+++ b/packages/vue/htmlvalidate/elements/components.js
@@ -1357,10 +1357,21 @@ module.exports = defineMetadata({
             "logo-size": {
                 enum: ["small", "large", "responsive"],
             },
-            "skip-link": {},
+            "skip-link": {
+                enum: ["/.+/"],
+                /* for backwards compatiblity allow the skiplink value to be
+                 * omitted (e.g. same as setting it to true) */
+                omit: true,
+            },
             "skip-link-href": {
                 enum: ["/^[#].*/"],
                 required: false,
+                deprecated: "use skip-link prop with string instead",
+                allowed(node) {
+                    return node.hasAttribute("skip-link")
+                        ? null
+                        : "requires skip-link prop to be set";
+                },
             },
             "header-tag": {
                 enum: ["span", "h1"],

--- a/packages/vue/src/components/FPageHeader/FPageHeader.cy.ts
+++ b/packages/vue/src/components/FPageHeader/FPageHeader.cy.ts
@@ -14,14 +14,14 @@ const TestComponent = defineComponent({
     template: /* HTML */ `
         <div>
             <f-page-header
-                skip-link
+                skip-link="main-content"
                 logo-size="responsive"
                 routerLinkPath="logo-link"
             >
                 Exempelapplikation
                 <template #right> Namn Namnsson </template>
             </f-page-header>
-            <a href="#" id="applicationlayout-main-content"> Huvudinnehåll </a>
+            <a href="#" id="main-content"> Huvudinnehåll </a>
         </div>
     `,
     components: {
@@ -48,7 +48,7 @@ describe("FPageHeader", () => {
         skipLink.focus().click();
 
         cy.location("hash").should("eq", "#/applicationlayout-main-content");
-        cy.get("#applicationlayout-main-content").focused();
+        cy.focused().should("have.attr", "id", "main-content");
     });
 
     it("should get application name", () => {

--- a/packages/vue/src/components/FPageHeader/FPageHeader.cy.ts
+++ b/packages/vue/src/components/FPageHeader/FPageHeader.cy.ts
@@ -47,7 +47,7 @@ describe("FPageHeader", () => {
 
         skipLink.focus().click();
 
-        cy.location("hash").should("eq", "#/applicationlayout-main-content");
+        cy.location("hash").should("eq", "#/main-content");
         cy.focused().should("have.attr", "id", "main-content");
     });
 

--- a/packages/vue/src/components/FPageHeader/FPageHeader.vue
+++ b/packages/vue/src/components/FPageHeader/FPageHeader.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="page-header__root">
-        <nav v-if="skipLink">
-            <i-skip-link :href="skipLinkHref">
+        <nav v-if="skipLinkAnchor">
+            <i-skip-link :href="skipLinkAnchor">
                 <!-- @slot Slot for skip link text. -->
                 <slot name="skip-link-text"></slot>
             </i-skip-link>
@@ -32,7 +32,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { type PropType, defineComponent } from "vue";
 import { type RouteLocationPathRaw, type RouteLocationNamedRaw } from "vue-router";
 import { TranslationMixin } from "../../plugins/translation";
 import { ISkipLink } from "../../internal-components/ISkipLink";
@@ -55,14 +55,26 @@ export default defineComponent({
         },
         /**
          * Render skiplink.
+         *
+         * When set to a non-empty string thethe skiplink feature is enabled.
+         * The string is the id of the element to move focus to.
+         *
+         * When set to `true` the deprecated `skipLinkHref` prop is used to
+         * set the element id to move focus to.
+         *
+         * When set to `false` or empty string the skiplink feature is disabled.
+         *
+         * Using a boolean is deprecated. Leave unset or a non-empty string.
          */
         skipLink: {
-            type: Boolean,
+            type: [String, Boolean] as PropType<string | boolean>,
             required: false,
-            default: false,
+            default: "",
         },
         /**
          * Target for skiplink.
+         *
+         * @deprecated Use `skipLink` prop with a non-empty string instead.
          */
         skipLinkHref: {
             type: String,
@@ -122,6 +134,16 @@ export default defineComponent({
                 return { path: routerLinkPath };
             }
             return null;
+        },
+        skipLinkAnchor(): string | null {
+            const { skipLink, skipLinkHref } = this;
+            if (skipLink === false || skipLink === "") {
+                return null;
+            } else if (skipLink === true) {
+                return skipLinkHref;
+            } else {
+                return `#${skipLink}`;
+            }
         },
         altLogoText(): string {
             return getAltLogoText(this.hasRouterLink, this.routerLinkLabel, this.$t);


### PR DESCRIPTION
Löser det jag stötte på med skiplink (dock inte att det smäller utan vue-router eller att man inte kan sätta href på logo).

Ändringen är bakåtkompatibel.