### PR TITLE
`IPopupMenu` fixes

### DIFF
--- a/docs/components/framework/IPopupMenu.md
+++ b/docs/components/framework/IPopupMenu.md
@@ -10,6 +10,19 @@ Popup-meny är en ramverkskomponent som används i samband med meny ({@link IMen
 IPopupMenuExample.vue
 ```
 
+## Teleport
+
+Komponenten använder {@link IPopup} och kommer därför att teleporteras till body-elementet när den visas som overlay.
+Detta kan ändras till valfritt element genom att ändra värdet för `config.teleportTarget`.
+
+## Fokushantering
+
+Popupmenyn kräver att du själv sätter fokus till menyn ifrån knappen som öppnar den.
+Detta kan du göra genom att ange en `key` i `v-model:focused-item` som matchar ett objekt i `items`.
+Komponenten kommer då sätta fokus på det elementet som matchade objektet.
+
+Se koden för ovan exempel för hur man kan hantera fokus till menyn i samband med tangentbordsnavigering.
+
 ## API
 
 :::api

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -6579,7 +6579,7 @@ focusElement(): HTMLElement | null;
 findItemByKey(key: string): IMenuItem | undefined;
 indexOfItemByKey(key: string): number;
 onClickItem(item: IMenuItem, doClick?: boolean): Promise<void>;
-cssClassHighlight(item: IMenuItem): string;
+itemClasses(item: IMenuItem): string[];
 setFocusOnItem(index: number): Promise<void>;
 activateItem(index: number): Promise<void>;
 setFocusedItemIndex(index: number): void;

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -6533,6 +6533,16 @@ export interface IPopupErrorData {
 
 // @public (undocumented)
 export const IPopupMenu: DefineComponent<    {
+modelValue: {
+type: StringConstructor;
+required: false;
+default: string;
+};
+focusedItem: {
+type: StringConstructor;
+required: false;
+default: string;
+};
 isOpen: {
 type: BooleanConstructor;
 required: true;
@@ -6541,19 +6551,9 @@ anchor: {
 type: PropType<HTMLElement | undefined>;
 default: undefined;
 };
-modelValue: {
-type: StringConstructor;
-required: false;
-default: string;
-};
 items: {
 type: PropType<IMenuItem[]>;
 required: true;
-};
-focusedItemKey: {
-type: StringConstructor;
-required: false;
-default: string;
 };
 enableKeyboardNavigation: {
 type: BooleanConstructor;
@@ -6585,7 +6585,17 @@ activateItem(index: number): Promise<void>;
 setFocusedItemIndex(index: number): void;
 onKeyUp(event: KeyboardEvent): void;
 onKeyDown(event: KeyboardEvent): Promise<void>;
-}, ComponentOptionsMixin, ComponentOptionsMixin, ("select" | "close" | "update:modelValue")[], "select" | "close" | "update:modelValue", PublicProps, Readonly<ExtractPropTypes<    {
+}, ComponentOptionsMixin, ComponentOptionsMixin, ("select" | "close" | "update:modelValue" | "update:focusedItem")[], "select" | "close" | "update:modelValue" | "update:focusedItem", PublicProps, Readonly<ExtractPropTypes<    {
+modelValue: {
+type: StringConstructor;
+required: false;
+default: string;
+};
+focusedItem: {
+type: StringConstructor;
+required: false;
+default: string;
+};
 isOpen: {
 type: BooleanConstructor;
 required: true;
@@ -6594,19 +6604,9 @@ anchor: {
 type: PropType<HTMLElement | undefined>;
 default: undefined;
 };
-modelValue: {
-type: StringConstructor;
-required: false;
-default: string;
-};
 items: {
 type: PropType<IMenuItem[]>;
 required: true;
-};
-focusedItemKey: {
-type: StringConstructor;
-required: false;
-default: string;
 };
 enableKeyboardNavigation: {
 type: BooleanConstructor;
@@ -6627,13 +6627,14 @@ default: string;
 onSelect?: ((...args: any[]) => any) | undefined;
 onClose?: ((...args: any[]) => any) | undefined;
 "onUpdate:modelValue"?: ((...args: any[]) => any) | undefined;
+"onUpdate:focusedItem"?: ((...args: any[]) => any) | undefined;
 }, {
 anchor: HTMLElement | undefined;
 modelValue: string;
 ariaLabel: string;
-focusedItemKey: string;
 enableKeyboardNavigation: boolean;
 selectedMenuItemScreenReaderText: string;
+focusedItem: string;
 }, {}>;
 
 // @public (undocumented)

--- a/packages/vue/src/components/FNavigationMenu/FNavigationMenu.vue
+++ b/packages/vue/src/components/FNavigationMenu/FNavigationMenu.vue
@@ -17,10 +17,10 @@
         <i-popup-menu
             ref="popupMenu"
             v-model="selectedPopupItemKey"
+            v-model:focused-item="focusedPopupMenuItemKey"
             :items="popupItems"
             :is-open="popupOpen"
             :anchor="popupAnchor"
-            :focused-item-key="focusedPopupMenuItemKey"
             :selected-menu-item-screen-reader-text="selectedMenuItemSrText()"
             :aria-label="popupAriaLabel"
             @select="onSelectPopup"

--- a/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.cy.ts
+++ b/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.cy.ts
@@ -97,6 +97,35 @@ describe("keyboard navigation", () => {
             popupMenu.getItemLink(0).should("have.focus");
         });
 
+        it("should wrap focus with arrow keys", () => {
+            cy.focused().trigger("keydown", { key: "ArrowUp" });
+            popupMenu.getItemLink(2).should("have.focus");
+
+            cy.focused().trigger("keydown", { key: "ArrowDown" });
+            popupMenu.getItemLink(0).should("have.focus");
+        });
+
+        it("should move focus with tab", () => {
+            cy.focused().trigger("keydown", { key: "Tab" });
+            popupMenu.getItemLink(1).should("have.focus");
+
+            cy.focused().trigger("keydown", { key: "Tab", shiftKey: true });
+            popupMenu.getItemLink(0).should("have.focus");
+        });
+
+        it("should close popup on tab to previous when on first item", () => {
+            cy.focused().trigger("keydown", { key: "Tab", shiftKey: true });
+            popupMenu.el().should("not.exist");
+        });
+
+        it("should close popup on tab to next when on last item", () => {
+            cy.focused().trigger("keydown", { key: "ArrowUp" });
+            popupMenu.getItemLink(2).should("have.focus");
+
+            cy.focused().trigger("keydown", { key: "Tab" });
+            popupMenu.el().should("not.exist");
+        });
+
         it("should select item with spacebar", () => {
             cy.focused().trigger("keydown", { key: "Spacebar" });
             cy.get(highlightedItemTestId).should("have.text", "key1");
@@ -119,6 +148,14 @@ describe("keyboard navigation", () => {
             popupMenu.getItemLink(0).should("have.focus");
 
             cy.focused().trigger("keydown", { key: "ArrowUp" });
+            popupMenu.getItemLink(0).should("have.focus");
+        });
+
+        it("should not programmatically move focus with tab", () => {
+            cy.focused().trigger("keydown", { key: "Tab" });
+            popupMenu.getItemLink(0).should("have.focus");
+
+            cy.focused().trigger("keydown", { key: "Tab", shiftKey: true });
             popupMenu.getItemLink(0).should("have.focus");
         });
 

--- a/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.vue
+++ b/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.vue
@@ -116,7 +116,29 @@ export default defineComponent({
             default: "vald nu",
         },
     },
-    emits: ["close", "select", "update:modelValue"],
+    emits: [
+        /**
+         * Emitted when an item is selected and when tabbing out of the popup.
+         *
+         * @event close
+         */
+        "close",
+        /**
+         * Vue 2 V-model event. Emitted when an item is selected.
+         *
+         * @event select
+         * @deprecated
+         * @type {string} item key
+         */
+        "select",
+        /**
+         * V-model event. Emitted when an item is selected.
+         *
+         * @event select
+         * @type {string} item key
+         */
+        "update:modelValue",
+    ],
     data() {
         return {
             currentFocusedItemIndex: 0,
@@ -177,28 +199,13 @@ export default defineComponent({
         },
         async onClickItem(item: IMenuItem, doClick: boolean = false): Promise<void> {
             if (item.key !== this.lastSelectedItem) {
-                /**
-                 * V-model event. Event that is dispatched when an item is selected.
-                 * @event select
-                 * @type {string} item key
-                 */
                 this.$emit("update:modelValue", item.key);
-
-                /**
-                 * Vue 2 V-model event. Event that is dispatched when an item is selected.
-                 * @event select
-                 * @deprecated
-                 * @type {string} item key
-                 */
                 this.$emit("select", item.key);
-
                 this.lastSelectedItem = item.key;
             }
-            /**
-             * Event that is dispatched after an item is selected or
-             * after pressing tab in the menu
-             */
+
             this.$emit("close");
+
             if (item.href && doClick) {
                 const anchors = getSortedHTMLElementsFromVueRef(this.$refs.anchors);
                 anchors[this.currentFocusedItemIndex]?.click();

--- a/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.vue
+++ b/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.vue
@@ -16,8 +16,7 @@
                     ref="items"
                     :key="item.key"
                     role="presentation"
-                    class="ipopupmenu__list__item"
-                    :class="cssClassHighlight(item)"
+                    :class="itemClasses(item)"
                     @click="onClickItem(item)"
                 >
                     <a
@@ -211,8 +210,9 @@ export default defineComponent({
                 anchors[this.currentFocusedItemIndex]?.click();
             }
         },
-        cssClassHighlight(item: IMenuItem): string {
-            return item.key === this.modelValue ? "ipopupmenu__list__item--highlight" : "";
+        itemClasses(item: IMenuItem): string[] {
+            const highlight = item.key === this.modelValue ? ["ipopupmenu__list__item--highlight"] : [];
+            return ["ipopupmenu__list__item", ...highlight];
         },
         async setFocusOnItem(index: number): Promise<void> {
             this.setFocusedItemIndex(index);

--- a/packages/vue/src/internal-components/IPopupMenu/examples/IPopupMenuExample.vue
+++ b/packages/vue/src/internal-components/IPopupMenu/examples/IPopupMenuExample.vue
@@ -1,36 +1,53 @@
 <template>
     <div>
-        <button ref="popupAnchor" type="button" @click="onClick">Öppna</button>
-        <pre>Highlight: {{ model }}</pre>
+        <button
+            id="popup-menu-open-button"
+            ref="popup-anchor"
+            type="button"
+            class="button button--secondary"
+            @click="onClick"
+            @keyup="onKeyUp"
+            @keydown="onKeyDown"
+        >
+            Öppna popupmeny
+        </button>
+
         <i-popup-menu
-            v-model="model"
-            :is-open="isOpen"
+            id="popup-menu"
+            v-model="selectedItem"
+            v-model:focused-item="focusedItem"
             :items="items"
+            :is-open="popupOpen"
             :anchor="getAnchor()"
-            :enable-keyboard-navigation="true"
+            enable-keyboard-navigation
             @close="onClose"
         ></i-popup-menu>
+
+        <pre>Selected item: {{ selectedItem }}</pre>
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
-import { IPopupMenu } from "@fkui/vue";
+import { IPopupMenu } from "..";
 
 const exampleItems = [
-    { label: "Det", key: "MENU_1", href: "/qwe" },
-    { label: "var", key: "MENU_2" },
-    { label: "en", key: "MENU_3" },
-    { label: "finliten", key: "MENU_4" },
-    { label: "meny", key: "MENU_5" },
-    { label: "som är", key: "MENU_6" },
-    { label: "rätt lång", key: "MENU_7" },
-    { label: "och innehållet", key: "MENU_8" },
-    { label: "kommer", key: "MENU_9" },
-    { label: "wrappas", key: "MENU_10" },
-    { label: "Med href", key: "MENU_HREF", href: "/" },
-    { label: "Testar target", key: "MENU_EXTERN", href: "http://www.google.com", target: "_blank" },
+    { label: "Länk 1", key: "MENU_1" },
+    { label: "Länk 2", key: "MENU_2" },
+    { label: "Länk 3", key: "MENU_3" },
+    { label: "Länk 4 (med href)", key: "MENU_HREF", href: "/" },
+    {
+        label: "Länk 5 (med href + target)",
+        key: "MENU_EXTERN",
+        href: "https://github.com/Forsakringskassan/designsystem",
+        target: "_blank",
+    },
 ];
+
+const upKeys = ["Up", "ArrowUp"];
+const downKeys = ["Down", "ArrowDown"];
+const verticalKeys = [...upKeys, ...downKeys];
+const preventKeys = ["Tab", ...verticalKeys];
 
 export default defineComponent({
     name: "IPopupMenuExample",
@@ -38,19 +55,47 @@ export default defineComponent({
     data() {
         return {
             items: exampleItems,
-            model: "",
-            isOpen: false,
+            selectedItem: "",
+            focusedItem: "",
+            popupOpen: false,
         };
     },
     methods: {
-        getAnchor() {
-            return this.$refs.popupAnchor;
+        getAnchor(): HTMLElement {
+            return this.$refs["popup-anchor"] as HTMLElement;
         },
-        onClose() {
-            this.isOpen = false;
+        onClose(): void {
+            this.popupOpen = false;
         },
-        onClick() {
-            this.isOpen = !this.isOpen;
+        onClick(): void {
+            this.popupOpen = !this.popupOpen;
+        },
+        onKeyUp(event: KeyboardEvent): void {
+            if (!this.popupOpen) {
+                return;
+            }
+            if (preventKeys.includes(event.key)) {
+                event.preventDefault();
+            }
+        },
+        onKeyDown(event: KeyboardEvent): void {
+            if (!this.popupOpen) {
+                return;
+            }
+            if (!preventKeys.includes(event.key)) {
+                return;
+            }
+
+            const tabNext = event.key === "Tab" && !event.shiftKey;
+            const focusPopup = tabNext || verticalKeys.includes(event.key);
+            if (focusPopup) {
+                event.preventDefault();
+                const index = upKeys.includes(event.key) ? this.items.length - 1 : 0;
+                this.focusedItem = this.items[index].key;
+                return;
+            }
+
+            this.popupOpen = false;
         },
     },
 });


### PR DESCRIPTION
- chore: move `IPopupMenu` emit docs to `emits` (refs SFKUI-6500)

I feel it is more convenient to have it in the `emits` block so I always know where emits are documented and don't have to search through the file. Since I'm touching this file I'll do it here, but maybe also think about doing this for the rest at some point? Yay/nay?

- refactor: simplify `IPopupMenu` item classes (refs SFKUI-6500)

The double `class` is a bit awkward so make this conform to structure for other components for class bindings.

- fix: fix tabbing issues in `IPopupMenu` (refs SFKUI-6644)

Fixes so that `IPopupMenu` properly handles tab between items and focus when tabbing out from the menu.

- fix: enable focus to `IPopupMenu` while using key nav (refs SFKUI-6622)

`focusedItemKey` was previously used to set focus into the menu, but wasn't available if `enable-keyboard-navigation` was used. Additionally, it had to be manually reset to set focus to same item again (such as when last focus was on first item then you wouldn't be able to tab into the popup since its the same value).

I changed the prop into a v-model instead so it can handle the reset by itself and also enable its use with key nav on (I assume I don't need to go through a deprecation process since this is an internal component).