### PR TITLE
fix: teritary buttons in table (refs SFKUI-6710)

### DIFF
--- a/packages/css-variables/src/fkui-exp-css-variables.scss
+++ b/packages/css-variables/src/fkui-exp-css-variables.scss
@@ -350,7 +350,8 @@ $global: true !default;
     --f-button-discrete-radius-hover: none;
     --f-button-discrete-table-column-action-margin: 0;
     --f-button-discrete-table-column-action-border-radius: #{$_f-border-radius-medium};
-    --f-button-discrete-table-column-action-icon-margin: 0;
+    --f-button-discrete-table-column-action-icon-margin: 0 2px 0 2px;
+    --f-button-tertiary-table-column-action-margin: 0 0 0 0.5rem;
 
     $_f-button-default-padding-top: 1rem;
     $_f-button-default-padding-right: 1.5rem;

--- a/packages/css-variables/src/fkui-int-css-variables.scss
+++ b/packages/css-variables/src/fkui-int-css-variables.scss
@@ -351,7 +351,8 @@ $global: true !default;
     --f-button-discrete-radius-hover: 3rem;
     --f-button-discrete-table-column-action-margin: 0 0 0 0.9rem;
     --f-button-discrete-table-column-action-border-radius: 0.4rem;
-    --f-button-discrete-table-column-action-icon-margin: 0 4px 0 4px;
+    --f-button-discrete-table-column-action-icon-margin: 0 2px 0 2px;
+    --f-button-tertiary-table-column-action-margin: 0 0 0 0.5rem;
 
     $_f-button-default-padding-top: 0.75rem;
     $_f-button-default-padding-right: 1rem;

--- a/packages/design/src/components/table/_table.scss
+++ b/packages/design/src/components/table/_table.scss
@@ -280,10 +280,19 @@ $table-input-offset-horizontal: 0.25rem;
                 padding-left: var(--f-button-discrete-table-column-action-padding-left);
                 /* stylelint-enable declaration-block-no-redundant-longhand-properties */
                 min-width: 24px;
+                width: max-content;
             }
 
-            &--action .button__icon {
+            &--action .button--tertiary {
+                margin: var(--f-button-tertiary-table-column-action-margin);
+                min-width: 24px;
+                width: max-content;
+            }
+
+            &--action .button--discrete .button__icon,
+            &--action .button--tertiary .button__icon {
                 margin: var(--f-button-discrete-table-column-action-icon-margin);
+                transform: translate(0, 10%);
             }
         }
     }

--- a/packages/vue/src/components/FCrudDataset/FCrudButton.vue
+++ b/packages/vue/src/components/FCrudDataset/FCrudButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <button type="button" class="button button--discrete" @click="executeAction">
+    <button type="button" class="button button--small button--tertiary" @click="executeAction">
         <f-icon v-if="icon" class="button__icon" :name="iconName"></f-icon>
         <span v-if="!label" class="sr-only">
             <slot> {{ buttonText }} </slot>

--- a/packages/vue/src/components/FCrudDataset/FCrudDataset.spec.ts
+++ b/packages/vue/src/components/FCrudDataset/FCrudDataset.spec.ts
@@ -184,7 +184,7 @@ describe("snapshot", () => {
 it("should show add button when #add slot is present", () => {
     const wrapper = createWrapper([ADD_TEMPLATE], { stubs: ["FConfirmModal"] });
     expect(wrapper.find(".crud-dataset__add-button")).toMatchInlineSnapshot(`
-        <button type="button" class="button button--discrete crud-dataset__add-button">
+        <button type="button" class="button button--tertiary crud-dataset__add-button">
           <f-icon-stub name="plus" library="f" class="button__icon"></f-icon-stub>Lägg till ny
         </button>
     `);

--- a/packages/vue/src/components/FCrudDataset/FCrudDataset.vue
+++ b/packages/vue/src/components/FCrudDataset/FCrudDataset.vue
@@ -8,7 +8,7 @@
             <button
                 data-test="f-crud-dataset-add-button"
                 type="button"
-                class="button button--discrete crud-dataset__add-button"
+                class="button button--tertiary crud-dataset__add-button"
                 @click="createItem()"
             >
                 <f-icon class="button__icon" name="plus" />

--- a/packages/vue/src/components/FCrudDataset/__snapshots__/FCrudButton.spec.ts.snap
+++ b/packages/vue/src/components/FCrudDataset/__snapshots__/FCrudButton.spec.ts.snap
@@ -1,35 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snapshot should match snapshot when action = delete 1`] = `
-<button type="button" class="button button--discrete">
+<button type="button" class="button button--small button--tertiary">
   <!--v-if--><span class="sr-only">Ta bort</span>
   <!--v-if-->
 </button>
 `;
 
 exports[`snapshot should match snapshot when action = modify 1`] = `
-<button type="button" class="button button--discrete">
+<button type="button" class="button button--small button--tertiary">
   <!--v-if--><span class="sr-only">Ändra</span>
   <!--v-if-->
 </button>
 `;
 
 exports[`snapshot should match snapshot when both label and icon is used 1`] = `
-<button type="button" class="button button--discrete">
+<button type="button" class="button button--small button--tertiary">
   <f-icon-stub name="pen" library="f" class="button__icon"></f-icon-stub>
   <!--v-if-->Ändra
 </button>
 `;
 
 exports[`snapshot should match snapshot when only icon is used 1`] = `
-<button type="button" class="button button--discrete">
+<button type="button" class="button button--small button--tertiary">
   <f-icon-stub name="pen" library="f" class="button__icon"></f-icon-stub><span class="sr-only">Ändra</span>
   <!--v-if-->
 </button>
 `;
 
 exports[`snapshot should match snapshot when only label is used 1`] = `
-<button type="button" class="button button--discrete">
+<button type="button" class="button button--small button--tertiary">
   <!--v-if-->
   <!--v-if-->Ändra
 </button>

--- a/packages/vue/src/components/FCrudDataset/__snapshots__/FCrudDataset.spec.ts.snap
+++ b/packages/vue/src/components/FCrudDataset/__snapshots__/FCrudDataset.spec.ts.snap
@@ -11,11 +11,11 @@ exports[`snapshot should match snapshot 1`] = `
     <tr>
       <td>1</td>
       <td>a</td>
-      <td><button type="button" class="button button--discrete" id="modifyButton">
+      <td><button type="button" class="button button--small button--tertiary" id="modifyButton">
           <!--v-if-->
           <!--v-if-->Ändra
         </button></td>
-      <td><button type="button" class="button button--discrete" id="deleteButton">
+      <td><button type="button" class="button button--small button--tertiary" id="deleteButton">
           <!--v-if-->
           <!--v-if-->Ta bort
         </button></td>
@@ -23,11 +23,11 @@ exports[`snapshot should match snapshot 1`] = `
     <tr>
       <td>2</td>
       <td>b</td>
-      <td><button type="button" class="button button--discrete" id="modifyButton">
+      <td><button type="button" class="button button--small button--tertiary" id="modifyButton">
           <!--v-if-->
           <!--v-if-->Ändra
         </button></td>
-      <td><button type="button" class="button button--discrete" id="deleteButton">
+      <td><button type="button" class="button button--small button--tertiary" id="deleteButton">
           <!--v-if-->
           <!--v-if-->Ta bort
         </button></td>
@@ -35,17 +35,17 @@ exports[`snapshot should match snapshot 1`] = `
     <tr>
       <td>3</td>
       <td>c</td>
-      <td><button type="button" class="button button--discrete" id="modifyButton">
+      <td><button type="button" class="button button--small button--tertiary" id="modifyButton">
           <!--v-if-->
           <!--v-if-->Ändra
         </button></td>
-      <td><button type="button" class="button button--discrete" id="deleteButton">
+      <td><button type="button" class="button button--small button--tertiary" id="deleteButton">
           <!--v-if-->
           <!--v-if-->Ta bort
         </button></td>
     </tr>
   </table>
-  <div><button type="button" class="button button--discrete crud-dataset__add-button">
+  <div><button type="button" class="button button--tertiary crud-dataset__add-button">
       <f-icon-stub name="plus" library="f" class="button__icon"></f-icon-stub>Lägg till ny
     </button></div>
   <f-form-modal-stub fullscreen="true" isopen="false" size="" datatest="" useerrorlist="false" formid="fkui-vue-element-0001" ariaclosetext="Stäng" beforesubmit="[Function]" beforevalidation="[Function]" buttons="[object Object],[object Object]" value="[object Object]"></f-form-modal-stub>

--- a/packages/vue/src/components/FInteractiveTable/examples/FInteractiveTableLiveExample.vue
+++ b/packages/vue/src/components/FInteractiveTable/examples/FInteractiveTableLiveExample.vue
@@ -206,19 +206,27 @@ export default defineComponent({
                 <f-table-column name="actions" title="Åtgärd" type="action" shrink>
                     <button
                         aria-label="Redigera"
-                        class="button button--discrete table__action"
+                        class="button button--tertiary button--small"
                         type="button"
                     >
-                        <svg aria-hidden="true" class="icon button__pen" focusable="false">
+                        <svg
+                            aria-hidden="true"
+                            class="icon button__icon button__pen"
+                            focusable="false"
+                        >
                             <use xlink:href="#f-icon-pen" />
                         </svg>
                     </button>
                     <button
                         aria-label="Ta bort"
-                        class="button button--discrete table__action"
+                        class="button button--tertiary button--small"
                         type="button"
                     >
-                        <svg aria-hidden="true" class="icon button__trashcan" focusable="false">
+                        <svg
+                            aria-hidden="true"
+                            class="icon button__icon button__trashcan"
+                            focusable="false"
+                        >
                             <use xlink:href="#f-icon-trashcan" />
                         </svg>
                     </button>


### PR DESCRIPTION
- Lägger till stöd använda tertiära knappar i tabellkolumn med åtgärder
- Fixar fall där knapp-label klipps i tabellkolumn
- Datamängsredigeraren använder tertiära istället för diskreta knappar 