### PR TITLE
chore(deps): drop unused highlight.js dependency (refs SFKUI-6500)

### DIFF
--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -1,13 +1,13 @@
-@use "~@fkui/css-variables/dist/fkui-exp-css-variables";
-@use "~@fkui/css-variables/src/palette-variables" as palette;
-@use "~@fkui/design/src/core/config-variables" with (
+@use "@fkui/css-variables/dist/fkui-exp-css-variables";
+@use "@fkui/css-variables/src/palette-variables" as palette;
+@use "@fkui/design/src/core/config-variables" with (
     $asset-path: ".",
     $asset-path-images: "./images"
 );
-@use "~@fkui/design/src/core/mixins/breakpoints";
-@use "~@fkui/design/src/fkui-exp";
-@use "~@forsakringskassan/docs-generator/style";
-@use "~@forsakringskassan/docs-live-example/dist/main";
+@use "@fkui/design/src/core/mixins/breakpoints";
+@use "@fkui/design/src/fkui-exp";
+@use "@forsakringskassan/docs-generator/style";
+@use "@forsakringskassan/docs-live-example/dist/main";
 
 :root {
     --docs-font-family: arial, "Helvetica Neue", sans-serif;

--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -5,7 +5,6 @@
     $asset-path-images: "./images"
 );
 @use "~@fkui/design/src/core/mixins/breakpoints";
-@use "~highlight.js/styles/default";
 @use "~@fkui/design/src/fkui-exp";
 @use "~@forsakringskassan/docs-generator/style";
 @use "~@forsakringskassan/docs-live-example/dist/main";

--- a/docs/src/exp-theme.scss
+++ b/docs/src/exp-theme.scss
@@ -1,4 +1,4 @@
-@use "~@fkui/css-variables/src/fkui-exp-css-variables" as fkui with (
+@use "@fkui/css-variables/src/fkui-exp-css-variables" as fkui with (
     $global: false
 );
 

--- a/docs/src/int-theme.scss
+++ b/docs/src/int-theme.scss
@@ -1,4 +1,4 @@
-@use "~@fkui/css-variables/src/fkui-int-css-variables" as fkui with (
+@use "@fkui/css-variables/src/fkui-int-css-variables" as fkui with (
     $global: false
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "flush-promises": "1.0.2",
         "fs-extra": "11.2.0",
         "glob": "11.0.0",
-        "highlight.js": "11.10.0",
         "html-validate": "8.24.1",
         "html-validate-markdown": "4.0.0",
         "html-validate-vue": "6.1.0",
@@ -14412,16 +14411,6 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.10.0.tgz",
-      "integrity": "sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/hosted-git-info": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "flush-promises": "1.0.2",
     "fs-extra": "11.2.0",
     "glob": "11.0.0",
-    "highlight.js": "11.10.0",
     "html-validate": "8.24.1",
     "html-validate-markdown": "4.0.0",
     "html-validate-vue": "6.1.0",

--- a/packages/vue-labs/docs/src/docs-theme.scss
+++ b/packages/vue-labs/docs/src/docs-theme.scss
@@ -3,7 +3,6 @@
     $asset-path: ".",
     $asset-path-images: "./images"
 );
-@use "~highlight.js/styles/default";
 @use "~@fkui/design/src/fkui-exp";
 @use "~@forsakringskassan/docs-generator/docs";
 @use "~@fkui/vue-labs/style";

--- a/packages/vue-labs/docs/src/docs-theme.scss
+++ b/packages/vue-labs/docs/src/docs-theme.scss
@@ -1,8 +1,8 @@
-@use "~@fkui/css-variables/dist/fkui-exp-css-variables";
-@use "~@fkui/design/src/core/config-variables" with (
+@use "@fkui/css-variables/dist/fkui-exp-css-variables";
+@use "@fkui/design/src/core/config-variables" with (
     $asset-path: ".",
     $asset-path-images: "./images"
 );
-@use "~@fkui/design/src/fkui-exp";
-@use "~@forsakringskassan/docs-generator/docs";
-@use "~@fkui/vue-labs/style";
+@use "@fkui/design/src/fkui-exp";
+@use "@forsakringskassan/docs-generator/docs";
+@use "@fkui/vue-labs/style";

--- a/packages/vue-labs/docs/src/exp-theme.scss
+++ b/packages/vue-labs/docs/src/exp-theme.scss
@@ -1,4 +1,4 @@
-@use "~@fkui/css-variables/src/fkui-exp-css-variables" as fkui with (
+@use "@fkui/css-variables/src/fkui-exp-css-variables" as fkui with (
     $global: false
 );
 

--- a/packages/vue-labs/docs/src/int-theme.scss
+++ b/packages/vue-labs/docs/src/int-theme.scss
@@ -1,4 +1,4 @@
-@use "~@fkui/css-variables/src/fkui-int-css-variables" as fkui with (
+@use "@fkui/css-variables/src/fkui-int-css-variables" as fkui with (
     $global: false
 );
 


### PR DESCRIPTION
and tilde imports.

Highlight.js styling is now bundled with docs-generator: forsakringskassan/docs-generator#109