### PR TITLE
feat: new prop `teleport` on `FLoader` to override default teleport target

### DIFF
--- a/docs/components/load/FLoader.md
+++ b/docs/components/load/FLoader.md
@@ -18,7 +18,11 @@ FLoaderExample.vue
 ## Teleport
 
 Komponenten teleporteras till body-elementet som standard när den visas som overlay.
-Detta kan ändras till valfritt element genom att ändra värdet för `config.teleportTarget`.
+
+Detta kan ändras till valfritt element antingen genom att
+
+-   ändra värdet för `config.teleportTarget` (global för applikationen).
+-   sätta prop `teleport` (per komponentinstans)
 
 ## API
 

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -9262,6 +9262,11 @@ type: StringConstructor;
 required: false;
 default: string;
 };
+teleport: {
+type: PropType<string | HTMLElement | undefined>;
+required: false;
+default: undefined;
+};
 }>, {}, {
 oldFocus: HTMLElement;
 }, {
@@ -9294,7 +9299,13 @@ type: StringConstructor;
 required: false;
 default: string;
 };
+teleport: {
+type: PropType<string | HTMLElement | undefined>;
+required: false;
+default: undefined;
+};
 }>> & Readonly<{}>, {
+teleport: string | HTMLElement | undefined;
 overlay: boolean;
 delay: boolean;
 language: string;

--- a/packages/vue/src/components/FLoader/FLoader.spec.ts
+++ b/packages/vue/src/components/FLoader/FLoader.spec.ts
@@ -1,5 +1,6 @@
 import "html-validate/jest";
 import { shallowMount } from "@vue/test-utils";
+import { config } from "../../config";
 import FLoader from "./FLoader.vue";
 
 describe("FLoader", () => {
@@ -63,6 +64,44 @@ describe("FLoader", () => {
             },
         });
         expect(wrapper.get(".loader__wait-text").text()).toBe("Please wait");
+    });
+});
+
+describe("props", () => {
+    describe("teleport", () => {
+        it("should teleport config.teleportTarget by default", () => {
+            expect.assertions(1);
+            config.teleportTarget = "#selector";
+            const wrapper = shallowMount(FLoader, {
+                props: { show: true },
+                global: {
+                    stubs: {
+                        teleport: {
+                            props: ["to", "disabled"],
+                            template: "{{ to }}",
+                        },
+                    },
+                },
+            });
+            expect(wrapper.text()).toBe("#selector");
+        });
+
+        it("should teleport to target set by prop", () => {
+            expect.assertions(1);
+            config.teleportTarget = "#selector";
+            const wrapper = shallowMount(FLoader, {
+                props: { show: true, teleport: "#overriden" },
+                global: {
+                    stubs: {
+                        teleport: {
+                            props: ["to", "disabled"],
+                            template: "{{ to }}",
+                        },
+                    },
+                },
+            });
+            expect(wrapper.text()).toBe("#overriden");
+        });
     });
 });
 

--- a/packages/vue/src/components/FLoader/FLoader.vue
+++ b/packages/vue/src/components/FLoader/FLoader.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { type PropType, defineComponent } from "vue";
 import { addFocusListener, findTabbableElements, removeFocusListener, restoreFocus, saveFocus } from "@fkui/logic";
 import { TranslationMixin } from "../../plugins";
 import { config } from "../../config";
@@ -79,6 +79,18 @@ export default defineComponent({
             required: false,
             default: "sv",
         },
+        /**
+         * Set teleport target (when overlay is enabled).
+         *
+         * - When set to a string it is used as a selector.
+         * - When set to a element it is used directly.
+         * - Default uses {@link config#teleportTarget}.
+         */
+        teleport: {
+            type: [String, HTMLElement] as PropType<string | HTMLElement | undefined>,
+            required: false,
+            default: undefined,
+        },
     },
     data() {
         return {
@@ -96,7 +108,11 @@ export default defineComponent({
             };
         },
         teleportTarget() {
-            return config.teleportTarget;
+            if (this.teleport) {
+                return this.teleport;
+            } else {
+                return config.teleportTarget;
+            }
         },
         teleportDisabled() {
             return !this.overlay;


### PR DESCRIPTION
Underlättar om man skapar upp en temporär applikation med en `FLoader` medans resterande filer/data hämtas. (Eftersom det då är lite klumpigt att sätta `config.teleportTarget` först till något provisoriskt)

Återstår:

* [x] Dokumentation
* [x] Testfall