### PR TITLE
feat: new `useModal()` composable for using modals with composition API

### DIFF
--- a/docs/components/modal/FFormModal.md
+++ b/docs/components/modal/FFormModal.md
@@ -14,16 +14,130 @@ Modalen har alltid en primärknapp för submit och en sekundärknapp för att av
 -   Använd inte formulärsmodaler till stora formulär, begränsa formuläret till några få komponenter och undvik flerradiga inmatningsfält.
 -   Öppna inte ytterligare modaler från en modal.
 
-## Användning med template
+## Användning
 
-```import
-FFormModalExample.vue
+Du skapar själv upp din formulärsmodal genom att skapa upp en ny Vue-komponent där `FFormModal`-komponenten nyttjas.
+
+Skapa först upp ett interface motsvarande den data din formulärsmodal ska arbeta med:
+
+```ts static
+interface Person {
+    name: string;
+    age: string;
+}
 ```
 
-## Användning med API
+Din komponent ska innehålla en prop `value` motsvarande ett objekt av interfacet:
+
+```diff
+ export default defineComponent({
+     props: {
++        value: {
++            type: Object as PropType<Person>,
++            required: true,
++        },
+     },
+ });
+```
+
+Template använder `FFormModal` och binder `value` dels som `value`-propen men också som `v-model` för respektive inmatningsfält.
+Inmatningsfälten läggs in i `#input-text-fields`-slotten.
+
+```html static
+<template>
+    <f-form-modal :value>
+        <template #header> Awesome Modal </template>
+        <template #input-text-fields>
+            <f-text-field v-model="value.name"> Namn </f-text-field>
+            <f-text-field v-model="value.age"> Ålder </f-text-field>
+        </template>
+    </f-form-modal>
+</template>
+```
+
+::: details Fullständigt exempel
+
+```vue static
+<template>
+    <f-form-modal :value>
+        <template #header> Awesome Modal </template>
+        <template #input-text-fields>
+            <f-text-field v-model="value.name"> Namn </f-text-field>
+            <f-text-field v-model="value.age"> Ålder </f-text-field>
+        </template>
+    </f-form-modal>
+</template>
+
+<script lang="ts">
+import { type PropType, defineComponent } from "vue";
+import { FFormModal, FTextField } from "@fkui/vue";
+
+interface Person {
+    name: string;
+    age: string;
+}
+
+export default defineComponent({
+    components: { FFormModal, FTextField },
+    props: {
+        value: {
+            type: Object as PropType<Person>,
+            required: true,
+        },
+    },
+});
+</script>
+```
+
+:::
+
+::: danger Tänk på att
+
+Data muteras direkt på `value`-propen.
+Det kan leda till oönskade konsekvenser om konsumenten skickas in existernade referenser till objekt istället för att skicka in en kopia eller nytt objekt.
+Du kan antingen låta din formulärsmodal hantera deta genom att internt kopiera `value` eller tydligt dokumentera att konsumenten måste skicka in en kopia.
+
+:::
+
+## Öppna modal med API
+
+Det rekommenderade sättet att använda formulärsmodalen är med {@link form-modal `formModal()`} (options API) eller {@link useModal `useModal()`} (composition API).
+
+```ts
+// options api
+const result = await formModal<Person>(this, PersonFormModal);
+
+// composition api
+const { formModal } = useModal();
+const result = await formModal<Person>(PersonFormModal);
+```
+
+Returvärdet är `Promise` som löses ut med `resolve(value)` (det objekt som ligger lagrat i `value` när modalen stängs).
+Om användaren avbryter modalen avvisas `Promise` med `reject()` .
+
+Förifylld data kan skickas in med propen `value`:
+
+```ts
+const result = await formModal<Person>(PersonFormModal, {
+    props: {
+        value: {
+            name: "Kalle Anka",
+            age: 60,
+        },
+    },
+});
+```
 
 ```import
 FFormModalApiExample.vue
+```
+
+## Öppna modal med template
+
+Komponenten kan också användas direkt i `<template>` men vi rekommenderar inte denna lösning::
+
+```import
+FFormModalExample.vue
 ```
 
 ## Formulärsmodal med flera knappar
@@ -123,6 +237,5 @@ vue:FFormModal
 
 ## Relaterat
 
-[Modal-api](#/Utilities/form-modal)
-
-[Modal dialogruta - FModal](#/Components/FModal)
+-   {@link useModal `useModal()`} (composition API) {@link form-modal `formModal()`} (options API) för programatiskt användande av formulärsmodal.
+-   {@link FModal Modal} för mer information om modaler.

--- a/docs/functions/functions/modal-functions/confirm-modal.md
+++ b/docs/functions/functions/modal-functions/confirm-modal.md
@@ -15,7 +15,7 @@ Use {@link useModal useModal()} with Composition API.
 function confirmModal(callingInstance, texts);
 ```
 
-### Parametrar
+### Parameters
 
 `callingInstance`
 : Current component attempting to open confirmation modal. Typically `this`.
@@ -34,6 +34,10 @@ function confirmModal(callingInstance, texts);
 
     `dismiss: string`
     : Text for cancel button.
+
+### Return value
+
+A `Promise` resolving to `true` if the user confirms the action and `false` if the user cancels the action.
 
 ## Exempel
 

--- a/docs/functions/functions/modal-functions/confirm-modal.md
+++ b/docs/functions/functions/modal-functions/confirm-modal.md
@@ -1,30 +1,54 @@
 ---
-title: confirmModal
-layout: content-with-menu
+title: confirmModal() function
+short-title: confirmModal()
+layout: article
 ---
 
+Open a {@link FConfirmModal} confirmation modal with given text.
+
+This is for Vue Options API.
+Use {@link useModal useModal()} with Composition API.
+
+## Syntax
+
 ```ts
-export interface confirmModalObject {
-    heading: string;
-    content: string;
-    confirm: string;
-    dismiss: string;
-}
-export async function confirmModal(
-    callingInstance: MaybeWithFKUIContext,
-    modalData: confirmModalObject,
-): Promise<boolean>;
+function confirmModal(callingInstance, texts);
 ```
 
-Provides function for simpler usage of [open-modal](#/Utilities/open-modal)
+### Parametrar
 
-## Usage
+`callingInstance`
+: Current component attempting to open confirmation modal. Typically `this`.
+
+`texts`
+: Texts to display in modal.
+
+    `heading: string`
+    : Text to display in modal header.
+
+    `content: string`
+    : Text to display in modal body.
+
+    `confirm: string`
+    : Text for confirmation button.
+
+    `dismiss: string`
+    : Text for cancel button.
+
+## Exempel
 
 ```ts
-result = await confirmModal(this, {
+const confirmed = await confirmModal(this, {
     heading: "Ta bort arbetsgivare",
     content: `Är du säker att du vill ta bort "${arbetsgivare.namn}"?`,
     confirm: "Ja, ta bort",
     dismiss: "Nej, behåll",
 });
+if (confirmed) {
+    /* ... */
+}
 ```
+
+## Relaterat
+
+-   {@link useModal useModal()} for using with composition API.

--- a/docs/functions/functions/modal-functions/form-modal.md
+++ b/docs/functions/functions/modal-functions/form-modal.md
@@ -1,25 +1,41 @@
 ---
-title: formModal
-layout: content-with-menu
+title: formModal() function
+short-title: formModal()
+layout: article
 ---
 
+Open a form inside a {@link FFormModal} modal and return the form data.
+
+This is for Vue Options API.
+Use {@link useModal useModal()} with Composition API.
+
+## Syntax
+
 ```ts
-export interface ModalOptions {
-    /** Modal size */
-    size: "large" | "fullscreen";
-    /** Modal props */
-    props: Record<string, string | undefined>;
-}
-
-type MaybeOptions = Partial<ModalOptions>;
-
-export async function formModal<T>(
-    Component: MaybeComponent,
-    options?: MaybeOptions,
-): Promise<T>;
+function formModal(callingInstance, options);
 ```
 
-Provides an API to programatically open FFormModal dialogs.
+### Parametrar
+
+`callingInstance`
+: Current component attempting to open confirmation modal. Typically `this`.
+
+`options` {@optional}
+: Modal options.
+
+    `size` {@optional}
+    : Optional modal size.
+
+        Must be one of:
+
+    	- `"large"`
+    	- `"fullscreen"
+
+    `beforeSubmit` {@optional}
+    : Optional callback passed to {@link FFormModal}.
+
+    `props` {@optional}
+    : Optional props to pass to modal.
 
 ## Usage
 
@@ -66,3 +82,7 @@ try {
 console.log("Modal closed with result", result);
 // Modal closed with result `data`
 ```
+
+## Relaterat
+
+-   {@link useModal useModal()} for using with composition API.

--- a/docs/functions/functions/modal-functions/form-modal.md
+++ b/docs/functions/functions/modal-functions/form-modal.md
@@ -15,7 +15,7 @@ Use {@link useModal useModal()} with Composition API.
 function formModal(callingInstance, options);
 ```
 
-### Parametrar
+### Parameters
 
 `callingInstance`
 : Current component attempting to open confirmation modal. Typically `this`.
@@ -36,6 +36,10 @@ function formModal(callingInstance, options);
 
     `props` {@optional}
     : Optional props to pass to modal.
+
+### Return value
+
+A `Promise` resolving to the form data bound to the `value` prop.
 
 ## Usage
 

--- a/docs/functions/functions/use-modal.md
+++ b/docs/functions/functions/use-modal.md
@@ -20,11 +20,11 @@ Use {@link open-modal openModal()}, {@link confirm-modal confirmModal()} and {@l
 function useModal();
 ```
 
-### Parametrar
+### Parameters
 
 None
 
-### Returvärde
+### Return value
 
 `openModal(component, options)`
 : A wrapped {@link open-modal openModal()} function without `callingInstance` parameter.
@@ -69,7 +69,7 @@ const { formModal } = useModal();
 const result = await formModal<MyAwesomeData>(MyAwesomeModal);
 ```
 
-## Relaterat
+## Related
 
 -   {@link open-modal openModal()}
 -   {@link confirm-modal confirmModal()}

--- a/docs/functions/functions/use-modal.md
+++ b/docs/functions/functions/use-modal.md
@@ -1,0 +1,76 @@
+---
+title: useModal() composable
+short-title: useModal()
+name: useModal
+layout: article
+---
+
+Composable to get access to modal functions without using `callingInstance`:
+
+-   `openModal()`
+-   `confirmModal()`
+-   `formModal()`
+
+This is for Vue Composition API.
+Use {@link open-modal openModal()}, {@link confirm-modal confirmModal()} and {@link form-modal formModal()} with Options API.
+
+## Syntax
+
+```ts
+function useModal();
+```
+
+### Parametrar
+
+None
+
+### Returvärde
+
+`openModal(component, options)`
+: A wrapped {@link open-modal openModal()} function without `callingInstance` parameter.
+
+`confirmModal(text)`
+: A wrapped {@link confirm-modal confirmModal()} function without `callingInstance` parameter.
+
+`formModal(component, options)`
+: A wrapped {@link form-modal formModal()} function without `callingInstance` parameter.
+
+## Example
+
+Open a simple modal:
+
+```ts
+const { openModal } = useModal();
+
+const result = await openModal(MyAwesomeModal);
+```
+
+Open a confirmation modal:
+
+```ts
+const { confirmModal } = useModal();
+
+const confirmed = await confirmModal({
+    heading: "Ta bort arbetsgivare",
+    content: `Är du säker att du vill ta bort "${arbetsgivare.namn}"?`,
+    confirm: "Ja, ta bort",
+    dismiss: "Nej, behåll",
+});
+if (confirmed) {
+    /* ... */
+}
+```
+
+Open a form modal:
+
+```ts
+const { formModal } = useModal();
+
+const result = await formModal<MyAwesomeData>(MyAwesomeModal);
+```
+
+## Relaterat
+
+-   {@link open-modal openModal()}
+-   {@link confirm-modal confirmModal()}
+-   {@link form-modal formModal()}

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -107,11 +107,11 @@ export type ComponentValueTypes = ComponentValidityEvent | Reference<FormErrorLi
 // @public (undocumented)
 export const config: FKUIConfig;
 
-// @public (undocumented)
-export function confirmModal(callingInstance: MaybeWithFKUIContext, modalData: confirmModalObject): Promise<boolean>;
+// @public
+export function confirmModal(callingInstance: MaybeWithFKUIContext, texts: ConfirmModalTexts): Promise<boolean>;
 
 // @public (undocumented)
-export interface confirmModalObject {
+export interface ConfirmModalTexts {
     // (undocumented)
     confirm: string;
     // (undocumented)
@@ -18388,6 +18388,16 @@ export const UNHANDLED_ERROR_EVENT: "unhandled-error";
 
 // @public (undocumented)
 export type UnknownItem = Record<string, unknown>;
+
+// @public
+export interface UseModal {
+    confirmModal(texts: ConfirmModalTexts): Promise<boolean>;
+    formModal<T>(component: Component, options?: Partial<OpenModalModaloptions>): Promise<T>;
+    openModal<T>(component: Component, options?: Partial<OpenModalModaloptions>): AsyncModalResult<T>;
+}
+
+// @public (undocumented)
+export function useModal(): UseModal;
 
 // @public
 export function useTranslate(): TranslateFunction;

--- a/packages/vue/src/components/FModal/FFormModal/FFormModal.vue
+++ b/packages/vue/src/components/FModal/FFormModal/FFormModal.vue
@@ -55,7 +55,7 @@
                         type="submit"
                         class="button button--primary button-group__item button--large"
                     >
-                        <!-- @slot @deprecated - Slot for submit button text. If you want to modify the footer section, see prop "buttons" -->
+                        <!-- @slot - @deprecated Slot for submit button text. If you want to modify the footer section, see prop "buttons" -->
                         <slot name="submit-button-text">
                             {{ $t("fkui.form-modal.button.submit.text", "Spara") }}
                         </slot>
@@ -66,7 +66,7 @@
                         class="button button--secondary button-group__item button--large"
                         @click="onCancel"
                     >
-                        <!-- @slot @deprecated -  Slot for cancel button text. If you want to modify the footer section, see prop "buttons" -->
+                        <!-- @slot - @deprecated Slot for cancel button text. If you want to modify the footer section, see prop "buttons" -->
                         <slot name="cancel-button-text">
                             {{ $t("fkui.form-modal.button.cancel.text", "Avbryt") }}
                         </slot>

--- a/packages/vue/src/utils/confirm-modal/confirm-modal.ts
+++ b/packages/vue/src/utils/confirm-modal/confirm-modal.ts
@@ -5,7 +5,7 @@ import { openModal } from "../open-modal";
 /**
  * @public
  */
-export interface confirmModalObject {
+export interface ConfirmModalTexts {
     heading: string;
     content: string;
     confirm: string;
@@ -14,19 +14,30 @@ export interface confirmModalObject {
 
 /**
  * @public
+ * @deprecated Deprecated alias, use [[ConfirmModalTexts]].
+ */
+export type confirmModalObject = ConfirmModalTexts;
+
+/**
+ * Open a confirmation modal with given text.
+ *
+ * @public
+ * @param texts - Texts to show in modal.
+ * @returns A promise resolved with a `true` if modal was dismissed in a
+ * positive manner ("Yes, I want to ...") or `false` if dismissed in a negative manner ("No, don't ...")
  */
 export async function confirmModal(
     callingInstance: MaybeWithFKUIContext,
-    modalData: confirmModalObject,
+    texts: ConfirmModalTexts,
 ): Promise<boolean> {
     const buttons = [
-        { label: modalData.confirm, event: "confirm", type: "primary" },
-        { label: modalData.dismiss, event: "dismiss", type: "secondary" },
+        { label: texts.confirm, event: "confirm", type: "primary" },
+        { label: texts.dismiss, event: "dismiss", type: "secondary" },
     ];
     const { reason } = await openModal(callingInstance, FConfirmModal, {
         props: {
-            heading: modalData.heading,
-            content: modalData.content,
+            heading: texts.heading,
+            content: texts.content,
             buttons,
         },
     });

--- a/packages/vue/src/utils/confirm-modal/index.ts
+++ b/packages/vue/src/utils/confirm-modal/index.ts
@@ -1,1 +1,1 @@
-export { type confirmModalObject, confirmModal } from "./confirm-modal";
+export { type ConfirmModalTexts, confirmModal } from "./confirm-modal";

--- a/packages/vue/src/utils/index.ts
+++ b/packages/vue/src/utils/index.ts
@@ -23,6 +23,7 @@ export { getInputElement } from "./get-input-element";
 export { hasSlot } from "./has-slot";
 export { type MaybeComponent } from "./maybe-component";
 export { type RenderSlotOptions, renderSlotText } from "./render-slot-text";
+export { type UseModal, useModal } from "./use-modal";
 export {
     findParentByName,
     getParentByName,

--- a/packages/vue/src/utils/open-modal/open-modal.ts
+++ b/packages/vue/src/utils/open-modal/open-modal.ts
@@ -35,6 +35,11 @@ function unpackPayload<T = void>(
  * Props can be passed to the component using the options parameter.
  *
  * @public
+ *
+ * @param component - Vue component to render.
+ * @param options - Component options.
+ * @returns A promise resolved with reason for dismissal and optionally a
+ * payload when the modal is closed.
  */
 export function openModal<T = void>(
     callingInstance: MaybeWithFKUIContext,

--- a/packages/vue/src/utils/use-modal.cy.ts
+++ b/packages/vue/src/utils/use-modal.cy.ts
@@ -1,0 +1,161 @@
+import { defineComponent, PropType, ref } from "vue";
+import { FFormModal, FModal, FTextField } from "../components";
+import { useModal } from "./use-modal";
+
+interface FormData {
+    name: string;
+}
+
+const page = {
+    button: "button",
+    pre: "pre",
+    modal: ".modal__dialog-container",
+    modalHeader: ".modal__header",
+    modalContent: ".modal__content",
+    modalDismiss: ".modal__dialog-container button.close-button",
+    modalSubmit: ".modal__dialog-container button[type=submit]",
+    modalFormInput: ".modal__dialog-container input",
+};
+
+it("openModal() should open modal", () => {
+    const MockModal = defineComponent({
+        template: /* HTML */ `
+            <f-modal>
+                <template #header> Awesome Modal </template>
+                <template #content> {{ content }} </template>
+            </f-modal>
+        `,
+        components: { FModal },
+        props: {
+            content: {
+                type: String,
+                required: true,
+            },
+        },
+    });
+    const TestComponent = defineComponent({
+        template: /* HTML */ `
+            <button type="button" @click="onClick">Open modal</button>
+            <pre>{{ result }}</pre>
+        `,
+        setup() {
+            const { openModal } = useModal();
+            const result = ref("");
+            async function onClick(): Promise<void> {
+                const data = await openModal(MockModal, {
+                    props: {
+                        content: "Lorem ipsum dolor sit amet",
+                    },
+                });
+                result.value = JSON.stringify(data);
+            }
+            return { result, onClick };
+        },
+    });
+    cy.mount(TestComponent);
+    cy.get(page.modal).should("not.exist");
+    cy.get("button").click();
+    cy.get(page.modal).should("be.visible");
+    cy.get(page.modalHeader).should("contain.text", "Awesome Modal");
+    cy.get(page.modalContent).should(
+        "contain.text",
+        "Lorem ipsum dolor sit amet",
+    );
+    cy.get(page.modalDismiss).click();
+    cy.get(page.modal).should("not.exist");
+    cy.get(page.pre).should("have.text", JSON.stringify({ reason: "close" }));
+});
+
+it("confirmModal() should open a confirmation modal", () => {
+    const TestComponent = defineComponent({
+        template: /* HTML */ `
+            <button type="button" @click="onClick">Open modal</button>
+            <pre>{{ result }}</pre>
+        `,
+        setup() {
+            const { confirmModal } = useModal();
+            const result = ref("");
+            async function onClick(): Promise<void> {
+                const data = await confirmModal({
+                    heading: "Awesome Modal",
+                    content: "Lorem ipsum dolor sit amet",
+                    confirm: "Yeah",
+                    dismiss: "Nope",
+                });
+                result.value = JSON.stringify(data);
+            }
+            return { result, onClick };
+        },
+    });
+    cy.mount(TestComponent);
+    cy.get(page.modal).should("not.exist");
+    cy.get("button").click();
+    cy.get(page.modal).should("be.visible");
+    cy.get(page.modalHeader).should("contain.text", "Awesome Modal");
+    cy.get(page.modalContent).should(
+        "contain.text",
+        "Lorem ipsum dolor sit amet",
+    );
+    cy.get(page.modalDismiss).click();
+    cy.get(page.modal).should("not.exist");
+    cy.get(page.pre).should("have.text", JSON.stringify(false));
+});
+
+it("formModal() should open form modal", () => {
+    const MockModal = defineComponent({
+        template: /* HTML */ `
+            <f-form-modal :value>
+                <template #header> Awesome Modal </template>
+                <template #input-text-fields>
+                    <f-text-field v-model="value.name">
+                        Awesome Field
+                    </f-text-field>
+                </template>
+            </f-form-modal>
+        `,
+        components: { FFormModal, FTextField },
+        props: {
+            value: {
+                type: Object as PropType<FormData>,
+                required: true,
+            },
+        },
+    });
+    const TestComponent = defineComponent({
+        template: /* HTML */ `
+            <button type="button" @click="onClick">Open modal</button>
+            <pre>{{ result }}</pre>
+        `,
+        setup() {
+            const { formModal } = useModal();
+            const result = ref("");
+            async function onClick(): Promise<void> {
+                const value = {
+                    name: "Kalle Anka",
+                } satisfies FormData;
+                const data = await formModal(MockModal, {
+                    props: {
+                        value,
+                    },
+                });
+                result.value = JSON.stringify(data);
+            }
+            return { result, onClick };
+        },
+    });
+    cy.mount(TestComponent);
+    cy.get(page.modal).should("not.exist");
+    cy.get("button").click();
+    cy.get(page.modal).should("be.visible");
+    cy.get(page.modalHeader).should("contain.text", "Awesome Modal");
+    cy.get(page.modalFormInput).should("have.value", "Kalle Anka");
+    cy.get(page.modalFormInput).clear();
+    cy.get(page.modalFormInput).type("Joakim von Anka");
+    cy.get(page.modalFormInput).blur();
+    cy.get(page.modalSubmit).click();
+    cy.get(page.modal).should("not.exist");
+    cy.get(page.pre).should(
+        "have.text",
+        JSON.stringify({ name: "Joakim von Anka" }),
+    );
+});

--- a/packages/vue/src/utils/use-modal.cy.ts
+++ b/packages/vue/src/utils/use-modal.cy.ts
@@ -1,4 +1,4 @@
-import { defineComponent, PropType, ref } from "vue";
+import { type PropType, defineComponent, ref } from "vue";
 import { FFormModal, FModal, FTextField } from "../components";
 import { useModal } from "./use-modal";
 

--- a/packages/vue/src/utils/use-modal.ts
+++ b/packages/vue/src/utils/use-modal.ts
@@ -1,0 +1,80 @@
+import { type Component, getCurrentInstance } from "vue";
+import { type MaybeWithFKUIContext } from "../config";
+import {
+    type AsyncModalResult,
+    type ModalOptions,
+    openModal,
+} from "./open-modal";
+import { type ConfirmModalTexts, confirmModal } from "./confirm-modal";
+import { formModal } from "./form-modal";
+
+/**
+ * Composable to get access to modal functions.
+ *
+ * @public
+ */
+export interface UseModal {
+    /**
+     * Opens a modal using the given component.
+     *
+     * The component must adhere to the following rules:
+     *
+     * - Either be open by default or use a prop named `is-open` to toggle it.
+     * - Emit the `close` event with the payload implementing `PartialResult<T>`.
+     *
+     * Props can be passed to the component using the options parameter.
+     *
+     * @param component - Vue component to render.
+     * @param options - Component options.
+     * @returns A promise resolved with reason for dismissal and optionally a
+     * payload when the modal is closed.
+     */
+    openModal<T>(
+        component: Component,
+        options?: Partial<ModalOptions>,
+    ): AsyncModalResult<T>;
+
+    /**
+     * Open a confirmation modal with given text.
+     *
+     * @public
+     * @param texts - Texts to show in modal.
+     * @returns A promise resolved with a `true` if modal was dismissed in a
+     * positive manner ("Yes, I want to ...") or `false` if dismissed in a negative manner ("No, don't ...")
+     */
+    confirmModal(texts: ConfirmModalTexts): Promise<boolean>;
+
+    /**
+     * Open a form modal and return the results from the input fields.
+     *
+     * @param Component - Vue component to render.
+     * @param options - Component options.
+     * @returns A promise resolved with values from input fields or rejected if user cancels.
+     */
+    formModal<T>(
+        component: Component,
+        options?: Partial<ModalOptions>,
+    ): Promise<T>;
+}
+
+/**
+ * @public
+ */
+export function useModal(): UseModal {
+    const instance = getCurrentInstance();
+    if (!instance) {
+        throw new Error(`useModal(..) used outside component scope`);
+    }
+    const context: MaybeWithFKUIContext = { $fkui: instance };
+    return {
+        openModal(component, options) {
+            return openModal(context, component, options);
+        },
+        confirmModal(texts) {
+            return confirmModal(context, texts);
+        },
+        formModal(component, options) {
+            return formModal(context, component, options);
+        },
+    };
+}


### PR DESCRIPTION
Det kom upp på FE-synk och kunde inte hålla fingrarna i styr.

Möjliggör att använda modal-funktionerna med composition:

```html
<script setup>
const { confirmModal } = useModal();

async function onClickButton() {
    const confirmed = await confirmModal({ content: "Är du säker att du vill ..." });
    if (confirmed) {
        /* do dangerous but confirmed action */
    }
}
</script>
```