### PR TITLE
fix: modal shelf color (refs SFKUI-6500)

### DIFF
--- a/packages/css-variables/src/fkui-exp-css-variables.scss
+++ b/packages/css-variables/src/fkui-exp-css-variables.scss
@@ -166,7 +166,7 @@ $global: true !default;
     --f-background-dialogue-tree: #{$palette-color-white-100};
     --f-background-dialogue-tree-hover: #{$palette-color-bluebell-15};
 
-    --f-background-modal-shelf: #{$palette-color-fk-black-15};
+    --f-background-modal-shelf: #{$palette-color-white-100};
 
     // *************
     // BORDER COLORS

--- a/packages/css-variables/src/fkui-int-css-variables.scss
+++ b/packages/css-variables/src/fkui-int-css-variables.scss
@@ -168,7 +168,7 @@ $global: true !default;
     --f-background-dialogue-tree: #{$palette-color-white-100};
     --f-background-dialogue-tree-hover: #{$palette-color-bluebell-15};
 
-    --f-background-modal-shelf: #{$palette-color-fk-black-15};
+    --f-background-modal-shelf: #{$palette-color-white-100};
 
     // *************
     // BORDER COLORS


### PR DESCRIPTION
Ändrar  till vit bakgrundsfärg i standardmodalens (och formulärsmodalens)  list. 