### PR TITLE
docs: added documentation for personnummer validators (refs KDK-48741)

### DIFF
--- a/docs/components/validation/examples/PersonnummerNotSameExample.cy.ts
+++ b/docs/components/validation/examples/PersonnummerNotSameExample.cy.ts
@@ -1,0 +1,41 @@
+import PersonnummerNotSameExample from "./PersonnummerNotSameExample.vue";
+
+const inputReference = `.text-field:has(#personnummer-not-same-reference) input`;
+const errorReference = `.text-field:has(#personnummer-not-same-reference) .label__message--error`;
+const input = `.text-field:has(#personnummer-not-same-input) input`;
+const error = `.text-field:has(#personnummer-not-same-input) .label__message--error`;
+
+// The test social security numbers(personnummer) used is approved by Skatteverket.
+
+it("should allow empty input", () => {
+    cy.mount(PersonnummerNotSameExample);
+    cy.get(inputReference).clear();
+    cy.get(inputReference).blur();
+    cy.get(errorReference).should("not.exist");
+    cy.get(input).clear();
+    cy.get(input).blur();
+    cy.get(error).should("not.exist");
+});
+
+it("should allow valid personnummer with 12 digits", () => {
+    cy.mount(PersonnummerNotSameExample);
+    cy.get(inputReference).clear();
+    cy.get(inputReference).type("19120211-9150");
+    cy.get(inputReference).blur();
+    cy.get(errorReference).should("not.exist");
+    cy.get(input).clear();
+    cy.get(input).type("20130101-2397");
+    cy.get(input).blur();
+    cy.get(error).should("not.exist");
+});
+
+it("should show error when personnummer is the same", () => {
+    cy.mount(PersonnummerNotSameExample);
+    cy.get(inputReference).clear();
+    cy.get(inputReference).type("19120211-9150");
+    cy.get(inputReference).blur();
+    cy.get(input).clear();
+    cy.get(input).type("19120211-9150");
+    cy.get(input).blur();
+    cy.get(error).should("exist");
+});

--- a/docs/components/validation/examples/PersonnummerNotSameExample.vue
+++ b/docs/components/validation/examples/PersonnummerNotSameExample.vue
@@ -1,0 +1,40 @@
+<template>
+    <div class="row">
+        <div class="col col--md-6">
+            <f-text-field
+                id="personnummer-not-same-reference"
+                v-model="reference"
+                v-validation.personnummerFormat
+            >
+                Fyll i ett personnummer (referens)
+            </f-text-field>
+        </div>
+        <div class="col col--md-6">
+            <f-text-field
+                id="personnummer-not-same-input"
+                v-model="model"
+                v-validation.personnummerFormat.personnummerNotSame="{
+                    personnummerNotSame: { otherField: reference },
+                }"
+            >
+                Fyll i ett personnummer
+            </f-text-field>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { FTextField } from "@fkui/vue";
+
+export default defineComponent({
+    name: "PersonnummerNotSameExample",
+    components: { FTextField },
+    data() {
+        return {
+            reference: "",
+            model: "",
+        };
+    },
+});
+</script>

--- a/docs/components/validation/examples/PersonnummerOlderExample.cy.ts
+++ b/docs/components/validation/examples/PersonnummerOlderExample.cy.ts
@@ -1,0 +1,52 @@
+import PersonnummerOlderExample from "./PersonnummerOlderExample.vue";
+
+const inputReference = `.text-field:has(#personnummer-older-reference) input`;
+const errorReference = `.text-field:has(#personnummer-older-reference) .label__message--error`;
+const input = `.text-field:has(#personnummer-older-input) input`;
+const error = `.text-field:has(#personnummer-older-input) .label__message--error`;
+
+// The test social security numbers(personnummer) used is approved by Skatteverket.
+
+it("should allow empty input", () => {
+    cy.mount(PersonnummerOlderExample);
+    cy.get(inputReference).clear();
+    cy.get(inputReference).blur();
+    cy.get(errorReference).should("not.exist");
+    cy.get(input).clear();
+    cy.get(input).blur();
+    cy.get(error).should("not.exist");
+});
+
+it("should allow valid personnummer with 12 digits", () => {
+    cy.mount(PersonnummerOlderExample);
+    cy.get(inputReference).clear();
+    cy.get(inputReference).type("19120211-9150");
+    cy.get(inputReference).blur();
+    cy.get(errorReference).should("not.exist");
+    cy.get(input).clear();
+    cy.get(input).type("19120211-9150");
+    cy.get(input).blur();
+    cy.get(error).should("not.exist");
+});
+
+it("should allow personnummer that is older", () => {
+    cy.mount(PersonnummerOlderExample);
+    cy.get(inputReference).clear();
+    cy.get(inputReference).type("20130101-2397");
+    cy.get(inputReference).blur();
+    cy.get(input).clear();
+    cy.get(input).type("19120211-9150");
+    cy.get(input).blur();
+    cy.get(error).should("not.exist");
+});
+
+it("should show error when personnummer isn't older", () => {
+    cy.mount(PersonnummerOlderExample);
+    cy.get(inputReference).clear();
+    cy.get(inputReference).type("19120211-9150");
+    cy.get(inputReference).blur();
+    cy.get(input).clear();
+    cy.get(input).type("20130101-2397");
+    cy.get(input).blur();
+    cy.get(error).should("exist");
+});

--- a/docs/components/validation/examples/PersonnummerOlderExample.vue
+++ b/docs/components/validation/examples/PersonnummerOlderExample.vue
@@ -1,0 +1,40 @@
+<template>
+    <div class="row">
+        <div class="col col--md-6">
+            <f-text-field
+                id="personnummer-older-reference"
+                v-model="reference"
+                v-validation.personnummerFormat
+            >
+                Fyll i ett personnummer (referens)
+            </f-text-field>
+        </div>
+        <div class="col col--md-6">
+            <f-text-field
+                id="personnummer-older-input"
+                v-model="model"
+                v-validation.personnummerFormat.personnummerOlder="{
+                    personnummerOlder: { otherField: reference },
+                }"
+            >
+                Fyll i ett personnummer
+            </f-text-field>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { FTextField } from "@fkui/vue";
+
+export default defineComponent({
+    name: "PersonnummerOlderExample",
+    components: { FTextField },
+    data() {
+        return {
+            reference: "",
+            model: "",
+        };
+    },
+});
+</script>

--- a/docs/components/validation/examples/PersonnummerYoungerExample.cy.ts
+++ b/docs/components/validation/examples/PersonnummerYoungerExample.cy.ts
@@ -1,0 +1,52 @@
+import PersonnummerYoungerExample from "./PersonnummerYoungerExample.vue";
+
+const inputReference = `.text-field:has(#personnummer-younger-reference) input`;
+const errorReference = `.text-field:has(#personnummer-younger-reference) .label__message--error`;
+const input = `.text-field:has(#personnummer-younger-input) input`;
+const error = `.text-field:has(#personnummer-younger-input) .label__message--error`;
+
+// The test social security numbers(personnummer) used is approved by Skatteverket.
+
+it("should allow empty input", () => {
+    cy.mount(PersonnummerYoungerExample);
+    cy.get(inputReference).clear();
+    cy.get(inputReference).blur();
+    cy.get(errorReference).should("not.exist");
+    cy.get(input).clear();
+    cy.get(input).blur();
+    cy.get(error).should("not.exist");
+});
+
+it("should allow valid personnummer with 12 digits", () => {
+    cy.mount(PersonnummerYoungerExample);
+    cy.get(inputReference).clear();
+    cy.get(inputReference).type("19120211-9150");
+    cy.get(inputReference).blur();
+    cy.get(errorReference).should("not.exist");
+    cy.get(input).clear();
+    cy.get(input).type("19120211-9150");
+    cy.get(input).blur();
+    cy.get(error).should("not.exist");
+});
+
+it("should allow personnummer that is younger", () => {
+    cy.mount(PersonnummerYoungerExample);
+    cy.get(inputReference).clear();
+    cy.get(inputReference).type("19120211-9150");
+    cy.get(inputReference).blur();
+    cy.get(input).clear();
+    cy.get(input).type("20130101-2397");
+    cy.get(input).blur();
+    cy.get(error).should("not.exist");
+});
+
+it("should show error when personnummer isn't younger", () => {
+    cy.mount(PersonnummerYoungerExample);
+    cy.get(inputReference).clear();
+    cy.get(inputReference).type("20130101-2397");
+    cy.get(inputReference).blur();
+    cy.get(input).clear();
+    cy.get(input).type("19120211-9150");
+    cy.get(input).blur();
+    cy.get(error).should("exist");
+});

--- a/docs/components/validation/examples/PersonnummerYoungerExample.vue
+++ b/docs/components/validation/examples/PersonnummerYoungerExample.vue
@@ -1,0 +1,40 @@
+<template>
+    <div class="row">
+        <div class="col col--md-6">
+            <f-text-field
+                id="personnummer-younger-reference"
+                v-model="reference"
+                v-validation.personnummerFormat
+            >
+                Fyll i ett personnummer (referens)
+            </f-text-field>
+        </div>
+        <div class="col col--md-6">
+            <f-text-field
+                id="personnummer-younger-input"
+                v-model="model"
+                v-validation.personnummerFormat.personnummerYounger="{
+                    personnummerYounger: { otherField: reference },
+                }"
+            >
+                Fyll i ett personnummer
+            </f-text-field>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { FTextField } from "@fkui/vue";
+
+export default defineComponent({
+    name: "PersonnummerYoungerExample",
+    components: { FTextField },
+    data() {
+        return {
+            reference: "",
+            model: "",
+        };
+    },
+});
+</script>

--- a/docs/components/validation/validators.md
+++ b/docs/components/validation/validators.md
@@ -671,7 +671,67 @@ Skriv så här i kod när användaren ska fylla i personnummer:
  ></f-text-field>
 ```
 
-Felmeddelandet till användarenn när valideringen inte är godkänd är:<br> Kolla att personnumret stämmer.
+Felmeddelandet till användaren när valideringen inte är godkänd är:<br> Kolla att personnumret stämmer.
+
+### Personnummer - inte samma `personnummerNotSame`
+
+Validatorn kontrollerar att det ifyllda personnumret inte är samma som personnumret i annat fält.
+
+Det finns en separat validator för att kontrollera format för personnummer, personnummer-format (`personnummerFormat`). Validatorn för format ska stå före validatorn för `personnummerNotSame`.
+
+```import nomarkup
+PersonnummerNotSameExample.vue
+```
+
+Skriv så här i kod för att jämföra med ett inmatningsfält med `v-model="reference"`:
+
+```diff
+ <f-text-field
++    v-validation.personnummerFormat.personnummerNotSame="{ personnummerNotSame: { otherField: reference } }"
+ ></f-text-field>
+```
+
+Felmeddelandet till användaren när valideringen inte är godkänd måste skapas av konsumenten.
+
+### Personnummer - äldre `personnummerOlder`
+
+Validatorn kontrollerar att det ifyllda personnumret är äldre än eller är i samma ålder som personnumret i annat fält.
+
+Det finns en separat validator för att kontrollera format för personnummer, personnummer-format (`personnummerFormat`). Validatorn för format ska stå före validatorn för `personnummerOlder`.
+
+```import nomarkup
+PersonnummerOlderExample.vue
+```
+
+Skriv så här i kod för att jämföra med ett inmatningsfält med `v-model="reference"`:
+
+```diff
+ <f-text-field
++    v-validation.personnummerFormat.personnummerOlder="{ personnummerOlder: { otherField: reference } }"
+ ></f-text-field>
+```
+
+Felmeddelandet till användaren när valideringen inte är godkänd måste skapas av konsumenten.
+
+### Personnummer - yngre `personnummerYounger`
+
+Validatorn kontrollerar att det ifyllda personnumret är yngre än eller är i samma ålder som personnumret i annat fält.
+
+Det finns en separat validator för att kontrollera format för personnummer, personnummer-format (`personnummerFormat`). Validatorn för format ska stå före validatorn för `personnummerYounger`.
+
+```import nomarkup
+PersonnummerYoungerExample.vue
+```
+
+Skriv så här i kod för att jämföra med ett inmatningsfält med `v-model="reference"`:
+
+```diff
+ <f-text-field
++    v-validation.personnummerFormat.personnummerYounger="{ personnummerYounger: { otherField: reference } }"
+ ></f-text-field>
+```
+
+Felmeddelandet till användaren när valideringen inte är godkänd måste skapas av konsumenten.
 
 ## Adress och kontaktuppgifter
 


### PR DESCRIPTION
- https://forsakringskassan.github.io/designsystem/pr-preview/pr-144/components/validation/validators.html#personnummer_inte_samma_personnummernotsame
- https://forsakringskassan.github.io/designsystem/pr-preview/pr-144/components/validation/validators.html#personnummer_aldre_personnummerolder
- https://forsakringskassan.github.io/designsystem/pr-preview/pr-144/components/validation/validators.html#personnummer_yngre_personnummeryounger