### PR TITLE
refactor: `FModal` use teleport (refs SFKUI-6688)

### DIFF
--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -2499,6 +2499,7 @@ validator(value: string): boolean;
 modalClass(): string[];
 containerClasses(): string[];
 hasHeaderSlot(): boolean;
+teleportTarget(): string | Element;
 }, {
 onClose(): void;
 openModal(): void;
@@ -3244,6 +3245,7 @@ validator(value: string): boolean;
 modalClass(): string[];
 containerClasses(): string[];
 hasHeaderSlot(): boolean;
+teleportTarget(): string | Element;
 }, {
 onClose(): void;
 openModal(): void;
@@ -3764,6 +3766,7 @@ validator(value: string): boolean;
 modalClass(): string[];
 containerClasses(): string[];
 hasHeaderSlot(): boolean;
+teleportTarget(): string | Element;
 }, {
 onClose(): void;
 openModal(): void;
@@ -4574,9 +4577,9 @@ default: boolean;
 onChange?: ((...args: any[]) => any) | undefined;
 "onUpdate:modelValue"?: ((...args: any[]) => any) | undefined;
 }>, {
+disabled: boolean;
 modelValue: string;
 alwaysInline: boolean;
-disabled: boolean;
 labelWidth: string;
 inputWidth: string;
 initialMonth: FDate | undefined;
@@ -7546,6 +7549,7 @@ validator(value: string): boolean;
 modalClass(): string[];
 containerClasses(): string[];
 hasHeaderSlot(): boolean;
+teleportTarget(): string | Element;
 }, {
 onClose(): void;
 openModal(): void;
@@ -9541,6 +9545,7 @@ validator(value: string): boolean;
 modalClass(): string[];
 containerClasses(): string[];
 hasHeaderSlot(): boolean;
+teleportTarget(): string | Element;
 }, {
 onClose(): void;
 openModal(): void;
@@ -15461,8 +15466,8 @@ onInput?: ((...args: any[]) => any) | undefined;
 "onUpdate:modelValue"?: ((...args: any[]) => any) | undefined;
 }>, {
 id: string;
-modelValue: string;
 disabled: boolean;
+modelValue: string;
 maxlength: number;
 softLimit: number;
 charactersLeftWarning: string;

--- a/packages/vue/src/components/FCrudDataset/FCrudDataset.spec.ts
+++ b/packages/vue/src/components/FCrudDataset/FCrudDataset.spec.ts
@@ -175,7 +175,7 @@ function createWrapper(
     return mount(newComponent, {
         global: {
             plugins: [ValidationPlugin],
-            stubs: ["FIcon", ...stubs],
+            stubs: ["FIcon", "teleport", ...stubs],
         },
         props,
         attachTo: createPlaceholderInDocument(),

--- a/packages/vue/src/components/FModal/FConfirmModal/FConfirmModal.spec.ts
+++ b/packages/vue/src/components/FModal/FConfirmModal/FConfirmModal.spec.ts
@@ -8,6 +8,9 @@ describe("events", () => {
             props: {
                 isOpen: true,
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
         const closeElement = wrapper.get(".close-button");
 
@@ -19,6 +22,9 @@ describe("events", () => {
         const wrapper = mount(FConfirmModal, {
             props: {
                 isOpen: true,
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
         const dismissElement = wrapper.get(".button--primary");
@@ -41,6 +47,9 @@ describe("events", () => {
                 ],
             },
             emits: ["close", "unsure"],
+            global: {
+                stubs: ["teleport"],
+            },
         });
         const closeElement = wrapper.get(".button--secondary");
 
@@ -56,6 +65,9 @@ describe("button order", () => {
             props: {
                 isOpen: true,
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
         const buttonsGroup = wrapper.get(".modal__footer");
         const primary = buttonsGroup.findAll("button")[0];
@@ -67,6 +79,9 @@ describe("button order", () => {
         const wrapper = mount(FConfirmModal, {
             props: {
                 isOpen: true,
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
         const buttonsGroup = wrapper.get(".modal__footer");
@@ -82,6 +97,9 @@ describe("props", () => {
                 isOpen: true,
                 heading: "foo heading",
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         const heading = wrapper.find("h1");
@@ -93,6 +111,9 @@ describe("props", () => {
             props: {
                 isOpen: true,
                 content: "bar content",
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
 
@@ -112,6 +133,9 @@ describe("props", () => {
                     },
                 ],
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         const button = wrapper.get(".button--secondary");
@@ -124,6 +148,9 @@ describe("props", () => {
             props: {
                 isOpen: true,
                 buttons: [{ label: "Lorem ipsum", type: "secondary" }],
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
 
@@ -141,6 +168,9 @@ describe("slots", () => {
             slots: {
                 heading: "foo heading",
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         const heading = wrapper.find("h1");
@@ -154,6 +184,9 @@ describe("slots", () => {
             },
             slots: {
                 heading: "<pre>bar content</pre>",
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
 
@@ -170,6 +203,9 @@ describe("slots", () => {
             slots: {
                 heading: "slot heading",
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         expect(wrapper.find(".modal__header").text()).toBe("slot heading");
@@ -183,6 +219,9 @@ describe("slots", () => {
             },
             slots: {
                 content: "<pre>slot content</pre>",
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
 

--- a/packages/vue/src/components/FModal/FFormModal/FFormModal.spec.ts
+++ b/packages/vue/src/components/FModal/FFormModal/FFormModal.spec.ts
@@ -59,6 +59,7 @@ function createWrapper(
         attachTo: createPlaceholderInDocument(),
         global: {
             plugins: [ValidationPlugin],
+            stubs: ["teleport"],
         },
     });
 }
@@ -80,6 +81,9 @@ describe("events", () => {
             props: {
                 isOpen: true,
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
         const closeElement = wrapper.get(".close-button");
         await closeElement.trigger("click");
@@ -92,6 +96,9 @@ describe("events", () => {
             props: {
                 isOpen: true,
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
         const closeElement = wrapper.get(".button--secondary");
         await closeElement.trigger("click");
@@ -103,6 +110,9 @@ describe("events", () => {
         const wrapper = mount(FFormModal, {
             props: {
                 isOpen: true,
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
 
@@ -117,6 +127,9 @@ describe("events", () => {
             props: {
                 isOpen: true,
                 beforeSubmit: beforeSubmit,
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
         expect(beforeSubmit).toHaveBeenCalledTimes(0);
@@ -135,6 +148,9 @@ describe("events", () => {
                 isOpen: true,
                 beforeSubmit: onBeforeSubmit,
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         await doTriggerSubmit(wrapper);
@@ -150,6 +166,9 @@ describe("events", () => {
             props: {
                 isOpen: true,
                 beforeSubmit: onBeforeSubmit,
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
 
@@ -167,6 +186,9 @@ describe("events", () => {
                 isOpen: true,
                 beforeSubmit: onBeforeSubmit,
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         await doTriggerSubmit(wrapper);
@@ -178,6 +200,9 @@ describe("events", () => {
         const wrapper = mount(FFormModal, {
             props: {
                 isOpen: true,
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
 
@@ -223,6 +248,9 @@ describe("deprecated slots", () => {
                 isOpen: true,
             },
             slots: { "cancel-button-text": cancelButtonText },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         const button = wrapper.find('[data-test="cancel-button"]');
@@ -236,6 +264,9 @@ describe("deprecated slots", () => {
                 isOpen: true,
             },
             slots: { "submit-button-text": submitButtonText },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         const button = wrapper.find('[data-test="submit-button"]');
@@ -253,6 +284,9 @@ describe("slots", () => {
             slots: {
                 header: headerText,
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         const header = wrapper.find("h1");
@@ -268,6 +302,9 @@ describe("slots", () => {
             slots: {
                 header: /* HTML */ ` <pre>${contentText}</pre> `,
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         const content = wrapper.find("pre");
@@ -282,6 +319,9 @@ describe("slots", () => {
             },
             slots: {
                 default: `${contentText}`,
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
 
@@ -320,6 +360,9 @@ describe("props", () => {
                     props: {
                         size,
                     },
+                    global: {
+                        stubs: ["teleport"],
+                    },
                 });
                 const container = wrapper.get(".modal__dialog-container");
                 expect(container.classes()).toContain(className);
@@ -334,6 +377,9 @@ describe("props", () => {
                 ariaCloseText: "CLOSE_TEXT",
             },
             slots: {},
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         const fmodal = wrapper.getComponent(FModal);
@@ -352,6 +398,9 @@ describe("props", () => {
                     },
                 ],
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         const button = wrapper.get(".button--secondary");
@@ -364,6 +413,9 @@ describe("props", () => {
             props: {
                 isOpen: true,
                 buttons: [{ label: "Lorem ipsum", type: "secondary" }],
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
 

--- a/packages/vue/src/components/FModal/FFormModal/FFormModal.vue
+++ b/packages/vue/src/components/FModal/FFormModal/FFormModal.vue
@@ -18,6 +18,7 @@
             </div>
             <f-validation-form
                 :id="formId"
+                ref="form"
                 :before-submit="beforeSubmit"
                 :before-validation="beforeValidation"
                 :use-error-list="useErrorList"
@@ -85,7 +86,7 @@ import { FValidationForm, type FValidationFormCallback } from "../../FValidation
 import { TranslationMixin } from "../../../plugins/translation";
 import { sizes } from "../sizes";
 import { FModalButton, FModalButtonDescriptor, prepareButtonList } from "../modal-button";
-import { hasSlot } from "../../../utils";
+import { getHTMLElementFromVueRef, hasSlot } from "../../../utils";
 import { FKUIConfigButtonOrder } from "../../../config";
 
 export default defineComponent({
@@ -218,7 +219,8 @@ export default defineComponent({
     },
     methods: {
         onClose() {
-            ValidationService.resetState(this.$el);
+            const form = getHTMLElementFromVueRef(this.$refs.form);
+            ValidationService.resetState(form);
             /**
              * Event that is dispatched when escape is pressed or when the cancel or close buttons are clicked.
              * In most use cases the isOpen prop should be set to false when this event is triggered.
@@ -231,7 +233,8 @@ export default defineComponent({
             this.$emit("close", { reason: "close" });
         },
         async onSubmit() {
-            ValidationService.resetState(this.$el);
+            const form = getHTMLElementFromVueRef(this.$refs.form);
+            ValidationService.resetState(form);
             /**
              * Event that is dispatched when the submit button is is clicked.
              * The event payload is the data that has been submitted.
@@ -240,7 +243,8 @@ export default defineComponent({
             this.$emit("close", { reason: "submit", data: this.value });
         },
         onCancel() {
-            ValidationService.resetState(this.$el);
+            const form = getHTMLElementFromVueRef(this.$refs.form);
+            ValidationService.resetState(form);
             this.$emit("cancel");
             this.$emit("close", { reason: "close" });
         },

--- a/packages/vue/src/components/FModal/FModal.spec.ts
+++ b/packages/vue/src/components/FModal/FModal.spec.ts
@@ -25,6 +25,9 @@ describe("events", () => {
             props: {
                 isOpen: true,
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
         const closeElement = wrapper.get(".close-button");
 
@@ -36,6 +39,9 @@ describe("events", () => {
         const wrapper = shallowMount(FModal, {
             props: {
                 isOpen: true,
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
         const closeElement = wrapper.get(".modal__content");
@@ -51,6 +57,9 @@ describe("props", () => {
             props: {
                 isOpen: true,
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         const modal = wrapper.get(".modal");
@@ -61,6 +70,9 @@ describe("props", () => {
         const wrapper = shallowMount(FModal, {
             props: {
                 isOpen: false,
+            },
+            global: {
+                stubs: ["teleport"],
             },
         });
 
@@ -76,6 +88,9 @@ describe("props", () => {
                 props: {
                     isOpen: true,
                 },
+                global: {
+                    stubs: ["teleport"],
+                },
             });
             await wrapper.vm.$nextTick();
             const element = wrapper.get(".modal__dialog-container");
@@ -89,6 +104,9 @@ describe("props", () => {
                     fullscreen: true,
                     isOpen: true,
                 },
+                global: {
+                    stubs: ["teleport"],
+                },
             });
             await wrapper.vm.$nextTick();
             const element = wrapper.get(".modal__dialog-container");
@@ -101,6 +119,9 @@ describe("props", () => {
                 props: {
                     fullscreen: false,
                     isOpen: true,
+                },
+                global: {
+                    stubs: ["teleport"],
                 },
             });
             await wrapper.vm.$nextTick();
@@ -122,6 +143,9 @@ describe("props", () => {
                 props: {
                     isOpen: true,
                     size,
+                },
+                global: {
+                    stubs: ["teleport"],
                 },
             });
             await wrapper.vm.$nextTick();
@@ -153,6 +177,9 @@ describe("accessibility", () => {
                 header: "my header",
                 content: { template: interactiveContent },
             },
+            global: {
+                stubs: ["teleport"],
+            },
         });
         await flushPromises();
         const headerElement = wrapper.get(".modal__title").element;
@@ -167,6 +194,9 @@ describe("accessibility", () => {
                 isOpen: true,
             },
             slots: { content: { template: interactiveContent } },
+            global: {
+                stubs: ["teleport"],
+            },
         });
         await flushPromises();
         const interactiveElement = wrapper.get("#interactive").element;
@@ -181,6 +211,9 @@ describe("accessibility", () => {
                 isOpen: true,
             },
             slots: { content: "my content" },
+            global: {
+                stubs: ["teleport"],
+            },
         });
         await flushPromises();
         const contentElement = wrapper.get(".modal__content").element;
@@ -215,6 +248,9 @@ describe("accessibility", () => {
         });
         const wrapper = mount(TestComponent, {
             attachTo: createPlaceholderInDocument(),
+            global: {
+                stubs: ["teleport"],
+            },
         });
 
         const toggleButton =
@@ -242,6 +278,9 @@ describe("scrollbars", () => {
                 isOpen: true,
             },
             attachTo: createPlaceholderInDocument(),
+            global: {
+                stubs: ["teleport"],
+            },
         });
         await wrapper.vm.$nextTick();
         // css class modal__open removes scrollbars
@@ -255,6 +294,9 @@ describe("scrollbars", () => {
                 isOpen: false,
             },
             attachTo: createPlaceholderInDocument(),
+            global: {
+                stubs: ["teleport"],
+            },
         });
         await wrapper.vm.$nextTick();
         const documentElement = document.documentElement;
@@ -267,6 +309,9 @@ describe("scrollbars", () => {
                 isOpen: true,
             },
             attachTo: createPlaceholderInDocument(),
+            global: {
+                stubs: ["teleport"],
+            },
         });
         await wrapper.vm.$nextTick();
 

--- a/packages/vue/src/components/FModal/FModal.vue
+++ b/packages/vue/src/components/FModal/FModal.vue
@@ -1,49 +1,56 @@
 <template>
-    <div v-if="isOpen" :id="id" class="modal" :class="modalClass">
-        <div class="modal__backdrop">
-            <div
-                class="modal__outer-container scroll-target"
-                tabindex="-1"
-                role="dialog"
-                aria-modal="true"
-                @keyup.esc="onClose"
-            >
-                <div class="modal__inner-container">
-                    <div ref="modalDialogContainer" class="modal__dialog-container" :class="containerClasses">
-                        <div class="modal__dialog">
-                            <div class="modal__dialog-inner">
-                                <div class="modal__header">
-                                    <div tabindex="0" @focus="onFocusFirst"></div>
-                                    <h1 v-if="hasHeaderSlot" ref="modalTitle" class="modal__title" tabindex="-1">
-                                        <!--@slot Slot for the header. -->
-                                        <slot name="header"></slot>
-                                    </h1>
+    <teleport v-if="isOpen" :to="teleportTarget">
+        <div v-bind="$attrs" :id="id" class="modal" :class="modalClass">
+            <div class="modal__backdrop">
+                <div
+                    class="modal__outer-container scroll-target"
+                    tabindex="-1"
+                    role="dialog"
+                    aria-modal="true"
+                    @keyup.esc="onClose"
+                >
+                    <div class="modal__inner-container">
+                        <div ref="modalDialogContainer" class="modal__dialog-container" :class="containerClasses">
+                            <div class="modal__dialog">
+                                <div class="modal__dialog-inner">
+                                    <div class="modal__header">
+                                        <div tabindex="0" @focus="onFocusFirst"></div>
+                                        <h1 v-if="hasHeaderSlot" ref="modalTitle" class="modal__title" tabindex="-1">
+                                            <!--@slot Slot for the header. -->
+                                            <slot name="header"></slot>
+                                        </h1>
+                                    </div>
+
+                                    <div ref="modalContent" class="modal__content" tabindex="-1">
+                                        <!--@slot Slot for the main content, e.g. paragraphs, input fields, etc. -->
+                                        <slot name="content"></slot>
+                                    </div>
+
+                                    <div class="modal__footer">
+                                        <!--@slot Slot the footer content, i.e. buttons. -->
+                                        <slot name="footer"></slot>
+                                    </div>
                                 </div>
 
-                                <div ref="modalContent" class="modal__content" tabindex="-1">
-                                    <!--@slot Slot for the main content, e.g. paragraphs, input fields, etc. -->
-                                    <slot name="content"></slot>
+                                <div class="modal__shelf">
+                                    <button
+                                        type="button"
+                                        class="close-button"
+                                        :aria-label="ariaCloseText"
+                                        @click="onClose"
+                                    >
+                                        <span>{{ $t("fkui.modal.close", "Stäng") }}</span>
+                                        <f-icon name="close"></f-icon>
+                                    </button>
+                                    <div tabindex="0" @focus="onFocusLast"></div>
                                 </div>
-
-                                <div class="modal__footer">
-                                    <!--@slot Slot the footer content, i.e. buttons. -->
-                                    <slot name="footer"></slot>
-                                </div>
-                            </div>
-
-                            <div class="modal__shelf">
-                                <button type="button" class="close-button" :aria-label="ariaCloseText" @click="onClose">
-                                    <span>{{ $t("fkui.modal.close", "Stäng") }}</span>
-                                    <f-icon name="close"></f-icon>
-                                </button>
-                                <div tabindex="0" @focus="onFocusLast"></div>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
+    </teleport>
 </template>
 
 <script lang="ts">
@@ -52,6 +59,7 @@ import { ElementIdService, pushFocus, popFocus, findTabbableElements } from "@fk
 import { FIcon } from "../FIcon";
 import { TranslationMixin } from "../../plugins";
 import { findElementFromVueRef, getHTMLElementFromVueRef, hasSlot } from "../../utils";
+import { config } from "../../config";
 import { sizes, sizeClass } from "./sizes";
 import { focusElement } from "./focus-element";
 import { type FModalData } from "./fmodal-data";
@@ -63,7 +71,7 @@ export default defineComponent({
     name: "FModal",
     components: { FIcon },
     mixins: [TranslationMixin],
-    inheritAttrs: true,
+    inheritAttrs: false,
     props: {
         /**
          * The id for the root element id attribute.
@@ -142,6 +150,9 @@ export default defineComponent({
         },
         hasHeaderSlot(): boolean {
             return hasSlot(this, "header");
+        },
+        teleportTarget() {
+            return config.modalTarget ?? config.teleportTarget;
         },
     },
     watch: {

--- a/packages/vue/src/pageobject/FCrudDataset.pageobject.ts
+++ b/packages/vue/src/pageobject/FCrudDataset.pageobject.ts
@@ -12,7 +12,8 @@ export class FCrudDatasetPageObject implements BasePageObject {
     public constructor(selector: string) {
         this.selector = selector;
         this.el = () => cy.get(this.selector);
-        this.form = new FValidationFormPageObject(`${this.selector} form`);
+        // Modal is teleported so `this.selector` can't be used.
+        this.form = new FValidationFormPageObject(`.modal__content form`);
     }
 
     public addButton(): DefaultCypressChainable {
@@ -22,14 +23,12 @@ export class FCrudDatasetPageObject implements BasePageObject {
     }
 
     public cancelButton(): DefaultCypressChainable {
-        return cy.get(
-            `${this.selector} .modal__footer > .button-group > .button--secondary`,
-        );
+        // Modal is teleported so `this.selector` can't be used.
+        return cy.get(`.modal__footer > .button-group > .button--secondary`);
     }
 
     public confirmButton(): DefaultCypressChainable {
-        return cy.get(
-            `${this.selector} .modal__footer > .button-group > .button--primary`,
-        );
+        // Modal is teleported so `this.selector` can't be used.
+        return cy.get(`.modal__footer > .button-group > .button--primary`);
     }
 }


### PR DESCRIPTION
Ändrar så att modalerna teleporteras.

Har en fundering dock. Det innebär att även modaler som använder API teleporteras. Se resultat nedan när den både mountas och teleporteras till body. Verkar inte göra mycket skillnad förutom att det ser lite fult ut. Skulle kunna lägga till prop som används av API logiken för att stänga av teleport , men känns lite knasigt att exponera det via props... kanske inte behöver göra nåt åt detta? Förslag?
```
<div data-v-app="">
    <!--teleport start-->
    <!--teleport end-->
</div>
<div id="fkui-vue-element-0012" class="modal">...</div>
```

todo: 
- [ ] deprekera `config.modalTarget`