### PR TITLE
feat: fmodal focus strategy (refs SB-4982)

### DIFF
--- a/docs/components/modal/FModal.md
+++ b/docs/components/modal/FModal.md
@@ -76,6 +76,14 @@ När modalen öppnas så sätts initialt fokus enligt denna rangordning:
 2. Första interagerbara element i innehåll
 3. Hela innehållet
 
+### Fokushantering
+
+Modaler hanterar som standard fokus själv där modalen flyttar fokus till rubriken vid öppning och återställer fokus till tidigare fokuserat element vid stägning. Du kan styra detta beteende med propen för focus:
+
+- "on" - komponenten hanterar fokus vid både öppning och stängning
+- "off" - komponenten hanterar inte fokus alls.
+- "open" - komponenten hanterar enbart fokus vid öppning.
+
 ## API
 
 :::api

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -2412,6 +2412,11 @@ type: PropType<FModalButtonDescriptor[]>;
 required: false;
 default: () => FModalButtonDescriptor[];
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>, {}, {}, {
 preparedButtons(): FModalButton[];
 }, {
@@ -2453,9 +2458,15 @@ type: PropType<FModalButtonDescriptor[]>;
 required: false;
 default: () => FModalButtonDescriptor[];
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>> & Readonly<{
 [x: `on${Capitalize<string>}`]: ((...args: any[]) => any) | undefined;
 }>, {
+focus: "on" | "off" | "open";
 size: string;
 content: string;
 isOpen: boolean;
@@ -2492,6 +2503,11 @@ validator(value: string): boolean;
 };
 size: {
 type: StringConstructor;
+default: string;
+validator(value: string): boolean;
+};
+focus: {
+type: PropType<"on" | "off" | "open">;
 default: string;
 validator(value: string): boolean;
 };
@@ -2537,9 +2553,15 @@ type: StringConstructor;
 default: string;
 validator(value: string): boolean;
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>> & Readonly<{
 onClose?: ((...args: any[]) => any) | undefined;
 }>, {
+focus: "on" | "off" | "open";
 type: "" | "warning" | "error" | "information";
 size: string;
 isOpen: boolean;
@@ -3240,6 +3262,11 @@ type: StringConstructor;
 default: string;
 validator(value: string): boolean;
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>, {}, FModalData, {
 modalClass(): string[];
 containerClasses(): string[];
@@ -3282,9 +3309,15 @@ type: StringConstructor;
 default: string;
 validator(value: string): boolean;
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>> & Readonly<{
 onClose?: ((...args: any[]) => any) | undefined;
 }>, {
+focus: "on" | "off" | "open";
 type: "" | "warning" | "error" | "information";
 size: string;
 isOpen: boolean;
@@ -3677,6 +3710,11 @@ type: PropType<FModalButtonDescriptor[]>;
 required: false;
 default: () => FModalButtonDescriptor[];
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>, {}, {}, {
 preparedButtons(): FModalButton[];
 }, {
@@ -3718,9 +3756,15 @@ type: PropType<FModalButtonDescriptor[]>;
 required: false;
 default: () => FModalButtonDescriptor[];
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>> & Readonly<{
 [x: `on${Capitalize<string>}`]: ((...args: any[]) => any) | undefined;
 }>, {
+focus: "on" | "off" | "open";
 size: string;
 content: string;
 isOpen: boolean;
@@ -3757,6 +3801,11 @@ validator(value: string): boolean;
 };
 size: {
 type: StringConstructor;
+default: string;
+validator(value: string): boolean;
+};
+focus: {
+type: PropType<"on" | "off" | "open">;
 default: string;
 validator(value: string): boolean;
 };
@@ -3802,9 +3851,15 @@ type: StringConstructor;
 default: string;
 validator(value: string): boolean;
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>> & Readonly<{
 onClose?: ((...args: any[]) => any) | undefined;
 }>, {
+focus: "on" | "off" | "open";
 type: "" | "warning" | "error" | "information";
 size: string;
 isOpen: boolean;
@@ -7542,6 +7597,11 @@ type: StringConstructor;
 default: string;
 validator(value: string): boolean;
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>, {}, FModalData, {
 modalClass(): string[];
 containerClasses(): string[];
@@ -7584,9 +7644,15 @@ type: StringConstructor;
 default: string;
 validator(value: string): boolean;
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>> & Readonly<{
 onClose?: ((...args: any[]) => any) | undefined;
 }>, {
+focus: "on" | "off" | "open";
 type: "" | "warning" | "error" | "information";
 size: string;
 isOpen: boolean;
@@ -9537,6 +9603,11 @@ type: StringConstructor;
 default: string;
 validator(value: string): boolean;
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>, {}, FModalData, {
 modalClass(): string[];
 containerClasses(): string[];
@@ -9579,9 +9650,15 @@ type: StringConstructor;
 default: string;
 validator(value: string): boolean;
 };
+focus: {
+type: PropType<"on" | "off" | "open">;
+default: string;
+validator(value: string): boolean;
+};
 }>> & Readonly<{
 onClose?: ((...args: any[]) => any) | undefined;
 }>, {
+focus: "on" | "off" | "open";
 type: "" | "warning" | "error" | "information";
 size: string;
 isOpen: boolean;

--- a/packages/vue/src/components/FModal/FConfirmModal/FConfirmModal.vue
+++ b/packages/vue/src/components/FModal/FConfirmModal/FConfirmModal.vue
@@ -5,6 +5,7 @@
         :aria-close-text="ariaCloseText"
         type="warning"
         :size="size"
+        :focus="focus"
         @close="onClose"
     >
         <template #header>
@@ -112,6 +113,19 @@ export default defineComponent({
             required: false,
             default: (): FModalButtonDescriptor[] => {
                 return defaultButtons;
+            },
+        },
+        /**
+         * Default behavior is that the modal will restore focus to previous element once closed.
+         * - "on" (default) - component will set focus both when opened and closed
+         * - "off" - focus strategy disabled
+         * - "open" - focus will only be applied once modal is opened
+         */
+        focus: {
+            type: String as PropType<"on" | "off" | "open">,
+            default: "on",
+            validator(value: string): boolean {
+                return ["on", "off", "open"].includes(value);
             },
         },
     },

--- a/packages/vue/src/components/FModal/FModal.cy.ts
+++ b/packages/vue/src/components/FModal/FModal.cy.ts
@@ -7,6 +7,99 @@ import {
 import { FSelectField } from "../FSelectField";
 import FModal from "./FModal.vue";
 
+function generateModalMarkup(focusStrategy = "on"): string {
+    return /* HTML */ `
+        <div class="f-modal-example">
+            <div class="row">
+                <div class="col col--md-6">
+                    <f-select-field
+                        v-model="type"
+                        v-test="'open-example-modal-type-select-field'"
+                    >
+                        <template #label> Modaltyp: </template>
+                        <option value>Standard</option>
+                        <option value="information">Informationsmodal</option>
+                        <option value="warning">Varningsmodal</option>
+                        <option value="error">Felmodal</option>
+                    </f-select-field>
+                </div>
+                <div class="col col--md-6">
+                    <f-select-field v-model="size">
+                        <template #label> Storlek (desktop): </template>
+                        <option value>Standard</option>
+                        <option value="small">Small (default)</option>
+                        <option value="medium">Medium</option>
+                        <option value="large">Large</option>
+                        <option value="fullscreen">Fullscreen</option>
+                    </f-select-field>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col col--md-6">
+                    <f-select-field v-model="fullscreen">
+                        <template #label> Fullskärm (mobil): </template>
+                        <option :value="true">Ja</option>
+                        <option :value="false">Standard (nej)</option>
+                    </f-select-field>
+                </div>
+                <div class="col col--md-6">
+                    <f-select-field v-model="modalContent">
+                        <template #label> Mängd innehåll: </template>
+                        <option :value="content.minimal">Minimal</option>
+                        <option :value="content.normal">Normal</option>
+                        <option :value="content.maximal">Maximal</option>
+                    </f-select-field>
+                </div>
+            </div>
+            <button
+                type="button"
+                class="button button--secondary"
+                data-test="open-example-modal-button"
+                @click="onClickOpenModal"
+            >
+                Öppna modal
+            </button>
+            <f-modal
+                :is-open="isOpen"
+                data-test="modul-open"
+                close-text="Stäng"
+                aria-close-text="Stäng"
+                :fullscreen="fullscreen"
+                :type="type"
+                :size="size"
+                focus="${focusStrategy}"
+                @close="onCloseModal"
+            >
+                <template #header> Träutensilierna </template>
+                <template #content>
+                    <p v-for="paragraph in modalContent" :key="paragraph">
+                        {{ paragraph }}
+                    </p>
+                </template>
+                <template #footer>
+                    <div class="button-group">
+                        <button
+                            data-test="closeButton"
+                            type="button"
+                            class="button button--secondary button-group__item button--large"
+                            @click="onClickCloseModal"
+                        >
+                            Stäng sekundär
+                        </button>
+                        <button
+                            type="button"
+                            class="button button--primary button-group__item button--large"
+                            @click="onClickCloseModal"
+                        >
+                            Stäng
+                        </button>
+                    </div>
+                </template>
+            </f-modal>
+        </div>
+    `;
+}
+
 const content = {
     minimal: ["Lorem ipsum dolor sit amet."],
     normal: [
@@ -92,98 +185,8 @@ describe("FModal", () => {
 
     beforeEach(() => {
         cy.clearLocalStorage();
-        const template = /* HTML */ `
-            <div class="f-modal-example">
-                <div class="row">
-                    <div class="col col--md-6">
-                        <f-select-field
-                            v-model="type"
-                            v-test="'open-example-modal-type-select-field'"
-                        >
-                            <template #label> Modaltyp: </template>
-                            <option value>Standard</option>
-                            <option value="information">
-                                Informationsmodal
-                            </option>
-                            <option value="warning">Varningsmodal</option>
-                            <option value="error">Felmodal</option>
-                        </f-select-field>
-                    </div>
-                    <div class="col col--md-6">
-                        <f-select-field v-model="size">
-                            <template #label> Storlek (desktop): </template>
-                            <option value>Standard</option>
-                            <option value="small">Small (default)</option>
-                            <option value="medium">Medium</option>
-                            <option value="large">Large</option>
-                            <option value="fullscreen">Fullscreen</option>
-                        </f-select-field>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col col--md-6">
-                        <f-select-field v-model="fullscreen">
-                            <template #label> Fullskärm (mobil): </template>
-                            <option :value="true">Ja</option>
-                            <option :value="false">Standard (nej)</option>
-                        </f-select-field>
-                    </div>
-                    <div class="col col--md-6">
-                        <f-select-field v-model="modalContent">
-                            <template #label> Mängd innehåll: </template>
-                            <option :value="content.minimal">Minimal</option>
-                            <option :value="content.normal">Normal</option>
-                            <option :value="content.maximal">Maximal</option>
-                        </f-select-field>
-                    </div>
-                </div>
-                <button
-                    type="button"
-                    class="button button--secondary"
-                    data-test="open-example-modal-button"
-                    @click="onClickOpenModal"
-                >
-                    Öppna modal
-                </button>
-                <f-modal
-                    :is-open="isOpen"
-                    data-test="modul-open"
-                    close-text="Stäng"
-                    aria-close-text="Stäng"
-                    :fullscreen="fullscreen"
-                    :type="type"
-                    :size="size"
-                    @close="onCloseModal"
-                >
-                    <template #header> Träutensilierna </template>
-                    <template #content>
-                        <p v-for="paragraph in modalContent" :key="paragraph">
-                            {{ paragraph }}
-                        </p>
-                    </template>
-                    <template #footer>
-                        <div class="button-group">
-                            <button
-                                data-test="closeButton"
-                                type="button"
-                                class="button button--secondary button-group__item button--large"
-                                @click="onClickCloseModal"
-                            >
-                                Stäng sekundär
-                            </button>
-                            <button
-                                type="button"
-                                class="button button--primary button-group__item button--large"
-                                @click="onClickCloseModal"
-                            >
-                                Stäng
-                            </button>
-                        </div>
-                    </template>
-                </f-modal>
-            </div>
-        `;
-        cy.mount(createComponent(template));
+
+        cy.mount(createComponent(generateModalMarkup()));
     });
 
     it("should provide a page object that can access any necessary elements", () => {
@@ -250,5 +253,41 @@ describe("FModal", () => {
         openModalButton().click();
         modal.secondaryButton().click();
         modal.el().should("not.exist");
+    });
+
+    describe("focus", () => {
+        it("default should set focus when modal is opened and closed", () => {
+            cy.mount(createComponent(generateModalMarkup("on")));
+            openModalButton().click();
+
+            cy.focused().should("have.class", "modal__title");
+
+            modal.primaryButton().click();
+            cy.focused().should(
+                "have.attr",
+                "data-test",
+                "open-example-modal-button",
+            );
+        });
+
+        it("should be able to disable focus strategy", () => {
+            cy.mount(createComponent(generateModalMarkup("off")));
+            openModalButton().click();
+            cy.focused().should(
+                "have.attr",
+                "data-test",
+                "open-example-modal-button",
+            );
+            modal.primaryButton().click();
+            cy.focused().should("not.exist");
+        });
+
+        it("should be able to disable close focus", () => {
+            cy.mount(createComponent(generateModalMarkup("open")));
+            openModalButton().click();
+            cy.focused().should("have.class", "modal__title");
+            modal.primaryButton().click();
+            cy.focused().should("not.exist");
+        });
     });
 });


### PR DESCRIPTION
Efter diskussioner irl kommer här en idé till lösningsförslag när konsumenter utav modalen själv vill definera vilket element som skall få focus när modalen släcks.

Vårt konkreta use case är att vi har en modal på en "Ta bort"-knapp, där knappen helt enkelt försvinner när elementet är borttaget. Vi vill därmed sätta focus på nåt annat element.

jag började enkelt med en boolean för detta, vet att det fanns förslag att ha det som ett objekt istället, tar tacksamt emot feedback på ändringar. :-)


Har medvetet valt att inte skriva nåt i dokumentationen tills jag vet om detta kandiderar att mergas eller inte.