### PR TITLE
fix: fix tooltip in fieldset (refs SFKUI-6500)

### DIFF
--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -15306,9 +15306,9 @@ validator(value: string): value is FTableColumnType;
 type: "text" | "date" | "action" | "numeric";
 description: string;
 shrink: boolean;
+expand: boolean;
 visible: boolean;
 rowHeader: boolean;
-expand: boolean;
 }, {}, {}, {}, string, ComponentProvideOptions, true, {}, any>;
 
 // @public (undocumented)
@@ -16423,8 +16423,8 @@ default(): AnimationCallback;
 };
 }>> & Readonly<{}>, {
 animate: boolean;
-expanded: string | number | boolean;
 useVShow: boolean;
+expanded: string | number | boolean;
 opacity: boolean;
 beforeAnimation: AnimationCallback;
 afterAnimation: AnimationCallback;
@@ -17008,8 +17008,8 @@ default(): AnimationCallback;
 };
 }>> & Readonly<{}>, {
 animate: boolean;
-expanded: string | number | boolean;
 useVShow: boolean;
+expanded: string | number | boolean;
 opacity: boolean;
 beforeAnimation: AnimationCallback;
 afterAnimation: AnimationCallback;

--- a/packages/vue/src/components/FCheckboxField/__snapshots__/FCheckboxGroup.spec.ts.snap
+++ b/packages/vue/src/components/FCheckboxField/__snapshots__/FCheckboxGroup.spec.ts.snap
@@ -42,28 +42,23 @@ exports[`snapshots should match snapshot with default classes and filled slots 1
   </span>
   
   <div
-    class="sr-separator"
+    class="label"
   >
-    <div
+    <span
       aria-hidden="true"
-      class="tooltip-before"
     >
-      <div
-        class="label tooltip-before__label"
-      >
-        
-        
-         Label 
-        
-        
-      </div>
-    </div>
-    
-    
-     Tooltip 
-    
-    
+      
+      
+       Label 
+      
+      
+    </span>
   </div>
+  
+  
+   Tooltip 
+  
+  
   <div
     aria-hidden="true"
     class="label fieldset__label"

--- a/packages/vue/src/components/FFieldset/FFieldset.vue
+++ b/packages/vue/src/components/FFieldset/FFieldset.vue
@@ -34,17 +34,19 @@
             <span v-else>{{ numberOfCheckedCheckboxesScreenText }}</span>
         </span>
 
+        <!-- the original <legend> element is sr-only when a tooltip is present
+        so the tooltip button can be positioned correctly when a description is
+        also present -->
         <template v-if="hasTooltipSlot">
-            <div class="sr-separator">
-                <div class="tooltip-before" aria-hidden="true">
-                    <div class="label tooltip-before__label">
-                        <slot name="label"></slot>
-                    </div>
-                </div>
-
-                <!-- @slot Slot for tooltip. -->
-                <slot name="tooltip"></slot>
+            <div ref="tooltipAttachTo" class="label">
+                <span aria-hidden="true">
+                    <slot name="label"></slot>
+                </span>
             </div>
+
+            <!-- @slot Slot for tooltip. -->
+            <slot name="tooltip"></slot>
+
             <div
                 v-if="hasDescriptionSlot || hasErrorMessageSlot || hasError"
                 class="label"
@@ -77,12 +79,13 @@
 </template>
 
 <script lang="ts">
-import { type PropType, defineComponent, provide, useSlots } from "vue";
+import { type PropType, defineComponent, provide, useSlots, useTemplateRef } from "vue";
 import { ElementIdService, type ValidityEvent, debounce } from "@fkui/logic";
 import { renderSlotText, dispatchComponentValidityEvent, hasSlot } from "../../utils";
 import { ComponentValidityEvent } from "../../types";
 import { FIcon } from "../FIcon";
 import { TranslationMixin } from "../../plugins";
+import { tooltipAttachTo } from "../FTooltip";
 import { labelClasses } from "./label-classes";
 import { contentClasses } from "./content-classes";
 import { injectionKeys } from "./use-fieldset";
@@ -181,6 +184,7 @@ export default defineComponent({
         provide(injectionKeys.getFieldsetLabelText, () => {
             return renderSlotText(slots.label);
         });
+        provide(tooltipAttachTo, useTemplateRef("tooltipAttachTo"));
     },
     data() {
         return {

--- a/packages/vue/src/components/FFieldset/__snapshots__/FFieldset.spec.ts.snap
+++ b/packages/vue/src/components/FFieldset/__snapshots__/FFieldset.spec.ts.snap
@@ -218,24 +218,19 @@ exports[`snapshots should match snapshot with label, content and tooltip 1`] = `
   <!--v-if-->
   
   <div
-    class="sr-separator"
+    class="label"
   >
-    <div
+    <span
       aria-hidden="true"
-      class="tooltip-before"
     >
-      <div
-        class="label tooltip-before__label"
-      >
-        
-        Label
-        
-      </div>
-    </div>
-    
-    Tooltip
-    
+      
+      Label
+      
+    </span>
   </div>
+  
+  Tooltip
+  
   <!--v-if-->
   
   <div

--- a/packages/vue/src/components/FRadioField/__snapshots__/FRadioGroup.spec.ts.snap
+++ b/packages/vue/src/components/FRadioField/__snapshots__/FRadioGroup.spec.ts.snap
@@ -44,28 +44,23 @@ exports[`snapshots should match snapshot with default classes and filled slots 1
   <!--v-if-->
   
   <div
-    class="sr-separator"
+    class="label"
   >
-    <div
+    <span
       aria-hidden="true"
-      class="tooltip-before"
     >
-      <div
-        class="label tooltip-before__label"
-      >
-        
-        
-        Label
-        
-        
-      </div>
-    </div>
-    
-    
-    Tooltip
-    
-    
+      
+      
+      Label
+      
+      
+    </span>
   </div>
+  
+  
+  Tooltip
+  
+  
   <div
     aria-hidden="true"
     class="label fieldset__label"


### PR DESCRIPTION
Tooltip on [`FFieldset`](https://forsakringskassan.github.io/designsystem/latest/components/input/fradiofield.html) is broken since v5.40.0:

![image](https://github.com/user-attachments/assets/41a34af4-1dd5-4d57-ba88-927f43fbb93d)

This PR fixes this issue but NVDA will present this slightly different to the screenreader:

**Före**:

![image](https://github.com/user-attachments/assets/87d53cf4-63bd-4aa3-889d-d7c04c020f14)

**Efter**:

![image](https://github.com/user-attachments/assets/375e0abc-1471-404e-8143-695e6aa9e4d9)

Skillnaden är att den tidigare läste upp det som två olika meddelanden där man måste pila mellan dem medans nu blir det direkt i ett och samma meddelande.

Det är samma beteende i vanliga inmatningsfält med `FLabel` och kollade i äldre FKUI-versioner och så har det varit tidigare på `FLabel` också. Så nu är det konsekvent mellan `FLabel` och `FFieldset` iaf, men om det är rätt eller fel låter jag vara osagt.