### PR TITLE
fix: fix resetting active item back to undefined (refs SFKUI-6941)

### DIFF
--- a/packages/vue/src/components/FList/FList.spec.ts
+++ b/packages/vue/src/components/FList/FList.spec.ts
@@ -1,6 +1,7 @@
 import "html-validate/jest";
 import { VueWrapper, mount } from "@vue/test-utils";
-import { ListArray } from "../../types";
+import { defineComponent } from "vue";
+import { ListArray, UnknownItem } from "../../types";
 import * as ListUtils from "../../utils/ListUtils";
 import { TranslationPlugin } from "../../plugins";
 import FList from "./FList.vue";
@@ -247,6 +248,41 @@ describe("active element", () => {
               "permission": "Write",
             }
         `);
+    });
+
+    it("should reset active item", async () => {
+        let activeItem: UnknownItem | undefined;
+        const TestComponent = defineComponent({
+            name: "TestComponent",
+            components: { FList },
+            data() {
+                return { items, activeItem, selectedItems: [] };
+            },
+            template: /* HTML */ `
+                <f-list
+                    v-model="selectedItems"
+                    v-model:active="activeItem"
+                    :items="items"
+                    key-attribute="id"
+                    selectable
+                >
+                    <template #default="{ item }">
+                        <h3>{{ item.frukt }}</h3>
+                    </template>
+                    <template #screenreader="{ item }">
+                        Frukt {{ item.frukt }}
+                    </template>
+                </f-list>
+            `,
+        });
+        const wrapper = mount(TestComponent);
+        wrapper.vm.$data.activeItem = items[1];
+        await wrapper.vm.$nextTick();
+        const listItem = wrapper.findAll(".list__item")[1];
+        expect(listItem.classes()).toContain("list__item--active");
+        wrapper.vm.$data.activeItem = undefined;
+        await wrapper.vm.$nextTick();
+        expect(listItem.classes()).not.toContain("list__item--active");
     });
 });
 

--- a/packages/vue/src/components/FList/FList.vue
+++ b/packages/vue/src/components/FList/FList.vue
@@ -316,7 +316,9 @@ export default defineComponent({
             }
         },
         updateActiveItemFromVModel(): void {
-            if (this.active && !itemEquals(this.active, this.activeItem, this.keyAttribute)) {
+            if (this.active === undefined) {
+                this.activeItem = undefined;
+            } else if (!itemEquals(this.active, this.activeItem, this.keyAttribute)) {
                 this.activeItem = this.active;
             }
         },


### PR DESCRIPTION
If the user sets a row to be active, then after that it is not possibe to reset active item to undefined