### PR TITLE
fix: fix wrong runtime error when missing `routes` prop on `FNavigationMenu` (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FNavigationMenu/FNavigationMenu.vue
+++ b/packages/vue/src/components/FNavigationMenu/FNavigationMenu.vue
@@ -202,6 +202,9 @@ export default defineComponent({
     },
     computed: {
         items(): MenuItem[] {
+            if (!this.routes || !Array.isArray(this.routes)) {
+                return [];
+            }
             return this.routes.map((i) => ({ label: i.label, key: i.route, href: i.href, target: i.target }));
         },
         overflowItems(): MenuItem[] {


### PR DESCRIPTION
If the `routes` prop is missing from `FNavigationMenu` the application crashes:

```vue
<script setup>
import { FNavigationMenu } from "@fkui/vue"
</script>

<template>
  <f-navigation-menu></f-navigation-menu>
</template>
```

### Expected results

```
local.ts:19 [Vue warn]: Missing required prop: "routes" 
  at <FNavigationMenu> 
  at <App>
```

### Actual results

```
index.html:12 TypeError: Cannot read properties of undefined (reading 'map')
    at Proxy.items (FNavigationMenu.vue:205:32)
    at Proxy._sfc_render (FNavigationMenu.vue:5:41)
```

Which crashes the application:

![image](https://github.com/user-attachments/assets/ed379a18-1a5d-4c0f-b591-5d0883430a89)



    