### PR TITLE
fix: focus in highcontrast mode (refs SFKUI-6909)

### DIFF
--- a/packages/design/src/core/helpers/accessibility/_focus.scss
+++ b/packages/design/src/core/helpers/accessibility/_focus.scss
@@ -14,8 +14,6 @@ input[type="image"]:focus,
 input[type="search"]:focus,
 [tabindex]:focus {
     @include focus.focus-indicator;
-
-    outline: none;
 }
 
 [tabindex="-1"]:focus {

--- a/packages/design/src/core/mixins/_focus.scss
+++ b/packages/design/src/core/mixins/_focus.scss
@@ -1,4 +1,5 @@
 @mixin focus-indicator() {
     border-radius: 0;
     box-shadow: var(--f-focus-box-shadow);
+    outline: 2px solid transparent; // Windows high contrast
 }


### PR DESCRIPTION
Lagt till en transparent fokusram (outline) som används som fokusram i högkontrastläge på alla komponenter.