### PR TITLE
fix: inline global modal styling (refs SFKUI-6500)

### DIFF
--- a/packages/design/src/components/modal/_modal.scss
+++ b/packages/design/src/components/modal/_modal.scss
@@ -12,19 +12,6 @@ $modal-sizes: (
 ) !default;
 $modal-width: calc(100vw - 40px) !default; // 100% - 20px each side;
 
-// @at-root is used to set these classes globally due to styling scope issue where the component is used out of the styling scope
-@at-root {
-    #{$MODAL_SELECTOR} {
-        &__open {
-            // both of these properties is used to prevent scrolling in the background
-            overflow: hidden;
-            position: fixed;
-            left: 0;
-            right: 0;
-        }
-    }
-}
-
 #{$MODAL_SELECTOR} {
     &__backdrop {
         background: var(--f-background-overlay);

--- a/packages/vue/src/components/FModal/FModal.spec.ts
+++ b/packages/vue/src/components/FModal/FModal.spec.ts
@@ -244,9 +244,8 @@ describe("scrollbars", () => {
             attachTo: createPlaceholderInDocument(),
         });
         await wrapper.vm.$nextTick();
-        // css class modal__open removes scrollbars
         const documentElement = document.documentElement;
-        expect(documentElement.classList).toContain("modal__open");
+        expect(documentElement.style.overflow).toBe("hidden");
     });
 
     it('should restore scrollbars in document if "isOpen" prop is false', async () => {
@@ -258,7 +257,7 @@ describe("scrollbars", () => {
         });
         await wrapper.vm.$nextTick();
         const documentElement = document.documentElement;
-        expect(documentElement.classList).not.toContain("modal__open");
+        expect(documentElement.style.overflow).not.toBe("hidden");
     });
 
     it("should restore scrollbars in document when component is unmounted", async () => {
@@ -272,11 +271,11 @@ describe("scrollbars", () => {
 
         const documentElement = document.documentElement;
 
-        expect(documentElement.classList).toContain("modal__open");
+        expect(documentElement.style.overflow).toBe("hidden");
 
         await wrapper.setProps({ isOpen: false });
         await wrapper.vm.$nextTick();
 
-        expect(documentElement.classList).not.toContain("modal__open");
+        expect(documentElement.style.overflow).not.toBe("hidden");
     });
 });

--- a/packages/vue/src/components/FModal/FModal.vue
+++ b/packages/vue/src/components/FModal/FModal.vue
@@ -185,7 +185,11 @@ export default defineComponent({
             const root = document.documentElement;
             const scroll = root.scrollTop;
             root.style.top = `-${scroll}px`;
-            root.classList.add("modal__open");
+            root.style.left = "0";
+            root.style.right = "0";
+            // both of these properties is used to prevent scrolling in the background
+            root.style.overflow = "hidden";
+            root.style.position = "fixed";
 
             const focusElement = this.resolveFocusElement();
             if (this.focus === "on") {
@@ -216,8 +220,12 @@ export default defineComponent({
         },
         restoreState(): void {
             const root = document.documentElement;
-            root.classList.remove("modal__open");
             root.style.removeProperty("top");
+            root.style.removeProperty("left");
+            root.style.removeProperty("right");
+            root.style.removeProperty("overflow");
+            root.style.removeProperty("position");
+
             root.scrollTop = this.savedScroll ?? 0;
             this.savedScroll = null;
 


### PR DESCRIPTION
Applications that scopes all styling from FKUI prevents some global styling. By inlining the global open modal styling it's no longer an issue.

If the styling is not applied, the user can scroll the page background when a modal is open.