### PR TITLE
fix: remove unnecessary beforeSubmit (refs SB-4982)

### DIFF
--- a/docs/functions/functions/modal-functions/form-modal.md
+++ b/docs/functions/functions/modal-functions/form-modal.md
@@ -31,9 +31,6 @@ function formModal(callingInstance, options);
     	- `"large"`
     	- `"fullscreen"
 
-    `beforeSubmit` {@optional}
-    : Optional callback passed to {@link FFormModal}.
-
     `props` {@optional}
     : Optional props to pass to modal.
 

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -391,8 +391,8 @@ default(): BeforeNavigate;
 }>> & Readonly<{
 onSubmit?: ((...args: any[]) => any) | undefined;
 }>, {
-beforeSubmit: FValidationFormCallback;
 id: string;
+beforeSubmit: FValidationFormCallback;
 beforeValidation: FValidationFormCallback;
 useErrorList: boolean;
 errorListBullets: boolean;
@@ -3267,9 +3267,9 @@ onCreated?: ((...args: any[]) => any) | undefined;
 onUpdated?: ((...args: any[]) => any) | undefined;
 onDeleted?: ((...args: any[]) => any) | undefined;
 }>, {
-beforeSubmit: FValidationFormCallback;
 beforeCreate: (() => ListItem) | undefined;
 modelValue: ListArray<UnknownItem>;
+beforeSubmit: FValidationFormCallback;
 beforeValidation: FValidationFormCallback;
 onCancel: () => void;
 primaryButtonRight: boolean;
@@ -3403,9 +3403,9 @@ value: Record<string, any>;
 size: string;
 isOpen: boolean;
 fullscreen: boolean;
-beforeSubmit: FValidationFormCallback;
 ariaCloseText: string;
 buttons: FModalButtonDescriptor[];
+beforeSubmit: FValidationFormCallback;
 beforeValidation: FValidationFormCallback;
 useErrorList: boolean;
 dataTest: string;
@@ -3635,8 +3635,8 @@ default(): BeforeNavigate;
 }>> & Readonly<{
 onSubmit?: ((...args: any[]) => any) | undefined;
 }>, {
-beforeSubmit: FValidationFormCallback;
 id: string;
+beforeSubmit: FValidationFormCallback;
 beforeValidation: FValidationFormCallback;
 useErrorList: boolean;
 errorListBullets: boolean;
@@ -7898,9 +7898,9 @@ value: Record<string, any>;
 size: string;
 isOpen: boolean;
 fullscreen: boolean;
-beforeSubmit: FValidationFormCallback;
 ariaCloseText: string;
 buttons: FModalButtonDescriptor[];
+beforeSubmit: FValidationFormCallback;
 beforeValidation: FValidationFormCallback;
 useErrorList: boolean;
 dataTest: string;
@@ -8130,8 +8130,8 @@ default(): BeforeNavigate;
 }>> & Readonly<{
 onSubmit?: ((...args: any[]) => any) | undefined;
 }>, {
-beforeSubmit: FValidationFormCallback;
 id: string;
+beforeSubmit: FValidationFormCallback;
 beforeValidation: FValidationFormCallback;
 useErrorList: boolean;
 errorListBullets: boolean;
@@ -11629,7 +11629,6 @@ export type FormModalMaybeOptions = Partial<FormModalModalOptions>;
 
 // @public (undocumented)
 export interface FormModalModalOptions {
-    beforeSubmit?: FValidationFormCallback;
     props: Record<string, unknown | undefined>;
     size: "large" | "fullscreen";
 }
@@ -17562,8 +17561,8 @@ default(): BeforeNavigate;
 }>> & Readonly<{
 onSubmit?: ((...args: any[]) => any) | undefined;
 }>, {
-beforeSubmit: FValidationFormCallback;
 id: string;
+beforeSubmit: FValidationFormCallback;
 beforeValidation: FValidationFormCallback;
 useErrorList: boolean;
 errorListBullets: boolean;

--- a/packages/vue/src/utils/form-modal/form-modal.spec.ts
+++ b/packages/vue/src/utils/form-modal/form-modal.spec.ts
@@ -1,7 +1,6 @@
 import * as openModalModule from "../open-modal/open-modal";
 import { type MaybeComponent } from "../maybe-component";
 import { MaybeWithFKUIContext } from "../../config";
-import { type ModalOptions } from "./modal-options";
 import { formModal } from "./form-modal";
 
 const callingInstance = { $fkui: {} } as MaybeWithFKUIContext;
@@ -43,37 +42,6 @@ it("should set size prop when size option is used", async () => {
         {
             props: {
                 size: "large",
-            },
-        },
-    );
-});
-
-it("should set beforeSubmit prop when beforeSubmit option is used", async () => {
-    expect.assertions(1);
-
-    const openModal = jest
-        .spyOn(openModalModule, "openModal")
-        .mockResolvedValue({
-            reason: "submit",
-            data: { field1: "" },
-        });
-    const myBeforeSubmit = jest.fn();
-
-    await formModal(
-        callingInstance,
-        {} as MaybeComponent,
-        {
-            beforeSubmit: myBeforeSubmit,
-        } as Partial<ModalOptions>,
-    );
-
-    expect(openModal).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        {
-            props: {
-                size: "",
-                beforeSubmit: myBeforeSubmit,
             },
         },
     );

--- a/packages/vue/src/utils/form-modal/form-modal.ts
+++ b/packages/vue/src/utils/form-modal/form-modal.ts
@@ -24,7 +24,6 @@ export async function formModal<T>(
 ): Promise<T> {
     const props = {
         size: options?.size ?? "",
-        beforeSubmit: options?.beforeSubmit,
         ...options?.props,
     };
     const result = await openModal<T>(callingInstance, Component, {

--- a/packages/vue/src/utils/form-modal/modal-options.ts
+++ b/packages/vue/src/utils/form-modal/modal-options.ts
@@ -1,13 +1,9 @@
-import { type FValidationFormCallback } from "../../components/FValidationForm/types";
-
 /**
  * @public
  */
 export interface ModalOptions {
     /** Modal size */
     size: "large" | "fullscreen";
-    /** Modal beforeSubmit callback */
-    beforeSubmit?: FValidationFormCallback;
     /** Modal props */
     props: Record<string, unknown | undefined>;
 }


### PR DESCRIPTION
Remove the beforeSubmit prop from formModal since it could overwrite beforeSubmit specified on the actual modal.