### PR TITLE
Bugfix/disabled combobox

### DIFF
--- a/etc/vue-labs.api.md
+++ b/etc/vue-labs.api.md
@@ -135,6 +135,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -228,6 +233,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -238,6 +248,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -774,6 +774,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -867,6 +872,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -877,6 +887,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -1221,6 +1232,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -1314,6 +1330,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -1324,6 +1345,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -2175,6 +2197,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -2268,6 +2295,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -2278,6 +2310,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -4261,6 +4294,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -4354,6 +4392,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -4364,6 +4407,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -5282,6 +5326,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -5375,6 +5424,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -5385,6 +5439,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -6019,6 +6074,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -6112,6 +6172,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -6122,6 +6187,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -10599,6 +10665,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -10692,6 +10763,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -10702,6 +10778,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -11209,6 +11286,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -11302,6 +11384,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -11312,6 +11399,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -11950,6 +12038,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -12043,6 +12136,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -12053,6 +12151,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -12416,6 +12515,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -12509,6 +12613,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -12519,6 +12628,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -12910,6 +13020,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -13003,6 +13118,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -13013,6 +13133,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -13350,6 +13471,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -13443,6 +13569,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -13453,6 +13584,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -13799,6 +13931,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -13892,6 +14029,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -13902,6 +14044,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -14539,6 +14682,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -14632,6 +14780,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -14642,6 +14795,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -15539,6 +15693,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -15632,6 +15791,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -15642,6 +15806,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;
@@ -16521,6 +16686,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>, {
 textFieldTableMode: boolean;
 viewValue: Ref<string, string>;
@@ -16614,6 +16784,11 @@ type: PropType<string[] | undefined>;
 required: false;
 default: () => undefined;
 };
+disabled: {
+type: BooleanConstructor;
+required: false;
+default: boolean;
+};
 }>> & Readonly<{
 onBlur?: ((...args: any[]) => any) | undefined;
 onChange?: ((...args: any[]) => any) | undefined;
@@ -16624,6 +16799,7 @@ type: string;
 id: string;
 modelValue: string | number;
 inline: boolean;
+disabled: boolean;
 options: string[] | undefined;
 labelWidth: string;
 formatter: FormatFunction<any>;

--- a/packages/css-variables/src/_semantic-tokens.scss
+++ b/packages/css-variables/src/_semantic-tokens.scss
@@ -33,6 +33,7 @@
 
     // ICON
     --fkds-icon-color-action-content-primary-default: #{$palette-color-bluebell-100};
+    --fkds-icon-color-action-content-primary-disabled: #{$palette-color-fk-black-50};
 
     // TEXT
     --fkds-color-text-inverted: #{$palette-color-white-100};

--- a/packages/design/src/components/combobox/_combobox.scss
+++ b/packages/design/src/components/combobox/_combobox.scss
@@ -40,4 +40,8 @@
     color: $combobox-f-icon-arrow-down-color-content-default;
     margin: 0;
     padding: 0;
+
+    &:disabled {
+        color: $combobox-f-icon-arrow-down-color-content-disabled;
+    }
 }

--- a/packages/design/src/components/combobox/_variables.scss
+++ b/packages/design/src/components/combobox/_variables.scss
@@ -6,3 +6,4 @@ $combobox-color-text-selected: var(--fkds-color-text-inverted);
 $combobox-color-text: var(--fkds-color-text-primary);
 $combobox-color-border: var(--fkds-color-border-primary);
 $combobox-f-icon-arrow-down-color-content-default: var(--fkds-icon-color-action-content-primary-default);
+$combobox-f-icon-arrow-down-color-content-disabled: var(--fkds-icon-color-action-content-primary-disabled);

--- a/packages/vue/src/components/FSortFilterDataset/__snapshots__/FSortFilterDataset.spec.ts.snap
+++ b/packages/vue/src/components/FSortFilterDataset/__snapshots__/FSortFilterDataset.spec.ts.snap
@@ -35,6 +35,7 @@ exports[`snapshots should match snapshot with a dropdown with attributes 1`] = `
               name="search"
             />
             <f-text-field-stub
+              disabled="false"
               id="fkui-vue-element-0001"
               inline="true"
               inputwidth="sm-12"

--- a/packages/vue/src/components/FTextField/FTextField.vue
+++ b/packages/vue/src/components/FTextField/FTextField.vue
@@ -58,6 +58,7 @@
                     :id="id"
                     ref="input"
                     v-model="viewValue"
+                    :disabled
                     :type="type"
                     class="text-field__input"
                     v-bind="$attrs"
@@ -87,6 +88,7 @@
                 </div>
                 <div v-if="options" class="text-field__append-inner">
                     <i-combobox-toggle-button
+                        :disabled
                         :aria-controls="dropdownIsOpen ? dropdownId : undefined"
                         :aria-expanded="dropdownIsOpen"
                         @toggle="toggleDropdown"
@@ -232,6 +234,14 @@ export default defineComponent({
             type: Array as PropType<string[] | undefined>,
             required: false,
             default: () => undefined,
+        },
+        /**
+         * Set to `true`, empty string `""` or string `"disabled"` to disable this field.
+         */
+        disabled: {
+            type: Boolean,
+            required: false,
+            default: false,
         },
     },
     emits: ["blur", "change", "update", "update:modelValue"],

--- a/packages/vue/src/internal-components/combobox/combobox.cy.ts
+++ b/packages/vue/src/internal-components/combobox/combobox.cy.ts
@@ -342,3 +342,17 @@ describe("Extended textfields", () => {
         cy.get(activeOption).should("have.text", "4,1");
     });
 });
+
+describe("Disabled component", () => {
+    it("should disable textfield and toggle button", () => {
+        cy.mount(FTextField, {
+            props: {
+                disabled: true,
+                options: ["foo"],
+            },
+            slots: { default: "etikett" },
+        });
+        cy.get(button).should("be.disabled");
+        cy.get(input).should("be.disabled");
+    });
+});


### PR DESCRIPTION
Pilknappen i komboboxens textfält är inte inaktiv när inmatningsfältet sätts som inaktivit. Som ett resultat kan användaren öppna dropplistan och göra ett val när fältet i sig är inaktivt. 