### PR TITLE
fix: scroll on modal close when `focus="on"` (fixes #187)

### DIFF
--- a/packages/vue/src/components/FModal/FModal.vue
+++ b/packages/vue/src/components/FModal/FModal.vue
@@ -226,10 +226,9 @@ export default defineComponent({
             root.style.removeProperty("overflow");
             root.style.removeProperty("position");
 
-            root.scrollTop = this.savedScroll ?? 0;
-            this.savedScroll = null;
-
             if (this.focus === "on" && this.savedFocus) {
+                root.scrollTop = this.savedScroll ?? 0;
+                this.savedScroll = null;
                 popFocus(this.savedFocus);
                 this.savedFocus = null;
             }


### PR DESCRIPTION
For other focus strategies, the consumer is responsible for focus and scroll when modal is closed.