### PR TITLE
fix!: update FTooltip to require headerTag if header exists (refs SFKUI-6972)

### DIFF
--- a/docs/components/FTooltip.md
+++ b/docs/components/FTooltip.md
@@ -14,6 +14,7 @@ FTooltipLiveExample.vue
 - Informationsrutan kan innehålla länkar och expanderbara fält.
 - Upprepa inte information som redan finns i rubrik eller brödtext.
 - Använd inte rubriken i tooltip om den inte verkligen behövs.
+    - Om rubrik används behöver även header-tag anges.
 - Flera informationsrutor kan vara öppna samtidigt.
 - Sträva efter att minimera användning av tooltip. Information som alla behöver veta ska visas med etiketten.
 

--- a/docs/components/input/examples/ComboboxExample.vue
+++ b/docs/components/input/examples/ComboboxExample.vue
@@ -301,7 +301,7 @@ export default defineComponent({
         tooltip(): string {
             const template = /* HTML */ `
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Läs mer här">
+                    <f-tooltip screen-reader-text="Läs mer här" header-tag="h2">
                         <template #header> Header </template>
                         <template #body> Body </template>
                     </f-tooltip>

--- a/docs/styles/examples/CompareDensity.vue
+++ b/docs/styles/examples/CompareDensity.vue
@@ -46,7 +46,7 @@
                 <f-static-field>
                     <template #label> Presentationsfält - statiskt </template>
                     <template #tooltip>
-                        <f-tooltip screen-reader-text="Skärmläsartext">
+                        <f-tooltip screen-reader-text="Skärmläsartext" header-tag="h2">
                             <template #header> Rubrik </template>
                             <template #body> Brödtext </template>
                         </f-tooltip>

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -15738,9 +15738,10 @@ required: false;
 default: string;
 };
 headerTag: {
-default: string;
+type: StringConstructor;
+default: undefined;
 required: false;
-validator(value: string): boolean;
+validator(value: string | undefined): boolean;
 };
 }>, {
 animate: (state: "expand" | "collapse") => void;
@@ -15775,9 +15776,10 @@ required: false;
 default: string;
 };
 headerTag: {
-default: string;
+type: StringConstructor;
+default: undefined;
 required: false;
-validator(value: string): boolean;
+validator(value: string | undefined): boolean;
 };
 }>> & Readonly<{
 "onUpdate:modelValue"?: ((...args: any[]) => any) | undefined;

--- a/packages/vue/htmlvalidate/elements/components.js
+++ b/packages/vue/htmlvalidate/elements/components.js
@@ -492,7 +492,7 @@ module.exports = defineMetadata({
                 enum: ["/.+/"],
             },
             "header-tag": {
-                enum: ["div", "span", "h1", "h2", "h3", "h4", "h5", "h6"],
+                enum: ["h1", "h2", "h3", "h4", "h5", "h6"],
             },
             "screen-reader-text": {
                 enum: ["/.+/"],

--- a/packages/vue/src/components/FCheckboxField/FCheckboxField.cy.ts
+++ b/packages/vue/src/components/FCheckboxField/FCheckboxField.cy.ts
@@ -147,7 +147,10 @@ describe("FCheckboxField", () => {
             <f-fieldset name="checkbox-name">
                 <template #label> Label text </template>
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Läs mer om Broschyrer">
+                    <f-tooltip
+                        screen-reader-text="Läs mer om Broschyrer"
+                        header-tag="h1"
+                    >
                         <template #header> Tooltip header text </template>
                         <template #body> Tooltip body text </template>
                     </f-tooltip>

--- a/packages/vue/src/components/FCheckboxField/examples/FCheckboxFieldLiveExample.vue
+++ b/packages/vue/src/components/FCheckboxField/examples/FCheckboxFieldLiveExample.vue
@@ -53,7 +53,7 @@ export default defineComponent({
         tooltip(): string {
             const template = /* HTML */ `
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Läs mer om Broschyrer">
+                    <f-tooltip screen-reader-text="Läs mer om Broschyrer" header-tag="h2">
                         <template #header> Broschyrer </template>
                         <template #body>
                             Här väljer du om du vill ha broschyrer eller faktablad och vilka områden

--- a/packages/vue/src/components/FDatepickerField/examples/FDatepickerFieldLiveExample.vue
+++ b/packages/vue/src/components/FDatepickerField/examples/FDatepickerFieldLiveExample.vue
@@ -142,7 +142,7 @@ export default defineComponent({
         tooltip(): string {
             const template = /* HTML */ `
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Läs mer här">
+                    <f-tooltip screen-reader-text="Läs mer här" header-tag="h2">
                         <template #header> Header </template>
                         <template #body> Body </template>
                     </f-tooltip>

--- a/packages/vue/src/components/FFieldset/examples/FFieldsetChipLiveExample.vue
+++ b/packages/vue/src/components/FFieldset/examples/FFieldsetChipLiveExample.vue
@@ -56,7 +56,7 @@ export default defineComponent({
         tooltip(): string {
             const template = /* HTML */ `
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Läs mer om Broschyrer">
+                    <f-tooltip screen-reader-text="Läs mer om Broschyrer" header-tag="h2">
                         <template #header> Header </template>
                         <template #body> Body </template>
                     </f-tooltip>
@@ -99,7 +99,7 @@ export default defineComponent({
                 >
                     Ytterligare alternativ
                 </${this.componentType}>
-                
+
                 <${this.componentType}
                     v-model="choices"
                     value="Sista"

--- a/packages/vue/src/components/FFieldset/examples/FFieldsetDefault.vue
+++ b/packages/vue/src/components/FFieldset/examples/FFieldsetDefault.vue
@@ -5,7 +5,10 @@
             <span :class="descriptionClass"> Vi behöver veta om du jobbar 100% eller ej </span>
         </template>
         <template #tooltip>
-            <f-tooltip screen-reader-text="Läs mer om Bor det barn som har fyllt 18 år i bostaden?">
+            <f-tooltip
+                screen-reader-text="Läs mer om Bor det barn som har fyllt 18 år i bostaden?"
+                header-tag="h2"
+            >
                 <template #header> Lite allmän information </template>
                 <template #body>
                     Här kan man skriva lite extra information om man nu önskar det!

--- a/packages/vue/src/components/FLabel/examples/FLabelLiveExample.vue
+++ b/packages/vue/src/components/FLabel/examples/FLabelLiveExample.vue
@@ -61,7 +61,7 @@ export default defineComponent({
         tooltip(): string {
             const template = /* HTML */ `
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Läs mer här">
+                    <f-tooltip screen-reader-text="Läs mer här" header-tag="h2">
                         <template #header> Header </template>
                         <template #body> Body </template>
                     </f-tooltip>

--- a/packages/vue/src/components/FOutputField/examples/FOutputFieldExample.vue
+++ b/packages/vue/src/components/FOutputField/examples/FOutputFieldExample.vue
@@ -17,7 +17,7 @@
         <f-output-field id="calculated" for="one two">
             <template #label> Summa </template>
             <template #tooltip>
-                <f-tooltip screen-reader-text="Läs mer om avancerat fält">
+                <f-tooltip screen-reader-text="Läs mer om avancerat fält" header-tag="h2">
                     <template #header> Mer om summa-fältet </template>
                     <template #body> Detta fältet är en summa av nummer 1 och nummer 2. </template>
                 </f-tooltip>

--- a/packages/vue/src/components/FRadioField/FRadioField.cy.ts
+++ b/packages/vue/src/components/FRadioField/FRadioField.cy.ts
@@ -156,7 +156,10 @@ describe("FRadioField", () => {
             <f-fieldset name="radio-name">
                 <template #label> Label text </template>
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Screen reader text.">
+                    <f-tooltip
+                        screen-reader-text="Screen reader text."
+                        header-tag="h1"
+                    >
                         <template #header> Tooltip header </template>
                         <template #body> Tooltip body </template>
                     </f-tooltip>

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.vue
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.vue
@@ -74,6 +74,7 @@ export default defineComponent({
                 <template #tooltip>
                     <f-tooltip
                         screen-reader-text="Läs mer om Bor det barn som har fyllt 18 år i bostaden?"
+                        header-tag="h2"
                     >
                         <template #header> Bor det barn som har fyllt 18 år i bostaden? </template>
                         <template #body>

--- a/packages/vue/src/components/FSelectField/FSelectField.cy.ts
+++ b/packages/vue/src/components/FSelectField/FSelectField.cy.ts
@@ -20,7 +20,7 @@ describe("FSelectField", () => {
                 >
                     <template #label> Dropplista </template>
                     <template #tooltip>
-                        <f-tooltip screen-reader-text="sr-text">
+                        <f-tooltip screen-reader-text="sr-text" header-tag="h1">
                             <template #header> Tooltip header </template>
                             <template #body> Tooltip body </template>
                         </f-tooltip>

--- a/packages/vue/src/components/FSelectField/examples/FSelectFieldLiveExample.vue
+++ b/packages/vue/src/components/FSelectField/examples/FSelectFieldLiveExample.vue
@@ -47,7 +47,7 @@ export default defineComponent({
         tooltip(): string {
             const template = /* HTML */ `
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Läs mer här">
+                    <f-tooltip screen-reader-text="Läs mer här" header-tag="h1">
                         <template #header> Header </template>
                         <template #body> Body </template>
                     </f-tooltip>

--- a/packages/vue/src/components/FStaticField/examples/FStaticFieldTooltipDescription.vue
+++ b/packages/vue/src/components/FStaticField/examples/FStaticFieldTooltipDescription.vue
@@ -3,7 +3,7 @@
         <f-static-field>
             <template #label> Etikett </template>
             <template #tooltip>
-                <f-tooltip screen-reader-text="Läs mer om avancerat fält">
+                <f-tooltip screen-reader-text="Läs mer om avancerat fält" header-tag="h2">
                     <template #header> Mer om avancerat fält </template>
                     <template #body> Detta fältet kräver lite närmare förklaring. </template>
                 </f-tooltip>

--- a/packages/vue/src/components/FTextField/examples/FTextFieldLiveExample.vue
+++ b/packages/vue/src/components/FTextField/examples/FTextFieldLiveExample.vue
@@ -180,7 +180,7 @@ export default defineComponent({
         tooltip(): string {
             const template = /* HTML */ `
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Läs mer här">
+                    <f-tooltip screen-reader-text="Läs mer här" header-tag="h2">
                         <template #header> Header </template>
                         <template #body> Body </template>
                     </f-tooltip>

--- a/packages/vue/src/components/FTextField/extendedTextFields/FSearchTextField/FSearchTextField.cy.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FSearchTextField/FSearchTextField.cy.ts
@@ -21,7 +21,10 @@ const component = defineComponent({
             label="Search"
         >
             <template #tooltip>
-                <f-tooltip screen-reader-text="tooltip info screen reader">
+                <f-tooltip
+                    screen-reader-text="tooltip info screen reader"
+                    header-tag="h1"
+                >
                     <template #header> Header </template>
                     <template #body> Body text </template>
                 </f-tooltip>

--- a/packages/vue/src/components/FTextareaField/FTextareaField.cy.ts
+++ b/packages/vue/src/components/FTextareaField/FTextareaField.cy.ts
@@ -38,6 +38,7 @@ describe("FTextareaField", () => {
                 <template #tooltip>
                     <f-tooltip
                         screen-reader-text="Läs mer om berätta om dig själv"
+                        header-tag="h1"
                     >
                         <template #header>
                             Mer om berätta om dig själv

--- a/packages/vue/src/components/FTextareaField/examples/FTextareaFieldLiveExample.vue
+++ b/packages/vue/src/components/FTextareaField/examples/FTextareaFieldLiveExample.vue
@@ -78,7 +78,7 @@ export default defineComponent({
         tooltip(): string {
             const template = /* HTML */ `
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Text för skärmläsare">
+                    <f-tooltip screen-reader-text="Text för skärmläsare" header-tag="h2">
                         <template #header> Header </template>
                         <template #body> Body </template>
                     </f-tooltip>

--- a/packages/vue/src/components/FTooltip/FTooltip.cy.ts
+++ b/packages/vue/src/components/FTooltip/FTooltip.cy.ts
@@ -18,6 +18,7 @@ describe("FTooltip", () => {
             },
             props: {
                 screenReaderText: "Screen reader text",
+                headerTag: "h3",
             },
         });
         const tooltip = new FTooltipPageObject(".tooltip");

--- a/packages/vue/src/components/FTooltip/FTooltip.spec.ts
+++ b/packages/vue/src/components/FTooltip/FTooltip.spec.ts
@@ -57,10 +57,26 @@ describe("slots", () => {
             slots: {
                 header: `Tooltip`,
             },
+            props: {
+                headerTag: "h3",
+            },
         });
         await wrapper.get(tooltipButtonClass).trigger("click");
         const header = wrapper.get(headerClass);
         expect(header.text()).toBe("Tooltip");
+    });
+
+    it("should throw error if has slot for header but no header-tag", async () => {
+        expect.assertions(1);
+        expect(() => {
+            createWrapper({
+                slots: {
+                    header: `Tooltip`,
+                },
+            });
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"Tooltip with header must define headerTag"`,
+        );
     });
 
     it("should not render header if header slot isn't used", async () => {
@@ -140,8 +156,6 @@ describe("html-validate", () => {
             <f-tooltip header-tag="" screen-reader-text="foo"></f-tooltip>
 
             <!-- valid header-tag -->
-            <f-tooltip header-tag="div" screen-reader-text="foo"></f-tooltip>
-            <f-tooltip header-tag="span" screen-reader-text="foo"></f-tooltip>
             <f-tooltip header-tag="h1" screen-reader-text="foo"></f-tooltip>
             <f-tooltip header-tag="h2" screen-reader-text="foo"></f-tooltip>
             <f-tooltip header-tag="h3" screen-reader-text="foo"></f-tooltip>
@@ -151,6 +165,8 @@ describe("html-validate", () => {
 
             <!-- invalid header-tag -->
             <f-tooltip header-tag="foobar" screen-reader-text="foo"></f-tooltip>
+            <f-tooltip header-tag="div" screen-reader-text="foo"></f-tooltip>
+            <f-tooltip header-tag="span" screen-reader-text="foo"></f-tooltip>
         `;
         const report = htmlvalidate.validateString(markup);
         expect(report).toMatchInlineCodeframe(`
@@ -170,13 +186,30 @@ describe("html-validate", () => {
                  |                        ^^^^^^^^^^
               10 |
               11 |             <!-- valid header-tag -->
-              12 |             <f-tooltip header-tag="div" screen-reader-text="foo"></f-tooltip>
+              12 |             <f-tooltip header-tag="h1" screen-reader-text="foo"></f-tooltip>
             Selector: f-tooltip:nth-child(3)
-            error: Attribute "header-tag" has invalid value "foobar" (attribute-allowed-values) at inline:22:36:
-              20 |
-              21 |             <!-- invalid header-tag -->
-            > 22 |             <f-tooltip header-tag="foobar" screen-reader-text="foo"></f-tooltip>
+            error: Attribute "header-tag" has invalid value "foobar" (attribute-allowed-values) at inline:20:36:
+              18 |
+              19 |             <!-- invalid header-tag -->
+            > 20 |             <f-tooltip header-tag="foobar" screen-reader-text="foo"></f-tooltip>
                  |                                    ^^^^^^
+              21 |             <f-tooltip header-tag="div" screen-reader-text="foo"></f-tooltip>
+              22 |             <f-tooltip header-tag="span" screen-reader-text="foo"></f-tooltip>
+              23 |
+            Selector: f-tooltip:nth-child(10)
+            error: Attribute "header-tag" has invalid value "div" (attribute-allowed-values) at inline:21:36:
+              19 |             <!-- invalid header-tag -->
+              20 |             <f-tooltip header-tag="foobar" screen-reader-text="foo"></f-tooltip>
+            > 21 |             <f-tooltip header-tag="div" screen-reader-text="foo"></f-tooltip>
+                 |                                    ^^^
+              22 |             <f-tooltip header-tag="span" screen-reader-text="foo"></f-tooltip>
+              23 |
+            Selector: f-tooltip:nth-child(11)
+            error: Attribute "header-tag" has invalid value "span" (attribute-allowed-values) at inline:22:36:
+              20 |             <f-tooltip header-tag="foobar" screen-reader-text="foo"></f-tooltip>
+              21 |             <f-tooltip header-tag="div" screen-reader-text="foo"></f-tooltip>
+            > 22 |             <f-tooltip header-tag="span" screen-reader-text="foo"></f-tooltip>
+                 |                                    ^^^^
               23 |
             Selector: f-tooltip:nth-child(12)"
         `);

--- a/packages/vue/src/components/FTooltip/FTooltip.vue
+++ b/packages/vue/src/components/FTooltip/FTooltip.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, inject, ref, toRef, useTemplateRef, watchEffect } from "vue";
+import { computed, defineComponent, inject, ref, toRef, useTemplateRef, watchEffect, useSlots } from "vue";
 import { TranslationService } from "@fkui/logic";
 import { FExpand } from "../FExpand";
 import { IFlex, IFlexItem } from "../../internal-components";
@@ -87,9 +87,6 @@ export default defineComponent({
          * Element to render for the header element inside the tooltip.
          *
          * Must be set to one of:
-         *
-         * - `div` (default)
-         * - `span`
          * - `h1`
          * - `h2`
          * - `h3`
@@ -98,10 +95,11 @@ export default defineComponent({
          * - `h6`
          */
         headerTag: {
-            default: "div",
+            type: String,
+            default: undefined,
             required: false,
-            validator(value: string): boolean {
-                return ["div", "span", "h1", "h2", "h3", "h4", "h5", "h6"].includes(value);
+            validator(value: string | undefined): boolean {
+                return [undefined, "h1", "h2", "h3", "h4", "h5", "h6"].includes(value);
             },
         },
     },
@@ -160,6 +158,12 @@ export default defineComponent({
                 this.animate(value ? "expand" : "collapse");
             },
         },
+    },
+    created() {
+        const slots = useSlots();
+        if (slots.header && !this.headerTag) {
+            throw new Error("Tooltip with header must define headerTag");
+        }
     },
     methods: {
         /**

--- a/packages/vue/src/components/FTooltip/examples/FTooltipLiveExample.vue
+++ b/packages/vue/src/components/FTooltip/examples/FTooltipLiveExample.vue
@@ -29,6 +29,9 @@ export default defineComponent({
         header(): string {
             return this.hasHeader ? "<template #header> Lär dig mer om [..] </template>" : "";
         },
+        headerTag(): string {
+            return this.hasHeader ? 'header-tag="h2"' : "";
+        },
         template(): string {
             const { longText } = this;
             const text = longText
@@ -38,7 +41,10 @@ export default defineComponent({
                 <f-label>
                     <template #default> ${text} </template>
                     <template #tooltip>
-                        <f-tooltip screen-reader-text="Denna text syns bara för skärmläsare">
+                        <f-tooltip
+                            screen-reader-text="Denna text syns bara för skärmläsare"
+                            ${this.headerTag}
+                        >
                             ${this.header}
                             <template #body> Lorem ipsum dolor sit amet. </template>
                         </f-tooltip>

--- a/packages/vue/src/pageobject/FCheckboxGroup.pageobject.cy.ts
+++ b/packages/vue/src/pageobject/FCheckboxGroup.pageobject.cy.ts
@@ -98,7 +98,10 @@ describe("FCheckboxGroupPageObject", () => {
                 <template #label> Label text </template>
 
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Screen reader text">
+                    <f-tooltip
+                        screen-reader-text="Screen reader text"
+                        header-tag="h1"
+                    >
                         <template #header> Header </template>
                         <template #body> Body </template>
                     </f-tooltip>

--- a/packages/vue/src/pageobject/FFieldset.pageobject.cy.ts
+++ b/packages/vue/src/pageobject/FFieldset.pageobject.cy.ts
@@ -52,7 +52,10 @@ describe("FFieldsetPageObject", () => {
                         </span>
                     </template>
                     <template #tooltip>
-                        <f-tooltip screen-reader-text="Screen reader text">
+                        <f-tooltip
+                            screen-reader-text="Screen reader text"
+                            header-tag="h1"
+                        >
                             <template #header> Header </template>
                             <template #body> Body </template>
                         </f-tooltip>
@@ -119,7 +122,10 @@ describe("FFieldsetPageObject", () => {
                     <template #label> Label text </template>
 
                     <template #tooltip>
-                        <f-tooltip screen-reader-text="Screen reader text">
+                        <f-tooltip
+                            screen-reader-text="Screen reader text"
+                            header-tag="h1"
+                        >
                             <template #header> Header </template>
                             <template #body> Body </template>
                         </f-tooltip>
@@ -197,7 +203,10 @@ describe("FFieldsetPageObject", () => {
                     <template #default> Etikett </template>
 
                     <template #tooltip>
-                        <f-tooltip screen-reader-text="Läs mer här">
+                        <f-tooltip
+                            screen-reader-text="Läs mer här"
+                            header-tag="h1"
+                        >
                             <template #header> Header </template>
                             <template #body> Body </template>
                         </f-tooltip>

--- a/packages/vue/src/pageobject/FRadioGroup.pageobject.cy.ts
+++ b/packages/vue/src/pageobject/FRadioGroup.pageobject.cy.ts
@@ -96,7 +96,10 @@ describe("FRadioGroupPageObject", () => {
                     <span :class="descriptionClass"> Description text </span>
                 </template>
                 <template #tooltip>
-                    <f-tooltip screen-reader-text="Screen reader text">
+                    <f-tooltip
+                        screen-reader-text="Screen reader text"
+                        header-tag="h1"
+                    >
                         <template #header> Header </template>
                         <template #body> Body </template>
                     </f-tooltip>

--- a/packages/vue/src/pageobject/FTooltip.pageobject.cy.ts
+++ b/packages/vue/src/pageobject/FTooltip.pageobject.cy.ts
@@ -15,6 +15,7 @@ describe("attached to label", () => {
                             <f-tooltip
                                 :model-value="true"
                                 screen-reader-text="Lorem ipsum dolor sit amet"
+                                header-tag="h1"
                             >
                                 <template #header> Header slot </template>
                                 <template #body> body slot </template>
@@ -60,6 +61,7 @@ describe("attached to heading", () => {
                         :attach-to="attach"
                         :model-value="true"
                         screen-reader-text="Lorem ipsum dolor sit amet"
+                        header-tag="h1"
                     >
                         <template #header> Header slot </template>
                         <template #body> body slot </template>
@@ -100,6 +102,7 @@ describe("unattached", () => {
             props: {
                 modelValue: true,
                 screenReaderText: "Lorem ipsum dolor sit amet",
+                headerTag: "h1",
             },
             slots: {
                 header: "Header slot",


### PR DESCRIPTION
BREAKING CHANGE: FTooltip now requires a `headerTag` if it has a header-slot.

I de fall tooltip har header men vi inte angett header-tag så har den tidigare använt default `div`, vilket sällan blir rätt.
Därför har vi nu gjort det obligatoriskt att ange header-tag om man har en header, för att se till så det blir semantiskt korrekt. 