### PR TITLE
refactor: remove unnecessary cast (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FCheckboxField/FCheckboxField.spec.ts
+++ b/packages/vue/src/components/FCheckboxField/FCheckboxField.spec.ts
@@ -41,9 +41,7 @@ it.each`
             },
         });
 
-        expect((wrapper.get("input").element as HTMLInputElement).checked).toBe(
-            expected,
-        );
+        expect(wrapper.get("input").element.checked).toBe(expected);
     },
 );
 
@@ -83,7 +81,7 @@ describe("disabled", () => {
                     disabled,
                 },
             });
-            const input = wrapper.get("input").element as HTMLInputElement;
+            const input = wrapper.get("input").element;
             expect(input.disabled).toBe(expectedResult);
             expect(wrapper.classes("disabled")).toBe(expectedResult);
         },
@@ -97,7 +95,7 @@ describe("events", () => {
         });
 
         const input = wrapper.get("input");
-        const htmlInput = input.element as HTMLInputElement;
+        const htmlInput = input.element;
 
         expect(htmlInput.checked).toBe(true);
         await wrapper.setProps({ modelValue: undefined });
@@ -240,7 +238,7 @@ describe("events", () => {
         });
 
         const input = wrapper.get("input");
-        const htmlInput = input.element as HTMLInputElement;
+        const htmlInput = input.element;
         htmlInput.focus = jest.fn();
 
         await input.trigger("click");

--- a/packages/vue/src/components/FRadioField/FRadioField.spec.ts
+++ b/packages/vue/src/components/FRadioField/FRadioField.spec.ts
@@ -47,9 +47,7 @@ it.each`
             },
         });
 
-        expect((wrapper.get("input").element as HTMLInputElement).checked).toBe(
-            expected,
-        );
+        expect(wrapper.get("input").element.checked).toBe(expected);
     },
 );
 
@@ -89,7 +87,7 @@ describe("disabled", () => {
                     disabled,
                 },
             });
-            const input = wrapper.get("input").element as HTMLInputElement;
+            const input = wrapper.get("input").element;
             expect(input.disabled).toBe(expectedResult);
             expect(wrapper.classes("disabled")).toBe(expectedResult);
         },
@@ -104,7 +102,7 @@ describe("events", () => {
 
         const input = wrapper.get("input");
 
-        const htmlInput = input.element as HTMLInputElement;
+        const htmlInput = input.element;
 
         expect(htmlInput.checked).toBe(true);
         await wrapper.setProps({ modelValue: undefined });
@@ -135,7 +133,7 @@ describe("events", () => {
         });
 
         const input = wrapper.get("input");
-        const htmlInput = input.element as HTMLInputElement;
+        const htmlInput = input.element;
         htmlInput.focus = jest.fn();
 
         await input.trigger("click");

--- a/packages/vue/src/components/FSelectField/FSelectField.spec.ts
+++ b/packages/vue/src/components/FSelectField/FSelectField.spec.ts
@@ -155,7 +155,7 @@ describe("events", () => {
             { props: { modelValue: "banana" } },
         );
         const select = wrapper.get("select");
-        const htmlSelect = select.element as HTMLSelectElement;
+        const htmlSelect = select.element;
 
         expect(htmlSelect.value).toBe("banana");
         select.setValue("apple");

--- a/packages/vue/src/components/FTextField/FTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/FTextField.spec.ts
@@ -70,7 +70,7 @@ describe("snapshots", () => {
             });
 
             const input = wrapper.get("input");
-            const htmlInput = input.element as HTMLInputElement;
+            const htmlInput = input.element;
 
             htmlInput.dispatchEvent(
                 new CustomEvent<ValidityEvent>("validity", {
@@ -216,7 +216,7 @@ describe("events", () => {
         });
 
         const input = wrapper.get("input");
-        const htmlInput = input.element as HTMLInputElement;
+        const htmlInput = input.element;
 
         htmlInput.dispatchEvent(
             new CustomEvent<ValidityEvent>("validity", {
@@ -255,7 +255,7 @@ describe("validation", () => {
         const input = wrapper.get("input");
         const validatorConfigs: ValidatorConfigs = { number: {}, integer: {} };
         ValidationService.addValidatorsToElement(
-            input.element as HTMLInputElement,
+            input.element,
             validatorConfigs,
         );
 
@@ -297,7 +297,7 @@ describe("formatting and parsing combined with validation", () => {
             });
 
             const input = wrapper.get("input");
-            const htmlInput = input.element as HTMLInputElement;
+            const htmlInput = input.element;
             input.setValue("qweRTY");
 
             htmlInput.dispatchEvent(
@@ -362,7 +362,7 @@ describe("formatting and parsing combined with validation", () => {
             });
 
             const input = wrapper.get("input");
-            const htmlInput = input.element as HTMLInputElement;
+            const htmlInput = input.element;
             input.setValue(inputValue);
 
             htmlInput.dispatchEvent(
@@ -416,7 +416,7 @@ describe("formatting and parsing combined with validation", () => {
             });
 
             const input = wrapper.get("input");
-            const htmlInput = input.element as HTMLInputElement;
+            const htmlInput = input.element;
             input.setValue(inputValue);
 
             htmlInput.dispatchEvent(
@@ -459,7 +459,7 @@ describe("set v-model programmatic", () => {
             const input = wrapper.get("input");
             input.setValue("original input");
 
-            const htmlInput = input.element as HTMLInputElement;
+            const htmlInput = input.element;
 
             htmlInput.dispatchEvent(
                 new CustomEvent<ValidityEvent>("validity", {

--- a/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.spec.ts
@@ -72,7 +72,7 @@ describe("snapshots", () => {
             });
 
             const input = wrapper.get("input");
-            const htmlInput = input.element as HTMLInputElement;
+            const htmlInput = input.element;
 
             htmlInput.dispatchEvent(
                 new CustomEvent<ValidityEvent>("validity", {
@@ -182,7 +182,7 @@ describe("events", () => {
         });
 
         const input = wrapper.get("input");
-        const htmlInput = input.element as HTMLInputElement;
+        const htmlInput = input.element;
 
         htmlInput.dispatchEvent(
             new CustomEvent<ValidityEvent>("validity", {
@@ -220,7 +220,7 @@ describe("validation", () => {
         const input = wrapper.get("input");
         const validatorConfigs: ValidatorConfigs = { required: {} };
         ValidationService.addValidatorsToElement(
-            input.element as HTMLInputElement,
+            input.element,
             validatorConfigs,
         );
 
@@ -306,7 +306,7 @@ describe("disable paste", () => {
         const wrapper = createWrapper({ options: { sync: false } });
         expect(wrapper.find(".label__message--error").exists()).toBeFalsy();
 
-        const inputElement = wrapper.get("input").element as HTMLInputElement;
+        const inputElement = wrapper.get("input").element;
         allowPaste(inputElement);
         await flushPromises();
 
@@ -320,8 +320,7 @@ describe("disable paste", () => {
         });
         expect(wrapper.find(".label__message--error").exists()).toBeFalsy();
 
-        const secondInputElement = wrapper.findAll("input")[1]
-            .element as HTMLInputElement;
+        const secondInputElement = wrapper.findAll("input")[1].element;
         testPaste(secondInputElement);
         await flushPromises();
 
@@ -335,10 +334,8 @@ describe("disable paste", () => {
             options: { sync: false },
             props: { extendedValidation: true },
         });
-        const firstInputElement = wrapper.findAll("input")[0]
-            .element as HTMLInputElement;
-        const secondInputElement = wrapper.findAll("input")[1]
-            .element as HTMLInputElement;
+        const firstInputElement = wrapper.findAll("input")[0].element;
+        const secondInputElement = wrapper.findAll("input")[1].element;
 
         allowPaste(firstInputElement);
         testPaste(secondInputElement);

--- a/packages/vue/src/components/FTextField/extendedTextFields/FNumericTextField/FNumericTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FNumericTextField/FNumericTextField.spec.ts
@@ -97,7 +97,7 @@ describe("format", () => {
         const wrapper = createWrapper(markup, 3);
 
         const input = wrapper.get("input");
-        const inputElement = input.element as HTMLInputElement;
+        const inputElement = input.element;
 
         expect(inputElement.value).toBe("3,00");
 

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.spec.ts
@@ -72,7 +72,7 @@ describe("snapshots", () => {
             });
 
             const input = wrapper.get("input");
-            const htmlInput = input.element as HTMLInputElement;
+            const htmlInput = input.element;
 
             htmlInput.dispatchEvent(
                 new CustomEvent<ValidityEvent>("validity", {
@@ -145,7 +145,7 @@ describe("events", () => {
             props: { modelValue: "888" },
         });
         const input = wrapper.get("input");
-        const htmlInput = input.element as HTMLInputElement;
+        const htmlInput = input.element;
         expect(htmlInput.value).toBe("888");
 
         input.setValue("888-888");
@@ -184,7 +184,7 @@ describe("events", () => {
         });
 
         const input = wrapper.get("input");
-        const htmlInput = input.element as HTMLInputElement;
+        const htmlInput = input.element;
 
         htmlInput.dispatchEvent(
             new CustomEvent<ValidityEvent>("validity", {
@@ -222,7 +222,7 @@ describe("validation", () => {
         const input = wrapper.get("input");
         const validatorConfigs: ValidatorConfigs = { required: {} };
         ValidationService.addValidatorsToElement(
-            input.element as HTMLInputElement,
+            input.element,
             validatorConfigs,
         );
 


### PR DESCRIPTION
`wrapper.get("input")` ger `HTMLInputElement` direkt (precis som att `document.querySelector("input")` gör det). Så meningslöst att casta.

Har säkert inte alltid varit så men det är så nu.