### PR TITLE
refactor: remove deprecated `alwaysInline` prop from `IPopup`

### DIFF
--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -2618,11 +2618,6 @@ required: false;
 validator(value: string): boolean;
 default: string;
 };
-alwaysInline: {
-type: BooleanConstructor;
-required: false;
-default: boolean;
-};
 container: {
 type: PropType<HTMLElement | null | undefined>;
 required: false;
@@ -2681,11 +2676,6 @@ required: false;
 validator(value: string): boolean;
 default: string;
 };
-alwaysInline: {
-type: BooleanConstructor;
-required: false;
-default: boolean;
-};
 container: {
 type: PropType<HTMLElement | null | undefined>;
 required: false;
@@ -2718,7 +2708,6 @@ onOpen?: ((...args: any[]) => any) | undefined;
 anchor: HTMLElement | null | undefined;
 viewport: HTMLElement;
 inline: "auto" | "always" | "never";
-alwaysInline: boolean;
 container: HTMLElement | null | undefined;
 keyboardTrap: boolean;
 focusElement: () => HTMLElement | null;
@@ -4610,12 +4599,12 @@ onChange?: ((...args: any[]) => any) | undefined;
 "onUpdate:modelValue"?: ((...args: any[]) => any) | undefined;
 }>, {
 modelValue: string;
-alwaysInline: boolean;
 disabled: boolean;
 labelWidth: string;
 inputWidth: string;
 initialMonth: FDate | undefined;
 highlightToday: boolean;
+alwaysInline: boolean;
 }, {}, {
 FCalendar: DefineComponent<ExtractPropTypes<    {
 modelValue: {
@@ -4871,11 +4860,6 @@ required: false;
 validator(value: string): boolean;
 default: string;
 };
-alwaysInline: {
-type: BooleanConstructor;
-required: false;
-default: boolean;
-};
 container: {
 type: PropType<HTMLElement | null | undefined>;
 required: false;
@@ -4934,11 +4918,6 @@ required: false;
 validator(value: string): boolean;
 default: string;
 };
-alwaysInline: {
-type: BooleanConstructor;
-required: false;
-default: boolean;
-};
 container: {
 type: PropType<HTMLElement | null | undefined>;
 required: false;
@@ -4971,7 +4950,6 @@ onOpen?: ((...args: any[]) => any) | undefined;
 anchor: HTMLElement | null | undefined;
 viewport: HTMLElement;
 inline: "auto" | "always" | "never";
-alwaysInline: boolean;
 container: HTMLElement | null | undefined;
 keyboardTrap: boolean;
 focusElement: () => HTMLElement | null;
@@ -9320,11 +9298,6 @@ required: false;
 validator(value: string): boolean;
 default: string;
 };
-alwaysInline: {
-type: BooleanConstructor;
-required: false;
-default: boolean;
-};
 container: {
 type: PropType<HTMLElement | null | undefined>;
 required: false;
@@ -9383,11 +9356,6 @@ required: false;
 validator(value: string): boolean;
 default: string;
 };
-alwaysInline: {
-type: BooleanConstructor;
-required: false;
-default: boolean;
-};
 container: {
 type: PropType<HTMLElement | null | undefined>;
 required: false;
@@ -9420,7 +9388,6 @@ onOpen?: ((...args: any[]) => any) | undefined;
 anchor: HTMLElement | null | undefined;
 viewport: HTMLElement;
 inline: "auto" | "always" | "never";
-alwaysInline: boolean;
 container: HTMLElement | null | undefined;
 keyboardTrap: boolean;
 focusElement: () => HTMLElement | null;
@@ -17221,11 +17188,6 @@ required: false;
 validator(value: string): boolean;
 default: string;
 };
-alwaysInline: {
-type: BooleanConstructor;
-required: false;
-default: boolean;
-};
 container: {
 type: PropType<HTMLElement | null | undefined>;
 required: false;
@@ -17284,11 +17246,6 @@ required: false;
 validator(value: string): boolean;
 default: string;
 };
-alwaysInline: {
-type: BooleanConstructor;
-required: false;
-default: boolean;
-};
 container: {
 type: PropType<HTMLElement | null | undefined>;
 required: false;
@@ -17321,7 +17278,6 @@ onOpen?: ((...args: any[]) => any) | undefined;
 anchor: HTMLElement | null | undefined;
 viewport: HTMLElement;
 inline: "auto" | "always" | "never";
-alwaysInline: boolean;
 container: HTMLElement | null | undefined;
 keyboardTrap: boolean;
 focusElement: () => HTMLElement | null;
@@ -17583,11 +17539,6 @@ required: false;
 validator(value: string): boolean;
 default: string;
 };
-alwaysInline: {
-type: BooleanConstructor;
-required: false;
-default: boolean;
-};
 container: {
 type: PropType<HTMLElement | null | undefined>;
 required: false;
@@ -17646,11 +17597,6 @@ required: false;
 validator(value: string): boolean;
 default: string;
 };
-alwaysInline: {
-type: BooleanConstructor;
-required: false;
-default: boolean;
-};
 container: {
 type: PropType<HTMLElement | null | undefined>;
 required: false;
@@ -17683,7 +17629,6 @@ onOpen?: ((...args: any[]) => any) | undefined;
 anchor: HTMLElement | null | undefined;
 viewport: HTMLElement;
 inline: "auto" | "always" | "never";
-alwaysInline: boolean;
 container: HTMLElement | null | undefined;
 keyboardTrap: boolean;
 focusElement: () => HTMLElement | null;

--- a/packages/vue/htmlvalidate/elements/internal-components.js
+++ b/packages/vue/htmlvalidate/elements/internal-components.js
@@ -163,12 +163,6 @@ module.exports = defineMetadata({
             anchor: {
                 required: true,
             },
-            "always-inline": {
-                boolean: true,
-                required: false,
-                deprecated:
-                    '`always-inline` is deprecated: use `inline="always"` instead.',
-            },
             inline: {
                 required: false,
                 enum: ["always", "never", "auto"],

--- a/packages/vue/src/internal-components/IPopup/IPopup.cy.ts
+++ b/packages/vue/src/internal-components/IPopup/IPopup.cy.ts
@@ -140,25 +140,6 @@ describe("open popup", () => {
                 popup.el().should("have.class", "popup--inline");
             });
         });
-
-        describe("always-inline prop", () => {
-            it("should add `popup--inline` class when prop `always-inline` is set", () => {
-                setViewport(VIEWPORT.DESKTOP);
-                const template = /* HTML */ `
-                    <i-popup
-                        :isOpen="isOpen"
-                        :anchor="$refs.anchor"
-                        always-inline
-                    >
-                        <span> POPUP CONTENT </span>
-                    </i-popup>
-                `;
-                const component = createComponent(template);
-                cy.mount(component);
-                cy.get(popupButtonId).click();
-                popup.el().should("have.class", "popup--inline");
-            });
-        });
     });
 
     describe("focus", () => {

--- a/packages/vue/src/internal-components/IPopup/IPopup.spec.ts
+++ b/packages/vue/src/internal-components/IPopup/IPopup.spec.ts
@@ -155,16 +155,6 @@ describe("html-validate", () => {
         });
     });
 
-    it("should not allow setting always-inline value", () => {
-        const markup = /* HTML */ `
-            <i-popup anchor="anchorref" is-open always-inline=""></i-popup>
-        `;
-        expect(markup).not.toHTMLValidate({
-            ruleId: "attribute-boolean-style",
-            message: 'Attribute "always-inline" should omit value',
-        });
-    });
-
     it("should allow setting viewport value", () => {
         const markup = /* HTML */ `
             <i-popup

--- a/packages/vue/src/internal-components/IPopup/IPopup.vue
+++ b/packages/vue/src/internal-components/IPopup/IPopup.vue
@@ -62,15 +62,6 @@ export default defineComponent({
             default: "auto",
         },
         /**
-         * Force popup to always display inline.
-         * @deprecated Use `inline="always"` instead.
-         */
-        alwaysInline: {
-            type: Boolean,
-            required: false,
-            default: false,
-        },
-        /**
          * Which element to use as container.
          */
         container: {
@@ -150,7 +141,7 @@ export default defineComponent({
             return isInline;
         },
         forceInline(): boolean {
-            return this.alwaysInline || this.inline === "always";
+            return this.inline === "always";
         },
         forceOverlay(): boolean {
             return this.inline === "never";


### PR DESCRIPTION
Nu är ju detta typ brytande fast det är en I-komponent. Ska vi använda `feat` eller är `refactor` ok? Med i migreringsguiden?

Jag röstar för att vi är hårda med att vi kan ändra I-komponenter och att det är på konsumentens ansvar.