### PR TITLE
build: fkui-serve less verbose output unless using --verbose

### DIFF
--- a/generate-docs.mjs
+++ b/generate-docs.mjs
@@ -23,7 +23,6 @@ const require = module.createRequire(import.meta.url);
 
 const pkg = require("./package.json");
 
-let createVersionMock = false;
 const DEFAULT_MATOMO_CONFIG = {
     trackerUrl: "https://webstats.forsakringskassan.se/matomo/",
     hostname: [
@@ -66,8 +65,6 @@ if (isCI) {
     console.log("Source url format: ", DOCS_SOURCE_URL_FORMAT);
     console.groupEnd();
     console.log();
-} else {
-    createVersionMock = true;
 }
 
 const docs = new Generator({
@@ -161,19 +158,17 @@ docs.copyResource("images", path.join(fkuiDesign, "assets/images"));
 try {
     await docs.build(config.sourceFiles);
 
-    if (createVersionMock) {
-        await fs.mkdir("public/latest", { recursive: true });
-        const latest = `v${pkg.version}`;
-        const versions = JSON.stringify(
-            {
-                latest,
-                versions: [latest],
-            },
-            null,
-            2,
-        );
-        await fs.writeFile("public/versions.json", versions, "utf-8");
-    }
+    const latest = `v${pkg.version}`;
+    const versions = JSON.stringify(
+        {
+            latest,
+            versions: [latest],
+        },
+        null,
+        2,
+    );
+    await fs.mkdir("temp/docs", { recursive: true });
+    await fs.writeFile("temp/docs/versions.json", versions, "utf-8");
 } catch (err) {
     console.error(err.prettyError ? err.prettyError() : err);
     process.exitCode = 1;

--- a/internal/serve/lib/cli.js
+++ b/internal/serve/lib/cli.js
@@ -25,7 +25,7 @@ function CLI(argv) {
             const table = new Table({
                 head: ["URL", "Path"],
                 style: { compact: true, head: ["cyan"] },
-                rows: Object.entries(paths),
+                rows: paths,
             });
             console.log();
             console.log(`Server started at http://localhost:${addr.port}`);

--- a/internal/serve/lib/cli.js
+++ b/internal/serve/lib/cli.js
@@ -14,10 +14,13 @@ function CLI(argv) {
     const port = process.env.HTTP_PORT
         ? parseInt(process.env.HTTP_PORT, 10)
         : defaultPort;
-    const verbose = !flags.includes("-s") && !flags.includes("--silent");
+    const verbose = flags.includes("-v") || flags.includes("--verbose");
+    const silent =
+        !verbose && (flags.includes("-s") || flags.includes("--silent"));
     const folders = positionals;
     serve(port, folders, {
         verbose,
+        silent,
         onReady(addr, paths) {
             const table = new Table({
                 head: ["URL", "Path"],
@@ -27,7 +30,7 @@ function CLI(argv) {
             console.log();
             console.log(`Server started at http://localhost:${addr.port}`);
             console.log();
-            if (verbose) {
+            if (!silent) {
                 console.table(table.toString());
                 console.log();
             }

--- a/internal/serve/lib/cli.js
+++ b/internal/serve/lib/cli.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console -- expected to log */
-const { serve } = require("./serve");
 const Table = require("cli-table");
+const { serve } = require("./serve");
 
 const defaultPort = 8080;
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prettier:check": "prettier --check .",
     "prettier:write": "prettier --write .",
     "sandbox": "npm run --workspace internal/vue-sandbox --",
-    "start": "fkui-serve public",
+    "start": "fkui-serve public temp/docs",
     "start:cypress": "node cypress/server.js",
     "start:demo": "run-s build:docs start",
     "start:sandbox": "run-s build:docs && fkui-serve public/vue-sandbox",


### PR DESCRIPTION
Ändrar så servern som hostar dokumentationen och kör E2E tester är mindre pratig by default.

* Kör man bara `npm start` eller `fkui-serve` så visas bara fel (HTTP 4xx och 5xx).
* Kör man `npm start -- --verbose` eller `fkui-serve --verbose` så visas allt som tidigare, dvs alla requests inkl HTTP 200 och 304.
* Finns också `--silent` för att tysta den helt.

Tror inte det är vanligt att man behöver använda någon utav flaggorna men de finns där iaf.