### PR TITLE
docs: fix invalid attribute (refs SFKUI-6500)

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -2,7 +2,7 @@
 title: Tillgänglighets&shy;redogörelse
 name: accessibility
 layout: pattern
-hidden: true
+visible: false
 ---
 
 ## Tillgänglighet för webbplats


### PR DESCRIPTION
Nästkommande version av `@forsakringskassan/docs-generator` kommer falera byggen som använder okända attribut:

```
Unknown attribute "hidden" in "docs/accessibility.md"
  3 | name: accessibility
  4 | layout: pattern
> 5 | hidden: true
    | ^^^^^^ Did you mean to use "visible"?
  6 | ---
  7 |
  8 | ## Tillgänglighet för webbplats
```