### PR TITLE
feat!: change default `buttonOrder` to `RIGHT_TO_LEFT` (refs SFKUI-6500)

### DIFF
--- a/docs/functions/config.md
+++ b/docs/functions/config.md
@@ -18,14 +18,14 @@ Görs lämpligtvis i applikationens `main.ts`.
 ```js
 import { config, FKUIConfigButtonOrder } from "@fkui/vue";
 
-config.buttonOrder = FKUIConfigButtonOrder.RIGHT_TO_LEFT;
+config.buttonOrder = FKUIConfigButtonOrder.LEFT_TO_RIGHT;
 ```
 
 ## Referens
 
 ### `buttonOrder`
 
-- default: `LEFT_TO_RIGHT`
+- default: `RIGHT_TO_LEFT`
 - type: `FKUIConfigButtonOrder`
 
 Anger i vilken ordning man vill visa knappar.

--- a/docs/gettingstarted/migration/migrating-to-v6.md
+++ b/docs/gettingstarted/migration/migrating-to-v6.md
@@ -46,7 +46,11 @@ Följande komponenter, funktioner och typer är även de borttagna:
 - `FPageHeader`: propen `skipLinkHref` är borttagen
 - `FTextField`: `update` eventet emittas inte längre.
 - `getTextFromScopedSlot`: funktionen är borttagen.
-- Konfiguration: `FKUIConfig.modalTarget` och `FKUIConfig.popupTarget` är borttagna.
+
+Ändringar i konfiguration:
+
+- `FKUIConfig.modalTarget` och `FKUIConfig.popupTarget` är borttagna.
+- `FKUIConfig.buttonOrder` byter standardvärde till `RIGHT_TO_LEFT`.
 
 För Cypress pageobjekt:
 

--- a/packages/vue/src/components/FModal/FFormModal/FFormModal.vue
+++ b/packages/vue/src/components/FModal/FFormModal/FFormModal.vue
@@ -183,7 +183,7 @@ export default defineComponent({
     },
     computed: {
         preparedButtons(): FModalButton[] {
-            return prepareButtonList(this.buttons, FKUIConfigButtonOrder.LEFT_TO_RIGHT);
+            return prepareButtonList(this.buttons, FKUIConfigButtonOrder.RIGHT_TO_LEFT);
         },
     },
     methods: {

--- a/packages/vue/src/config/config.ts
+++ b/packages/vue/src/config/config.ts
@@ -8,7 +8,7 @@ let production = true;
  * @public
  */
 export const config: FKUIConfig = {
-    buttonOrder: FKUIConfigButtonOrder.LEFT_TO_RIGHT,
+    buttonOrder: FKUIConfigButtonOrder.RIGHT_TO_LEFT,
     teleportTarget: document.body,
 
     get popupContainer(): HTMLElement {


### PR DESCRIPTION
BREAKING CHANGE: default `buttonOrder` is now `RIGHT_TO_LEFT`.