### PR TITLE
feat: entrypoint always uses full width (refs SB-4982)

### DIFF
--- a/docs/components/links/entrypoint.md
+++ b/docs/components/links/entrypoint.md
@@ -9,7 +9,7 @@ component:
 
 Startpunkt används för att framhäva en länk extra tydligt, som till exempel en ingång till en digital tjänst.
 
-Startpunkten tar upp 2/3 av tillgänglig yta i desktopläge och 100% i mobilt läge.
+Startpunkten tar alltid upp 100% tillgänglig yta.
 
 ```import live-example
 EntrypointLiveExample.vue
@@ -22,7 +22,3 @@ Texten på en startpunkt ska vara begriplig utan någon annan kontext, men håll
 Bra texter på startpunkter är t.ex. "Ansök om VAB" och "Ansök om sjukpenning".
 
 En startpunkt ska alltid ha en skärmläsartext som ska förtydliga att startpunkten leder till en tjänst och inte är en vanlig länk. Exempel som motsvarar texterna ovan är "Till tjänsten ansök om vab" och "Till tjänsten ansök om sjukpenning".
-
-## Fullbredd
-
-Vill du styra bredden med hjälp av gridsystemet använd klassen `entrypoint--full-width`.

--- a/docs/gettingstarted/migration/migrating-to-v6/design.md
+++ b/docs/gettingstarted/migration/migrating-to-v6/design.md
@@ -45,3 +45,15 @@ Klasserna är ersatta med `modal__dialog-container--large` respektive `modal__di
 -<div class="modal__dialog-container modal__dialog-container-large">
 +<div class="modal__dialog-container modal__dialog-container--large">
 ```
+
+## Entrypoint tar alltid upp 100% yta
+
+Tidigare tog komponenten enbart upp 66% bredd i desktop, om du vill återskapa det beteendet kan du exempelvis nyttja grid'en:
+
+```diff
++ <div class="row">
++    <div class="col col--md-8">
+        <a class="entrypoint" href="javascript:">...</a>
++    </div>
++ </div>
+```

--- a/packages/design/src/components/entrypoint/_entrypoint.scss
+++ b/packages/design/src/components/entrypoint/_entrypoint.scss
@@ -13,15 +13,7 @@ $ENTRYPOINT_SELECTOR: ".entrypoint" !default;
         text-align: left;
         padding: size.$padding-100 calc(size.$padding-200 * 2) size.$padding-100 size.$padding-100;
         line-height: var(--f-line-height-large);
-        width: 66.667%;
-    }
-
-    @include mixins.breakpoint-down(sm) {
-        min-width: 100%;
-    }
-
-    &--full-width {
-        min-width: 100%;
+        width: 100%;
     }
 
     &__icon {

--- a/packages/vue/src/design-component-tests/entrypoint/examples/EntrypointLiveExample.vue
+++ b/packages/vue/src/design-component-tests/entrypoint/examples/EntrypointLiveExample.vue
@@ -1,32 +1,23 @@
 <template>
-    <live-example :components="components" :template="template">
-        <f-checkbox-field v-model="isFullWidth" :value="true"> Fullbredd </f-checkbox-field>
-    </live-example>
+    <live-example :components="components" :template="template"> </live-example>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import { FCheckboxField, FIcon } from "@fkui/vue";
+import { FIcon } from "@fkui/vue";
 import { LiveExample } from "@forsakringskassan/docs-live-example";
 
 export default defineComponent({
     name: "EntrypointLiveExample",
-    components: { LiveExample, FCheckboxField },
-    data() {
-        return {
-            isFullWidth: false,
-        };
-    },
+    components: { LiveExample },
     computed: {
         components(): object {
             return { FIcon };
         },
-        fullwidth(): string {
-            return this.isFullWidth ? "entrypoint--full-width" : "";
-        },
+
         template(): string {
             return /* HTML */ `
-                <a class="entrypoint ${this.fullwidth}" href="javascript:">
+                <a class="entrypoint" href="javascript:">
                     Ansök om hundbidrag
                     <span class="sr-only"> Till tjänsten ansök om hundbidrag</span>
                     <f-icon name="arrow-right" class="entrypoint__icon"></f-icon>


### PR DESCRIPTION
BREAKING CHANGE: Consumers of this component need to define their disered width.