### PR TITLE
chore: in sandbox devmode detect internal package updates

### DIFF
--- a/internal/vue-sandbox/src/local.scss
+++ b/internal/vue-sandbox/src/local.scss
@@ -1,0 +1,3 @@
+@use "@fkui/theme-default";
+@use "@fkui/design";
+@use "@fkui/design/lib/fonts.css";

--- a/internal/vue-sandbox/src/local.ts
+++ b/internal/vue-sandbox/src/local.ts
@@ -1,5 +1,2 @@
-import "@fkui/theme-default";
-import "@fkui/design";
-import "@fkui/design/lib/fonts.css";
-
+import "./local.scss";
 import "./main";

--- a/internal/vue-sandbox/vite.config.ts
+++ b/internal/vue-sandbox/vite.config.ts
@@ -10,12 +10,4 @@ export default defineConfig({
     build: {
         minify: false,
     },
-    optimizeDeps: {
-        /**
-         * Vite treats monorepo packages as sourcecode and performs no prebundling by default.
-         * See https://vitejs.dev/guide/dep-pre-bundling.html#monorepos-and-linked-dependencies
-         */
-        include: ["@fkui/date", "@fkui/logic", "@fkui/vue"],
-        force: false,
-    },
 });

--- a/packages/vue-labs/src/local.scss
+++ b/packages/vue-labs/src/local.scss
@@ -1,0 +1,3 @@
+@use "@fkui/theme-default";
+@use "@fkui/design";
+@use "@fkui/design/lib/fonts.css";

--- a/packages/vue-labs/src/local.ts
+++ b/packages/vue-labs/src/local.ts
@@ -1,10 +1,7 @@
 import { createApp } from "vue";
 import { type SetupOptions } from "@forsakringskassan/vite-lib-config";
-
 import "@fkui/icon-lib-default/dist/f";
-import "@fkui/theme-default/dist/fkui-css-variables.css";
-import "@fkui/design/lib/fkui.css";
-import "@fkui/design/lib/fonts.css";
+import "./local.scss";
 
 import {
     setRunningContext,

--- a/packages/vue/src/local.scss
+++ b/packages/vue/src/local.scss
@@ -1,0 +1,3 @@
+@use "@fkui/theme-default";
+@use "@fkui/design";
+@use "@fkui/design/lib/fonts.css";

--- a/packages/vue/src/local.ts
+++ b/packages/vue/src/local.ts
@@ -2,9 +2,7 @@ import { createApp } from "vue";
 import { type SetupOptions } from "@forsakringskassan/vite-lib-config";
 
 import "@fkui/icon-lib-default/dist/f";
-import "@fkui/theme-default/dist/fkui-css-variables.css";
-import "@fkui/design/src/fkui.scss";
-import "@fkui/design/lib/fonts.css";
+import "./local.scss";
 
 import { TestPlugin, TranslationPlugin, ValidationPlugin } from "./plugins";
 import { setRunningContext } from "./config";


### PR DESCRIPTION
This issue arised when upgrading to Vite6.
The solution is to not configure any prebundle optimization.
Vite detects internal packages and since they are esm packages nothing more is required.