### PR TITLE
optional `keyAttribute`

### DIFF
--- a/docs/components/table-and-list/FList.md
+++ b/docs/components/table-and-list/FList.md
@@ -12,6 +12,27 @@ Lista används när användaren behöver gå igenom ett antal poster för att hi
 FListLiveExample.vue
 ```
 
+## Ange nyckel (`keyAttribute`)
+
+Med `keyAttribute` så kan du ange namnet för en nyckel (`key`) som finns i varje list-ojekt och innehåller ett värde som kan användas för att identifiera olika objekt.
+Om detta anges, så måste varje objekt innehålla denna nyckel med ett unikt värde.
+
+Att använda `keyAttribute` är valfritt och behövs inte anges om du inte har nåt naturligt id att ange för dina objekt.
+Men om det är tänkt att objekten ska laddas om från REST-api eller liknande så måste du använda `keyAttribute` för att aktuell status för dina objekt ska kunna bibehållas.
+
+```diff
+-<f-list :items="myitems">
++<f-list :items="myitems" key-attribute="id">
+```
+
+```js
+// The key "id" is used for "keyAttribute".
+const myItems = ref([
+    { id: "a", name: "Banan" },
+    { id: "b", name: "Äpple" },
+]);
+```
+
 ## Användning av komponent
 
 **Komponent motsvarar följande HTML element:** [Unordered List](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul)

--- a/docs/components/table-and-list/table.md
+++ b/docs/components/table-and-list/table.md
@@ -48,6 +48,36 @@ FInteractiveTableInputExample.vue
 
 Även dropplista har stöd för att användas i tabellcell. I de fall en obligatorisk dropplista lämnas tom visas samma text som platshållartexten tillsammas med ikon och röd ram.
 
+### Välja rader
+
+En interaktiv tabell med `selectable` prop lägger till kryssrutor som kan användas för att välja rader.
+När en rad väljs uppdateras `v-model` med referens till alla rader som är valda.
+
+```diff
+-<f-interactive-table :rows="myRows">
+ <f-interactive-table
++   v-model="selectedRows"
+    :rows="myRows"
++   selectable
+ >
+```
+
+Du kan även lägga till eller ta bort valda rader genom att ändra referenserna som skickas till `v-model`.
+På så sätt kan du till exempel förvälja vissa rader eller skapa bulk-åtgärder som väljer vissa typer av rader.
+Notera att `v-model` kräver referenser till objekt som du skickat till `rows` prop för att kunna välja dessa.
+
+```js
+const rows = ref([
+    { name: "Banan", type: "Frukt" },
+    { name: "Äpple", type: "Frukt" },
+    { name: "Vitkål", type: "Grönsak" },
+    { name: "Spenat", type: "Grönsak" },
+]);
+
+// Preselect all rows that are fruit type.
+const selectedRows = ref(rows.value.filter((row) => row.type === "Frukt"));
+```
+
 ### Expanderbara rader
 
 Med expanderbara rader går det att skapa ytterligare tabellrader som visas när man trycker på en expanderbar rad.

--- a/docs/components/table-and-list/table.md
+++ b/docs/components/table-and-list/table.md
@@ -126,6 +126,27 @@ För att istället skapa expanderbara rader med valfritt innehåll används `exp
 
 Observera att det inte är rekommenderat att skapa för komplext expanderat innehåll, så som att placera ytterligare expanderbara tabeller inuti.
 
+## Ange nyckel (`keyAttribute`)
+
+Med `keyAttribute` så kan du ange namnet för en nyckel (`key`) som finns i varje rad-ojekt och innehåller ett värde som kan användas för att identifiera olika rader.
+Om detta anges, så måste varje rad (även expanderade rader) innehålla denna nyckel med ett unikt värde.
+
+Att använda `keyAttribute` är valfritt och behövs inte anges om du inte har nåt naturligt id att ange för dina rader.
+Men om det är tänkt att dina rader ska laddas om från REST-api eller liknande så måste du använda `keyAttribute` för att aktuell status för raderna ska kunna bibehållas.
+
+```diff
+-<f-interactive-table :rows="myRows">
++<f-interactive-table :rows="myRows" key-attribute="id">
+```
+
+```js
+// The key "id" is used for "keyAttribute".
+const myRows = ref([
+    { id: "a", name: "Banan" },
+    { id: "b", name: "Äpple" },
+]);
+```
+
 ## Tabellrubrik
 
 En tabell ska alltid ha en rubrik, antingen med caption-elementet eller en associerad heading.

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -7053,6 +7053,7 @@ export const FList: <T extends object>(__VLS_props: NonNullable<Awaited<typeof _
         elementId: string;
         modelValue: T[] | undefined;
         checkbox: boolean;
+        keyAttribute: string;
         selectable: boolean;
         active: [{
             type: PropType<T | undefined>;
@@ -7067,9 +7068,9 @@ export const FList: <T extends object>(__VLS_props: NonNullable<Awaited<typeof _
         readonly elementId: string;
         readonly items: T[];
         readonly checkbox: boolean;
-        readonly keyAttribute: string;
         readonly selectable: boolean;
         readonly modelValue?: T[] | undefined;
+        readonly keyAttribute?: string | undefined;
         readonly active?: ([{
             type: PropType<T | undefined>;
             required: false;
@@ -7085,7 +7086,7 @@ export const FList: <T extends object>(__VLS_props: NonNullable<Awaited<typeof _
         readonly "onUpdate:modelValue"?: ((item: T[]) => any) | undefined;
         readonly onUnselect?: ((item: T) => any) | undefined;
         readonly "onUpdate:active"?: ((item: T) => any) | undefined;
-    } & VNodeProps & AllowedComponentProps & ComponentCustomProps, "elementId" | "modelValue" | "checkbox" | "selectable" | "active">, "onChange" | "onClick" | "onSelect" | "items" | "onUpdate:modelValue" | "keyAttribute" | "onUnselect" | "onUpdate:active" | ("elementId" | "modelValue" | "checkbox" | "selectable" | "active")> & {} & Partial<{}>> & PublicProps;
+    } & VNodeProps & AllowedComponentProps & ComponentCustomProps, "elementId" | "modelValue" | "checkbox" | "keyAttribute" | "selectable" | "active">, "onChange" | "onClick" | "onSelect" | "items" | "onUpdate:modelValue" | "onUnselect" | "onUpdate:active" | ("elementId" | "modelValue" | "checkbox" | "keyAttribute" | "selectable" | "active")> & {} & Partial<{}>> & PublicProps;
     expose(exposed: ShallowUnwrapRef<    {}>): void;
     attrs: any;
     slots: {

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -3385,13 +3385,14 @@ parser: ParseFunction<number>;
 export const FDataTable: <T extends object>(__VLS_props: NonNullable<Awaited<typeof __VLS_setup>>["props"], __VLS_ctx?: __VLS_PrettifyLocal_2<Pick<NonNullable<Awaited<typeof __VLS_setup>>, "attrs" | "emit" | "slots">>, __VLS_expose?: NonNullable<Awaited<typeof __VLS_setup>>["expose"], __VLS_setup?: Promise<{
     props: __VLS_PrettifyLocal_2<Pick<Partial<{
         scroll: TableScroll;
+        keyAttribute: string;
         striped: boolean;
     }> & Omit<{
         readonly scroll: TableScroll;
         readonly rows: T[];
-        readonly keyAttribute: string;
         readonly striped: boolean;
-    } & VNodeProps & AllowedComponentProps & ComponentCustomProps, "scroll" | "striped">, "rows" | "keyAttribute" | ("scroll" | "striped")> & {} & Partial<{}>> & PublicProps;
+        readonly keyAttribute?: string | undefined;
+    } & VNodeProps & AllowedComponentProps & ComponentCustomProps, "scroll" | "keyAttribute" | "striped">, "rows" | ("scroll" | "keyAttribute" | "striped")> & {} & Partial<{}>> & PublicProps;
     expose(exposed: ShallowUnwrapRef<    {}>): void;
     attrs: any;
     slots: {

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -6650,6 +6650,7 @@ export const FInteractiveTable: <T extends object, K extends keyof T>(__VLS_prop
     props: __VLS_PrettifyLocal_3<Pick<Partial<{
         scroll: TableScroll;
         modelValue: T[] | undefined;
+        keyAttribute: string;
         striped: boolean;
         hover: boolean;
         expandableAttribute: string;
@@ -6668,7 +6669,6 @@ export const FInteractiveTable: <T extends object, K extends keyof T>(__VLS_prop
     }> & Omit<{
         readonly scroll: TableScroll;
         readonly rows: T[];
-        readonly keyAttribute: string;
         readonly striped: boolean;
         readonly hover: boolean;
         readonly expandableAttribute: string;
@@ -6676,6 +6676,7 @@ export const FInteractiveTable: <T extends object, K extends keyof T>(__VLS_prop
         readonly selectable: boolean;
         readonly showActive: boolean;
         readonly modelValue?: T[] | undefined;
+        readonly keyAttribute?: string | undefined;
         readonly active?: ([{
             type: PropType<T | undefined>;
             required: false;
@@ -6693,7 +6694,7 @@ export const FInteractiveTable: <T extends object, K extends keyof T>(__VLS_prop
         readonly onExpand?: ((row: T) => any) | undefined;
         readonly onUnselect?: ((row: T) => any) | undefined;
         readonly "onUpdate:active"?: ((row: T) => any) | undefined;
-    } & VNodeProps & AllowedComponentProps & ComponentCustomProps, "scroll" | "modelValue" | "striped" | "hover" | "expandableAttribute" | "expandableDescribedby" | "selectable" | "showActive" | "active">, "onChange" | "onClick" | "onSelect" | "onUpdate:modelValue" | "rows" | "keyAttribute" | "onCollapse" | "onExpand" | "onUnselect" | "onUpdate:active" | ("scroll" | "modelValue" | "striped" | "hover" | "expandableAttribute" | "expandableDescribedby" | "selectable" | "showActive" | "active")> & {} & Partial<{}>> & PublicProps;
+    } & VNodeProps & AllowedComponentProps & ComponentCustomProps, "scroll" | "modelValue" | "keyAttribute" | "striped" | "hover" | "expandableAttribute" | "expandableDescribedby" | "selectable" | "showActive" | "active">, "onChange" | "onClick" | "onSelect" | "onUpdate:modelValue" | "rows" | "onCollapse" | "onExpand" | "onUnselect" | "onUpdate:active" | ("scroll" | "modelValue" | "keyAttribute" | "striped" | "hover" | "expandableAttribute" | "expandableDescribedby" | "selectable" | "showActive" | "active")> & {} & Partial<{}>> & PublicProps;
     expose(exposed: ShallowUnwrapRef<    {}>): void;
     attrs: any;
     slots: {

--- a/packages/vue/htmlvalidate/elements/components.js
+++ b/packages/vue/htmlvalidate/elements/components.js
@@ -376,7 +376,7 @@ module.exports = defineMetadata({
             "expandable-describedby": ["/.+/"],
             scroll: ["horizontal", "vertical", "both", "none"],
         },
-        requiredAttributes: ["key-attribute", "rows"],
+        requiredAttributes: ["rows"],
         slots: [
             "default",
             "caption",

--- a/packages/vue/htmlvalidate/elements/components.js
+++ b/packages/vue/htmlvalidate/elements/components.js
@@ -125,7 +125,7 @@ module.exports = defineMetadata({
             "key-attribute": ["/.+/"],
             scroll: ["horizontal", "vertical", "both", "none"],
         },
-        requiredAttributes: ["key-attribute", "rows"],
+        requiredAttributes: ["rows"],
         slots: ["default", "caption", "empty"],
         requiredSlots: ["default", "caption"],
     },

--- a/packages/vue/htmlvalidate/elements/components.js
+++ b/packages/vue/htmlvalidate/elements/components.js
@@ -321,7 +321,7 @@ module.exports = defineMetadata({
         inherit: "ul",
         flow: true,
         phrasing: true,
-        requiredAttributes: ["items", "key-attribute"],
+        requiredAttributes: ["items"],
         attributes: {
             selectable: ["/^[a-zA-Z][\\w\\d-_.:]+$/", "", "false", "true"],
             value: ["/.*/"],

--- a/packages/vue/src/components/FDataTable/FDataTable.spec.ts
+++ b/packages/vue/src/components/FDataTable/FDataTable.spec.ts
@@ -411,13 +411,51 @@ it("should call provided sort method when clicking columnheader that is registra
     `);
 });
 
+describe("`keyAttribute`", () => {
+    it("should not throw if valid and unique", async () => {
+        expect.assertions(1);
+
+        expect(() => {
+            mount(FDataTable, {
+                props: {
+                    keyAttribute: "id",
+                    rows: [{ id: "a" }, { id: "b" }, { id: "c" }],
+                },
+            });
+        }).not.toThrow();
+    });
+
+    it("should throw error if not unique in items", async () => {
+        expect.assertions(1);
+
+        expect(() => {
+            mount(FDataTable, {
+                props: {
+                    keyAttribute: "id",
+                    rows: [{ id: "a" }, { id: "b" }, { id: "b" }],
+                },
+            });
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"Expected each item to have key [id] with unique value but encountered duplicate of "b" in item index 2."`,
+        );
+    });
+
+    it("should be optional", async () => {
+        expect.assertions(1);
+
+        expect(() => {
+            mount(FDataTable, {
+                props: {
+                    rows: [{ id: "a" }, { id: "b" }, { id: "c" }],
+                },
+            });
+        }).not.toThrow();
+    });
+});
+
 describe("html-validate", () => {
-    it("should require non-empty key-attribute attribute", () => {
-        expect.assertions(2);
-        expect("<f-data-table></f-data-table>").not.toHTMLValidate({
-            message:
-                '<f-data-table> is missing required "key-attribute" attribute',
-        });
+    it("should require `key-attribute` to be non-empty if used", () => {
+        expect.assertions(1);
         expect(
             '<f-data-table key-attribute=""></f-data-table>',
         ).not.toHTMLValidate({

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.spec.ts
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.spec.ts
@@ -684,6 +684,10 @@ it("should add an extra column when selectable is enabled", async () => {
 
 it("should mark initial rows as selected", async () => {
     expect.assertions(2);
+
+    const rows = [{ id: 1 }, { id: 2 }];
+    const selected = [rows[0]];
+
     const TestComponent = {
         components: { FInteractiveTable, FTableColumn },
         template: /* HTML */ `
@@ -696,8 +700,8 @@ it("should mark initial rows as selected", async () => {
         `,
         data() {
             return {
-                rows: [{ id: 1 }, { id: 2 }],
-                selected: [{ id: 1 }],
+                rows,
+                selected,
             };
         },
     };
@@ -707,9 +711,9 @@ it("should mark initial rows as selected", async () => {
         },
     });
     await wrapper.vm.$nextTick();
-    const rows = wrapper.findAll("tbody tr");
-    expect(rows[0].classes()).toContain("table__row--selected");
-    expect(rows[1].classes()).not.toContain("table__row--selected");
+    const allRows = wrapper.findAll("tbody tr");
+    expect(allRows[0].classes()).toContain("table__row--selected");
+    expect(allRows[1].classes()).not.toContain("table__row--selected");
 });
 
 it("should set row-description as aria-label", async () => {
@@ -1013,15 +1017,51 @@ describe("Expandable rows", () => {
     });
 });
 
+describe("`keyAttribute`", () => {
+    it("should not throw if valid and unique", async () => {
+        expect.assertions(1);
+
+        expect(() => {
+            mount(FInteractiveTable, {
+                props: {
+                    keyAttribute: "id",
+                    rows: [{ id: "a" }, { id: "b" }, { id: "c" }],
+                },
+            });
+        }).not.toThrow();
+    });
+
+    it("should throw error if not unique in items", async () => {
+        expect.assertions(1);
+
+        expect(() => {
+            mount(FInteractiveTable, {
+                props: {
+                    keyAttribute: "id",
+                    rows: [{ id: "a" }, { id: "b" }, { id: "b" }],
+                },
+            });
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"Expected each item to have key [id] with unique value but encountered duplicate of "b" in item index 2."`,
+        );
+    });
+
+    it("should be optional", async () => {
+        expect.assertions(1);
+
+        expect(() => {
+            mount(FInteractiveTable, {
+                props: {
+                    rows: [{ id: "a" }, { id: "b" }, { id: "c" }],
+                },
+            });
+        }).not.toThrow();
+    });
+});
+
 describe("html-validate", () => {
-    it("should require non-empty key-attribute attribute", () => {
-        expect.assertions(2);
-        expect(
-            "<f-interactive-table></f-interactive-table>",
-        ).not.toHTMLValidate({
-            message:
-                '<f-interactive-table> is missing required "key-attribute" attribute',
-        });
+    it("should require `key-attribute` to be non-empty if used", () => {
+        expect.assertions(1);
         expect(
             '<f-interactive-table key-attribute=""></f-interactive-table>',
         ).not.toHTMLValidate({

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
@@ -124,7 +124,8 @@ const props = defineProps({
         },
     },
     /**
-     * V-model will bind to value containing selected rows.
+     * Currently selected rows.
+     * Requires `selectable` to be set.
      */
     modelValue: {
         type: Array as PropType<T[] | undefined>,

--- a/packages/vue/src/components/FInteractiveTable/useExpandableTable.ts
+++ b/packages/vue/src/components/FInteractiveTable/useExpandableTable.ts
@@ -24,7 +24,7 @@ type Emit<T> = ((evt: "expand", row: T) => void) &
  */
 export function useExpandableTable<T extends object>(
     expandableAttribute: string,
-    keyAttribute: string,
+    keyAttribute: keyof T,
     describedby: string | undefined,
     emit: Emit<T>,
     slots: Slots,
@@ -42,7 +42,7 @@ export function useExpandableTable<T extends object>(
     function toggleExpanded(row: T): void {
         if (isExpanded(row)) {
             expandedRows.value = expandedRows.value.filter(
-                (it) => !itemEquals(it, row, keyAttribute as keyof T),
+                (it) => !itemEquals(it, row, keyAttribute),
             );
             emit("collapse", row);
         } else {
@@ -52,7 +52,7 @@ export function useExpandableTable<T extends object>(
     }
 
     function isExpanded(row: T): boolean {
-        return includeItem(row, expandedRows.value, keyAttribute as keyof T);
+        return includeItem(row, expandedRows.value, keyAttribute);
     }
 
     function rowAriaExpanded(row: T): boolean | undefined {

--- a/packages/vue/src/components/FList/FList.spec.ts
+++ b/packages/vue/src/components/FList/FList.spec.ts
@@ -328,7 +328,7 @@ describe("select events", () => {
 });
 
 describe("v-model (update event)", () => {
-    it("should upate v-model when selecting and unselecting same item", async () => {
+    it("should update v-model when selecting and unselecting same item", async () => {
         const modelValue: ListArray = [];
         const wrapper = createWrapper({
             props: {
@@ -357,7 +357,7 @@ describe("v-model (update event)", () => {
         ).toMatchInlineSnapshot(`[]`);
     });
 
-    it("should upate v-model when selecting two different items", async () => {
+    it("should update v-model when selecting two different items", async () => {
         const modelValue: ListArray = [];
         const wrapper = createWrapper({
             props: {
@@ -393,7 +393,7 @@ describe("v-model (update event)", () => {
         ]);
     });
 
-    it("should upate v-model when selecting and unselecting two items", async () => {
+    it("should update v-model when selecting and unselecting two items", async () => {
         const modelValue: ListArray = [];
         const wrapper = createWrapper({
             props: {
@@ -451,7 +451,7 @@ describe("v-model (update event)", () => {
         expect(allInputs[2].checked).toBeTruthy();
     });
 
-    it("should upate activeItem from v-model if provided or changed", async () => {
+    it("should update activeItem from v-model if provided or changed", async () => {
         const active = items[1];
         const wrapper = createWrapper({
             props: {
@@ -472,6 +472,63 @@ describe("v-model (update event)", () => {
         expect(Array.from(liItems[2].element.classList.values())).toContain(
             "list__item--active",
         );
+    });
+
+    it("should be able to preselect items", () => {
+        const wrapper = createWrapper({
+            props: {
+                items,
+                selectable: true,
+                modelValue: [items[0], items[2]],
+            },
+        });
+
+        const allInputs = wrapper.element.querySelectorAll("input");
+        expect(allInputs[0].checked).toBeTruthy();
+        expect(allInputs[1].checked).toBeFalsy();
+        expect(allInputs[2].checked).toBeTruthy();
+    });
+});
+
+describe("`keyAttribute`", () => {
+    it("should not throw if valid and unique", async () => {
+        expect.assertions(1);
+
+        expect(() => {
+            mount(FList, {
+                props: {
+                    keyAttribute: "id",
+                    items: [{ id: "a" }, { id: "b" }, { id: "c" }],
+                },
+            });
+        }).not.toThrow();
+    });
+
+    it("should throw error if not unique in items", async () => {
+        expect.assertions(1);
+
+        expect(() => {
+            mount(FList, {
+                props: {
+                    keyAttribute: "id",
+                    items: [{ id: "a" }, { id: "b" }, { id: "b" }],
+                },
+            });
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"Expected each item to have key [id] with unique value but encountered duplicate of "b" in item index 2."`,
+        );
+    });
+
+    it("should be optional", async () => {
+        expect.assertions(1);
+
+        expect(() => {
+            mount(FList, {
+                props: {
+                    items: [{ id: "a" }, { id: "b" }, { id: "c" }],
+                },
+            });
+        }).not.toThrow();
     });
 });
 
@@ -527,11 +584,8 @@ describe("screenreader slot", () => {
 });
 
 describe("html-validate", () => {
-    it("should require non-empty key-attribute attribute", () => {
-        expect.assertions(2);
-        expect("<f-list></f-list>").not.toHTMLValidate({
-            message: '<f-list> is missing required "key-attribute" attribute',
-        });
+    it("should require `key-attribute` to be non-empty if used", () => {
+        expect.assertions(1);
         expect('<f-list key-attribute=""></f-list>').not.toHTMLValidate({
             message: 'Attribute "key-attribute" has invalid value ""',
         });

--- a/packages/vue/src/utils/internal-key.spec.ts
+++ b/packages/vue/src/utils/internal-key.spec.ts
@@ -1,0 +1,164 @@
+import {
+    setInternalKey,
+    setInternalKeys,
+    getInternalKey,
+} from "./internal-key";
+
+describe("`internalKey`", () => {
+    it("should not be enumerable", () => {
+        expect.assertions(1);
+
+        const item = {
+            name: "foo",
+        };
+        setInternalKey(item);
+
+        expect(Object.keys(item)).toMatchInlineSnapshot(`
+            [
+              "name",
+            ]
+        `);
+    });
+});
+
+describe("`setInternalKey`", () => {
+    it("should set provided value for `internalKey` on item", () => {
+        expect.assertions(2);
+
+        const internalKey = getInternalKey();
+        const items = [
+            { id: "a", name: "foo" },
+            { id: "b", name: "bar" },
+        ];
+        for (const item of items) {
+            setInternalKey(item, item.id);
+        }
+
+        expect(items[0][internalKey]).toBe("a");
+        expect(items[1][internalKey]).toBe("b");
+    });
+
+    it("should set `internalKey` on item if value not provided", () => {
+        expect.assertions(2);
+
+        const internalKey = getInternalKey();
+        const items = [{ name: "foo" }, { name: "bar" }];
+        for (const item of items) {
+            setInternalKey(item);
+        }
+
+        expect(items[0]).toHaveProperty([internalKey]);
+        expect(items[1]).toHaveProperty([internalKey]);
+    });
+});
+
+describe("`setInternalKeys`", () => {
+    it("should set value of provided `key` on all items", () => {
+        expect.assertions(2);
+
+        const internalKey = getInternalKey();
+        const items = [
+            { id: "a", name: "foo" },
+            { id: "b", name: "bar" },
+        ];
+        setInternalKeys(items, "id");
+
+        expect(items[0][internalKey]).toBe("a");
+        expect(items[1][internalKey]).toBe("b");
+    });
+
+    it("should set `internalKey` on all items if `key` not provided", () => {
+        expect.assertions(2);
+
+        const internalKey = getInternalKey();
+        const items = [{ name: "foo" }, { name: "bar" }];
+        setInternalKeys(items);
+
+        expect(items[0]).toHaveProperty([internalKey]);
+        expect(items[1]).toHaveProperty([internalKey]);
+    });
+
+    it("should set value of `key` on nested items if `nestedKey` is provided", () => {
+        expect.assertions(2);
+
+        const internalKey = getInternalKey();
+        const items = [{ id: "1", nested: [{ id: "1a" }, { id: "1b" }] }];
+        const nestedItems = items[0].nested;
+        setInternalKeys(items, "id", "nested");
+
+        expect(nestedItems[0][internalKey]).toBe("1a");
+        expect(nestedItems[1][internalKey]).toBe("1b");
+    });
+
+    it("should set `internalKey` on nested items if `key` not provided", () => {
+        expect.assertions(2);
+
+        const internalKey = getInternalKey();
+        const items = [
+            { name: "foo", nested: [{ name: "bar" }, { name: "baz" }] },
+        ];
+        const nestedItems = items[0].nested;
+        setInternalKeys(items, undefined, "nested");
+
+        expect(nestedItems[0]).toHaveProperty([internalKey]);
+        expect(nestedItems[1]).toHaveProperty([internalKey]);
+    });
+
+    it("should throw error if value of `key` in item is not unique", () => {
+        expect.assertions(1);
+
+        const items = [{ id: "a" }, { id: "b" }, { id: "b" }];
+
+        expect(() => {
+            setInternalKeys(items, "id");
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"Expected each item to have key [id] with unique value but encountered duplicate of "b" in item index 2."`,
+        );
+    });
+
+    it("should throw error if item is missing `key` property", () => {
+        expect.assertions(1);
+
+        const items = [{ id: "a" }, { id: "b" }, { name: "foo" }];
+
+        expect(() => {
+            setInternalKeys(items, "id");
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"Key [id] is missing or has invalid value in item index 2"`,
+        );
+    });
+
+    it("should throw error if value of `key` is invalid in item", () => {
+        expect.assertions(2);
+
+        const itemsEmpty = [{ id: "a" }, { id: "b" }, { id: "" }];
+        const itemsNull = [{ id: "a" }, { id: "b" }, { id: null }];
+
+        expect(() => {
+            setInternalKeys(itemsEmpty, "id");
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"Key [id] is missing or has invalid value in item index 2"`,
+        );
+        expect(() => {
+            setInternalKeys(itemsNull, "id");
+        }).toThrowErrorMatchingInlineSnapshot(
+            `"Key [id] is missing or has invalid value in item index 2"`,
+        );
+    });
+
+    it("should not throw error if `key` is not provided", () => {
+        expect.assertions(1);
+
+        const items = [
+            { id: "a" },
+            { id: "a" },
+            { id: "" },
+            { id: null },
+            { name: "b" },
+        ];
+
+        expect(() => {
+            setInternalKeys(items);
+        }).not.toThrow();
+    });
+});

--- a/packages/vue/src/utils/internal-key.ts
+++ b/packages/vue/src/utils/internal-key.ts
@@ -1,0 +1,77 @@
+/** @internal */
+export const internalKey = Symbol("internal-key");
+let internalIndex = 0;
+
+/** @internal */
+export function getInternalKey<T>(): keyof T {
+    return internalKey as keyof T;
+}
+
+/** @internal */
+export function setInternalKey<T extends object>(
+    item: T,
+    value?: string,
+): void {
+    if (item[internalKey as keyof T]) {
+        return;
+    }
+
+    Object.defineProperty(item, internalKey, {
+        value: value ?? String(internalIndex++),
+        enumerable: false,
+        writable: true,
+    });
+}
+
+/** @internal */
+export function setInternalKeys<T extends object>(
+    items: T[],
+    key?: keyof T,
+    nestedKey?: keyof T,
+    seenValues = new Set<unknown>(),
+): T[] {
+    if (key === undefined) {
+        return items.map((item) => {
+            setInternalKey(item);
+
+            if (nestedKey !== undefined) {
+                const nestedItem = item[nestedKey];
+                if (Array.isArray(nestedItem)) {
+                    setInternalKeys(nestedItem);
+                }
+            }
+
+            return item;
+        });
+    }
+
+    return items.map((item, index) => {
+        const value = item[key];
+        const keyString = String(key);
+        const invalidValue =
+            value === undefined || value === null || String(value).length === 0;
+
+        if (invalidValue) {
+            throw new Error(
+                `Key [${keyString}] is missing or has invalid value in item index ${index}`,
+            );
+        }
+        if (seenValues.has(value)) {
+            throw new Error(
+                `Expected each item to have key [${keyString}] with unique value but encountered duplicate of "${value}" in item index ${index}.`,
+            );
+        }
+
+        setInternalKey(item, String(value));
+        seenValues.add(value);
+
+        if (nestedKey !== undefined) {
+            const nestedItem = item[nestedKey];
+            if (Array.isArray(nestedItem)) {
+                setInternalKeys(nestedItem, key, undefined, seenValues);
+            }
+        }
+
+        return item;
+    });
+}


### PR DESCRIPTION
Ändrar så att `keyAttribute` inte är obligatorisk för:

- `FList`
- `FDataTable`
- `FInteractiveTable`

Todo:
- [x] Återställ sandbox efter testning är genomförd
- [x] Dokumentera preselect/selection för interaktiv tabell