### PR TITLE
refactor: remove `v-on.native` modifier (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FDatepickerField/FDatepickerField.vue
+++ b/packages/vue/src/components/FDatepickerField/FDatepickerField.vue
@@ -66,16 +66,14 @@
             @close="onClosePopup"
         >
             <div ref="popup" :class="popupClass">
-                <!-- eslint-disable vue/no-deprecated-v-on-native-modifier -- technical debt -->
                 <f-calendar
                     v-model="calendarMonth"
                     :tab-date="calendarValue"
                     :min-date="minDate"
                     :max-date="maxDate"
                     @click="onSelectCalendarDay"
-                    @keyup.esc.stop.native="onKeyupEsc"
+                    @keyup.esc.stop="onKeyupEsc"
                 >
-                    <!-- eslint-enable vue/no-deprecated-v-on-native-modifier -->
                     <template #default="{ date, isFocused }">
                         <f-calendar-day
                             :day="date"


### PR DESCRIPTION
Tar bort användningen av `v-on.native` från `FDatepickerField`.

Vad jag ser så gör den ingenting i dagsläget då modifiern är borttagen och Vue nu sätter native event listener på rot-elementet då komponenten inte har en matchande emit.

[v-on.native modifier removed](https://v3-migration.vuejs.org/breaking-changes/v-on-native-modifier-removed.html)

_"... Vue will now add all event listeners that are not defined as component-emitted events in the child as native event listeners to the child's root element ..."_