### PR TITLE
fix: fix action buttons wrapping in `FInteractiveTable`

### DIFF
--- a/packages/design/src/components/table/_table.scss
+++ b/packages/design/src/components/table/_table.scss
@@ -261,6 +261,11 @@ $table-input-offset-horizontal: 0.25rem;
                 @extend %table-monospace;
             }
 
+            // only tbody rows should have nowrap, thead should still be the same
+            &--action {
+                white-space: nowrap;
+            }
+
             &--selectable {
                 padding: densify(0.2rem) 0.2rem;
             }


### PR DESCRIPTION
fixes #296

![image](https://github.com/user-attachments/assets/8cfe6207-1144-47c6-917d-21c9b88c080f)
