### PR TITLE
refactor: no page-layout classes outside component (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FPageLayout/FPageLayout.vue
+++ b/packages/vue/src/components/FPageLayout/FPageLayout.vue
@@ -18,12 +18,10 @@ onMounted(() => {
 </script>
 
 <template>
-    <component :is="tagName" :layout class="page-layout">
-        <template v-for="slot of slotNames" :key="slot">
-            <!-- eslint-disable-next-line vue/no-deprecated-slot-attribute -- false postive, this is the native slot attribute -->
-            <div :slot class="page-layout__slot">
-                <slot :name="slot"></slot>
-            </div>
-        </template>
+    <component :is="tagName" :layout>
+        <!-- eslint-disable-next-line vue/no-deprecated-slot-attribute -- false positive, this is the native slot attribute -->
+        <div v-for="slot of slotNames" :key="slot" :slot>
+            <slot :name="slot"></slot>
+        </div>
     </component>
 </template>

--- a/packages/vue/src/components/FPageLayout/webcomponent/page-layout.css
+++ b/packages/vue/src/components/FPageLayout/webcomponent/page-layout.css
@@ -57,6 +57,6 @@
     }
 }
 
-::slotted(.page-layout__slot) {
+:host ::slotted(*) {
     display: contents;
 }


### PR DESCRIPTION
Slotted style is scoped to the component using `:host` instead.