### PR TITLE
feat: anchor discrete mixin (refs SB-4982)

### DIFF
--- a/packages/design/src/components/anchor/_anchor.scss
+++ b/packages/design/src/components/anchor/_anchor.scss
@@ -16,12 +16,6 @@ $anchor-svg-margin: 0.25rem;
     }
 
     &#{$ANCHOR_SELECTOR}--discrete {
-        color: var(--f-text-color-link-discrete);
-        text-decoration-color: var(--f-border-color-link-discrete);
-
-        &:hover {
-            color: var(--f-text-color-link-discrete-hover);
-            text-decoration-color: var(--f-text-color-link-discrete-hover);
-        }
+        @include anchor.anchor-discrete(false);
     }
 }

--- a/packages/design/src/core/mixins/_anchor.scss
+++ b/packages/design/src/core/mixins/_anchor.scss
@@ -15,3 +15,17 @@ $anchor-underline-width: 2px !default;
         text-decoration-color: var(--f-border-color-link-hover);
     }
 }
+
+@mixin anchor-discrete($standalone: true) {
+    @if $standalone {
+        @include anchor;
+    }
+
+    color: var(--f-text-color-link-discrete);
+    text-decoration-color: var(--f-border-color-link-discrete);
+
+    &:hover {
+        color: var(--f-text-color-link-discrete-hover);
+        text-decoration-color: var(--f-text-color-link-discrete-hover);
+    }
+}


### PR DESCRIPTION
I portalen är vi väldigt bortskämda med existerande mixin för ankar-länkar, som vi nyttjar i sass-kod där vi inte har möjlighet att själva applicera rätt klasser `.anchor`.

Jag funderar på om det vore möjligt med även en mixin för diskreta länkar, visst ~5 rader per förekomst men jag tror vi hade fått nytta av det på flera ställen.

Hela syftet med parametern "standalone", är så att ni inte skall få extra brus-kod i er egna kod. 

Helt öppet för diskussion!