### PR TITLE
fix: `FInteractiveTable` set selected on `v-model` change (fixes SFKUI-7052)

### DIFF
--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.cy.ts
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.cy.ts
@@ -4,7 +4,67 @@ import { FInteractiveTablePageObject } from "../../cypress";
 import { FTableColumn } from "../FTableColumn";
 import FInteractiveTable from "./FInteractiveTable.vue";
 
-function createComponent(template: string): DefineComponent {
+const table = new FInteractiveTablePageObject('[data-test="table-example"]');
+
+const rows = [
+    {
+        id: "1",
+        start: "2022-04-10",
+        end: "2022-04-25",
+        level: "Sjukpenning",
+        antal: "15",
+    },
+    {
+        id: "2",
+        start: "2022-05-06",
+        end: "2022-05-10",
+        level: "Lägstanivå",
+        antal: "4",
+    },
+    {
+        id: "3",
+        start: "2022-05-20",
+        end: "2022-05-31",
+        level: "Sjukpenning",
+        antal: "11",
+    },
+];
+
+const selectedRows = [rows[0], rows[2]];
+
+const defaultTemplate = /* HTML */ `
+    <f-interactive-table
+        v-model="selectedRows"
+        :rows
+        selectable
+        v-test="'table-example'"
+        key-attribute="id"
+    >
+        <template #caption> Föräldrapenning </template>
+        <template #default="{ row }">
+            <f-table-column name="level" title="Nivå" type="text">
+                {{ row.level }}
+            </f-table-column>
+            <f-table-column
+                name="start"
+                title="Från och med"
+                type="text"
+                expand
+            >
+                {{ row.start }}
+            </f-table-column>
+            <f-table-column name="end" title="Till och med" type="text">
+                {{ row.end }}
+            </f-table-column>
+            <f-table-column name="antal" title="Antal dagar" type="numeric">
+                {{ row.antal }}
+            </f-table-column>
+        </template>
+        <template #checkbox-description> Välj denna rad </template>
+    </f-interactive-table>
+`;
+
+function createComponent(template: string = defaultTemplate): DefineComponent {
     return defineComponent({
         template,
         components: {
@@ -13,110 +73,80 @@ function createComponent(template: string): DefineComponent {
         },
         data() {
             return {
-                selectedItems: [
-                    {
-                        id: "1",
-                        start: "2022-04-10",
-                        end: "2022-04-25",
-                        level: "Sjukpenning",
-                        antal: "15",
-                    },
-                    {
-                        id: "3",
-                        start: "2022-05-20",
-                        end: "2022-05-31",
-                        level: "Sjukpenning",
-                        antal: "11",
-                    },
-                ],
-                items: [
-                    {
-                        id: "1",
-                        start: "2022-04-10",
-                        end: "2022-04-25",
-                        level: "Sjukpenning",
-                        antal: "15",
-                    },
-                    {
-                        id: "2",
-                        start: "2022-05-06",
-                        end: "2022-05-10",
-                        level: "Lägstanivå",
-                        antal: "4",
-                    },
-                    {
-                        id: "3",
-                        start: "2022-05-20",
-                        end: "2022-05-31",
-                        level: "Sjukpenning",
-                        antal: "11",
-                    },
-                ],
+                selectedRows,
+                rows,
             };
         },
     });
 }
 
-describe("FInteractiveTable", () => {
-    beforeEach(() => {
-        const template = /* HTML */ `
-            <f-interactive-table
-                v-model="selectedItems"
-                :rows="items"
-                selectable
-                v-test="'table-example'"
-                key-attribute="id"
+it("should pre-select checkboxes", () => {
+    cy.mount(createComponent());
+    table.columnItem(1).checkbox().isSelected().should("be.true");
+    table.columnItem(2).checkbox().isSelected().should("be.false");
+    table.columnItem(3).checkbox().isSelected().should("be.true");
+});
+
+it("should update checkboxes on `v-model` change", () => {
+    const selectableTemplate = /* HTML */ `
+        <div>
+            <button type="button" id="remove-all" @click="selectedRows = []">
+                Remove all
+            </button>
+            <button type="button" id="select-all" @click="selectedRows = rows">
+                Select all
+            </button>
+            <button
+                type="button"
+                id="add-one"
+                @click="selectedRows.push(rows[1])"
             >
-                <template #caption> Föräldrapenning </template>
-                <template #default="{ row }">
-                    <f-table-column name="level" title="Nivå" type="text">
-                        {{ row.level }}
-                    </f-table-column>
-                    <f-table-column
-                        name="start"
-                        title="Från och med"
-                        type="text"
-                        expand
-                    >
-                        {{ row.start }}
-                    </f-table-column>
-                    <f-table-column name="end" title="Till och med" type="text">
-                        {{ row.end }}
-                    </f-table-column>
-                    <f-table-column
-                        name="antal"
-                        title="Antal dagar"
-                        type="numeric"
-                    >
-                        {{ row.antal }}
-                    </f-table-column>
-                </template>
-                <template #checkbox-description> Välj denna rad </template>
-            </f-interactive-table>
-        `;
-        cy.mount(createComponent(template));
+                Add one
+            </button>
+            ${defaultTemplate}
+        </div>
+    `;
+    cy.mount(createComponent(selectableTemplate));
+
+    table.columnItem(1).checkbox().isSelected().should("be.true");
+    table.columnItem(2).checkbox().isSelected().should("be.false");
+    table.columnItem(3).checkbox().isSelected().should("be.true");
+
+    cy.get("#remove-all").click();
+    table.columnItem(1).checkbox().isSelected().should("be.false");
+    table.columnItem(2).checkbox().isSelected().should("be.false");
+    table.columnItem(3).checkbox().isSelected().should("be.false");
+
+    cy.get("#add-one").click();
+    table.columnItem(1).checkbox().isSelected().should("be.false");
+    table.columnItem(2).checkbox().isSelected().should("be.true");
+    table.columnItem(3).checkbox().isSelected().should("be.false");
+
+    cy.get("#select-all").click();
+    table.columnItem(1).checkbox().isSelected().should("be.true");
+    table.columnItem(2).checkbox().isSelected().should("be.true");
+    table.columnItem(3).checkbox().isSelected().should("be.true");
+});
+
+describe("FInteractiveTable pageobject", () => {
+    beforeEach(() => {
+        cy.mount(createComponent());
     });
 
     it("should contain caption", () => {
-        const presentTable = new FInteractiveTablePageObject(
-            '[data-test="table-example"]',
-        );
-        presentTable.caption().should("contain", "Föräldrapenning");
+        table.caption().should("contain", "Föräldrapenning");
     });
 
     it("should provide a page object that can access any necessary elements in table headers", () => {
-        const presentTable = new FInteractiveTablePageObject(
-            '[data-test="table-example"]',
-        );
-        presentTable.headersRow().should("have.length", 5);
+        table.headersRow().should("have.length", 5);
 
-        presentTable
+        table
             .headerRowItem()
             .tableRowHeaderContent()
             .eq(1)
             .should("have.trimmedText", "Nivå");
 
-        presentTable
+        table
             .headerRowItem()
             .tableRowHeaderContent()
             .eq(2)
@@ -124,32 +154,19 @@ describe("FInteractiveTable", () => {
     });
 
     it("should provide a page object that can access any necessary elements in a table body", () => {
-        const presentTable = new FInteractiveTablePageObject(
-            '[data-test="table-example"]',
-        );
-        presentTable.bodyRow().should("have.length", 3);
+        table.bodyRow().should("have.length", 3);
 
-        presentTable
+        table
             .columnItem(1)
             .tableRowBodyContent(1)
             .should("contain", "Sjukpenning");
-        presentTable
+        table
             .columnItem(1)
             .tableRowBodyContent(2)
             .should("contain", "2022-04-10");
-        presentTable
+        table
             .columnItem(1)
             .tableRowBodyContent(3)
             .should("contain", "2022-04-25");
-    });
-
-    it("should pre-select checkboxes", () => {
-        const presentTable = new FInteractiveTablePageObject(
-            '[data-test="table-example"]',
-        );
-
-        presentTable.columnItem(1).checkbox().isSelected().should("be.true");
-        presentTable.columnItem(2).checkbox().isSelected().should("be.false");
-        presentTable.columnItem(3).checkbox().isSelected().should("be.true");
     });
 });

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
@@ -270,14 +270,7 @@ provide(
 
 watch(
     () => props.rows,
-    () => {
-        if (props.modelValue) {
-            // Remove old selected rows that may not exists in rows.
-            selectedRows.value = props.modelValue.filter((row: T) => {
-                return includeItem<T, K>(row, props.rows, props.keyAttribute as K);
-            });
-        }
-    },
+    () => setSelectedRows(),
     { immediate: true, deep: true },
 );
 
@@ -297,6 +290,12 @@ watch(
         }
     },
     { immediate: true },
+);
+
+watch(
+    () => props.modelValue,
+    () => setSelectedRows(),
+    { immediate: true, deep: true },
 );
 
 function updateTr(tbodyElement: HTMLElement): void {
@@ -399,6 +398,16 @@ function onSelect(row: T): void {
 
     updateVModelWithSelectedRows();
     getCurrentInstance()?.proxy?.$forceUpdate();
+}
+
+function setSelectedRows(): void {
+    if (!props.modelValue || !props.modelValue.length) {
+        selectedRows.value = [];
+        return;
+    }
+    selectedRows.value = props.modelValue.filter((row: T) => {
+        return includeItem<T, K>(row, props.rows, props.keyAttribute as K);
+    });
 }
 
 function updateVModelWithSelectedRows(): void {


### PR DESCRIPTION
Fixar så att vilka kryssrutor som är valda i `FInteractiveTable` uppdateras när `v-model` ändras.

Dokumentation om `selectable` grejer kommer i annan PR.