### PR TITLE
feat: add styling `text-align: left` on component `th` (fixes SFKUI-7151)

### DIFF
--- a/packages/design/src/components/table/_table.scss
+++ b/packages/design/src/components/table/_table.scss
@@ -141,6 +141,7 @@ $table-input-offset-horizontal: 0.25rem;
             font-weight: $table-header-font-weight;
             line-height: var(--f-line-height-large);
             padding: $table-header-padding;
+            text-align: left;
             vertical-align: top;
 
             &:last-child {


### PR DESCRIPTION
Sätter kolumnrubriken till att alltid vara vänsterställd.
![image](https://github.com/user-attachments/assets/c6a6dfb6-a507-4435-93cb-22d5e51605f6)