### PR TITLE
feat: remove styling for table scroll values `VERTICAL` and `BOTH` (refs SFKUI-7119)

### DIFF
--- a/docs/components/table-and-list/table.md
+++ b/docs/components/table-and-list/table.md
@@ -279,7 +279,7 @@ I undantagsfall kan du också använda en dold skärmläsartext i caption, men t
 
 ### Skroll i tabell
 
-För att lägga till skoll i tabell använder du prop `scroll`:
+För att lägga till skroll i tabell använder du prop `scroll`:
 
 ```diff
 -<f-data-table :rows="items">

--- a/packages/design/src/components/table/_table.scss
+++ b/packages/design/src/components/table/_table.scss
@@ -371,10 +371,6 @@ $table-input-offset-horizontal: 0.25rem;
         &--horizontal {
             overflow-x: auto;
         }
-
-        &--vertical {
-            overflow-y: auto;
-        }
     }
 
     &__input {


### PR DESCRIPTION
Tar bort styling för `TableScroll.VERTICAL` och `TableScroll.BOTH`.

Denna PR har splittrats ut till #474 och #475.