### PR TITLE
Better treeshaking of @fkui/logic

### DIFF
--- a/etc/logic.api.md
+++ b/etc/logic.api.md
@@ -24,6 +24,9 @@ export interface AllowListValidatorConfig extends ValidatorOptions {
 }
 
 // @public
+export const availableValidators: Validator[];
+
+// @public
 export type BankAccountNumberString = string;
 
 // @public

--- a/packages/date/src/locale.ts
+++ b/packages/date/src/locale.ts
@@ -12,7 +12,7 @@ function getDefaultLocale(): Locale {
     return Locale.SWEDISH;
 }
 
-let _locale: Locale = getDefaultLocale();
+let _locale: Locale = /* @__PURE__ */ getDefaultLocale();
 
 /**
  * Reset current locale to its default value.

--- a/packages/logic/src/dom/focus.ts
+++ b/packages/logic/src/dom/focus.ts
@@ -2,7 +2,7 @@ import { configLogic } from "../config";
 import { isVisible } from "./is-visible";
 import { scrollTo } from "./scroll-to";
 
-const sym = Symbol("focus-stack");
+const sym = /* @__PURE__ */ Symbol("focus-stack");
 
 /**
  * @public
@@ -49,7 +49,7 @@ export interface FocusOptions {
     scrollToTop?: boolean;
 }
 
-const TABBABLE_ELEMENT_SELECTOR = [
+const TABBABLE_ELEMENT_SELECTOR = /* @__PURE__ */ [
     "a[href]",
     "area[href]",
     "input",

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -41,6 +41,7 @@ export {
     TranslationService,
     ValidationErrorMessageBuilder,
     ValidationService,
+    availableValidators,
     getErrorMessages,
     isInvalidDatesConfig,
     isInvalidWeekdaysConfig,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -1,7 +1,51 @@
 export * from "./config";
 export * from "./converters";
 export * from "./dom";
-export * from "./services";
+export {
+    type AllowListValidatorConfig,
+    type BlacklistValidatorConfig,
+    type DecimalValidatorConfig,
+    type ElementIdServiceInterface,
+    type ElementValidatorsReference,
+    type EmailValidatorConfig,
+    type InvalidDatesValidatorConfig,
+    type InvalidWeekdaysValidatorConfig,
+    type MatchesValidatorConfig,
+    type MaxDateValidatorConfig,
+    type MaxLengthValidatorConfig,
+    type MinDateValidatorConfig,
+    type MinLengthValidatorConfig,
+    type PendingValidityEvent,
+    type PersistenceServiceInterface,
+    type SimplePersistenceServiceInterface,
+    type TranslateFunction,
+    type TranslationProviderInterface,
+    type TranslationServiceInterface,
+    type ValidatableHTMLElement,
+    type ValidateEvent,
+    type ValidationConfigUpdateDetail,
+    type ValidationResult,
+    type ValidationServiceInterface,
+    type ValidationState,
+    type Validator,
+    type ValidatorConfig,
+    type ValidatorConfigs,
+    type ValidatorName,
+    type ValidatorOptions,
+    type ValidityEvent,
+    type ValidityMode,
+    type ValidityNativeEvent,
+    ElementIdService,
+    PersistenceService,
+    SimplePersistenceService,
+    TranslationService,
+    ValidationErrorMessageBuilder,
+    ValidationService,
+    getErrorMessages,
+    isInvalidDatesConfig,
+    isInvalidWeekdaysConfig,
+    isValidatableHTMLElement,
+} from "./services";
 export * from "./text";
 export * from "./types";
 export * from "./utils";

--- a/packages/logic/src/services/ElementIdService/ElementIdService.ts
+++ b/packages/logic/src/services/ElementIdService/ElementIdService.ts
@@ -39,4 +39,5 @@ class ElementIdServiceImpl implements ElementIdServiceInterface {
  * @public
  */
 export const ElementIdService: ElementIdServiceInterface =
+    /* @__PURE__ */
     new ElementIdServiceImpl();

--- a/packages/logic/src/services/ElementIdService/index.ts
+++ b/packages/logic/src/services/ElementIdService/index.ts
@@ -1,2 +1,2 @@
-export * from "./ElementIdService";
-export * from "./ElementIdServiceInterface";
+export { ElementIdService } from "./ElementIdService";
+export { type ElementIdServiceInterface } from "./ElementIdServiceInterface";

--- a/packages/logic/src/services/PersistenceService/PersistenceService.ts
+++ b/packages/logic/src/services/PersistenceService/PersistenceService.ts
@@ -1,7 +1,7 @@
 import { PersistenceServiceInterface } from "./PersistenceServiceInterface";
 
 /* istanbul ignore next: manually tested */
-const haveSessionStorage = (() => {
+const haveSessionStorage = /* @__PURE__ */ (() => {
     const test = "fkui.sessionstorage.test";
     try {
         if (window.sessionStorage) {

--- a/packages/logic/src/services/PersistenceService/index.ts
+++ b/packages/logic/src/services/PersistenceService/index.ts
@@ -1,4 +1,4 @@
-export * from "./SimplePersistenceService";
-export * from "./SimplePersistenceServiceInterface";
-export * from "./PersistenceService";
-export * from "./PersistenceServiceInterface";
+export { SimplePersistenceService } from "./SimplePersistenceService";
+export { type SimplePersistenceServiceInterface } from "./SimplePersistenceServiceInterface";
+export { PersistenceService } from "./PersistenceService";
+export { type PersistenceServiceInterface } from "./PersistenceServiceInterface";

--- a/packages/logic/src/services/TranslationService/TranslationService.ts
+++ b/packages/logic/src/services/TranslationService/TranslationService.ts
@@ -15,4 +15,5 @@ class TranslationServiceImpl implements TranslationServiceInterface {
  * @public
  */
 export const TranslationService: TranslationServiceInterface =
+    /* @__PURE__ */
     new TranslationServiceImpl();

--- a/packages/logic/src/services/TranslationService/index.ts
+++ b/packages/logic/src/services/TranslationService/index.ts
@@ -1,3 +1,6 @@
-export * from "./TranslationService";
-export * from "./TranslationProviderInterface";
-export * from "./TranslationServiceInterface";
+export { TranslationService } from "./TranslationService";
+export {
+    type TranslateFunction,
+    type TranslationProviderInterface,
+} from "./TranslationProviderInterface";
+export { type TranslationServiceInterface } from "./TranslationServiceInterface";

--- a/packages/logic/src/services/ValidationService/FieldsetValidationHandler.spec.ts
+++ b/packages/logic/src/services/ValidationService/FieldsetValidationHandler.spec.ts
@@ -1,6 +1,8 @@
-import "./Validators";
+import { requiredValidator } from "./Validators/RequiredValidator";
 import { ValidationService } from "./ValidationService";
 import { type ValidatableHTMLElement } from "./ValidationServiceInterface";
+
+ValidationService.registerValidator(requiredValidator);
 
 let fieldset: HTMLFieldSetElement;
 

--- a/packages/logic/src/services/ValidationService/ValidationService.blackbox.spec.ts
+++ b/packages/logic/src/services/ValidationService/ValidationService.blackbox.spec.ts
@@ -1,5 +1,7 @@
-import "./Validators";
+import { requiredValidator } from "./Validators/RequiredValidator";
 import { ValidationService } from "./ValidationService";
+
+ValidationService.registerValidator(requiredValidator);
 
 it("should set isTouched on blur", async () => {
     expect.assertions(2);

--- a/packages/logic/src/services/ValidationService/ValidationService.spec.ts
+++ b/packages/logic/src/services/ValidationService/ValidationService.spec.ts
@@ -8,8 +8,20 @@ import {
     type ValidityEvent,
 } from "./ValidationServiceInterface";
 import { type Validator, type ValidatorName } from "./Validator";
-import "./Validators";
+import { dateValidator } from "./Validators/DateValidator";
+import { emailValidator } from "./Validators/EmailValidator";
+import { maxLengthValidator } from "./Validators/MaxLengthValidator";
+import { minLengthValidator } from "./Validators/MinLengthValidator";
+import { requiredValidator } from "./Validators/RequiredValidator";
+import { whitelistValidator } from "./Validators/WhitelistValidator";
 import { registry } from "./registry";
+
+ValidationService.registerValidator(dateValidator);
+ValidationService.registerValidator(emailValidator);
+ValidationService.registerValidator(requiredValidator);
+ValidationService.registerValidator(maxLengthValidator);
+ValidationService.registerValidator(minLengthValidator);
+ValidationService.registerValidator(whitelistValidator);
 
 function setBodyInnerHTML(html: string): void {
     document.body.innerHTML = html;

--- a/packages/logic/src/services/ValidationService/ValidationService.ts
+++ b/packages/logic/src/services/ValidationService/ValidationService.ts
@@ -811,4 +811,5 @@ class ValidationServiceImpl implements ValidationServiceInterface {
  * @public
  */
 export const ValidationService: ValidationServiceInterface =
+    /* @__PURE__ */
     new ValidationServiceImpl();

--- a/packages/logic/src/services/ValidationService/Validators/index.ts
+++ b/packages/logic/src/services/ValidationService/Validators/index.ts
@@ -1,4 +1,4 @@
-import { ValidationService } from "../ValidationService";
+import { type Validator } from "../Validator";
 import { allowListValidator } from "./AllowListValidator";
 import { bankAccountNumberValidator } from "./BankAccountNumberValidator";
 import { bankgiroValidator } from "./BankgiroValidator";
@@ -52,38 +52,45 @@ export {
 } from "./InvalidWeekdaysValidator";
 export { type AllowListValidatorConfig } from "./AllowListValidator";
 
-ValidationService.registerValidator(allowListValidator);
-ValidationService.registerValidator(bankAccountNumberValidator);
-ValidationService.registerValidator(bankgiroValidator);
-ValidationService.registerValidator(blacklistValidator);
-ValidationService.registerValidator(clearingNumberValidator);
-ValidationService.registerValidator(currencyValidator);
-ValidationService.registerValidator(dateFormatValidator);
-ValidationService.registerValidator(dateValidator);
-ValidationService.registerValidator(decimalValidator);
-ValidationService.registerValidator(emailValidator);
-ValidationService.registerValidator(greaterThanValidator);
-ValidationService.registerValidator(integerValidator);
-ValidationService.registerValidator(invalidDatesValidator);
-ValidationService.registerValidator(invalidWeekdaysValidator);
-ValidationService.registerValidator(lessThanValidator);
-ValidationService.registerValidator(matchesValidator);
-ValidationService.registerValidator(maxDateValidator);
-ValidationService.registerValidator(maxLengthValidator);
-ValidationService.registerValidator(maxValueValidator);
-ValidationService.registerValidator(minDateValidator);
-ValidationService.registerValidator(minLengthValidator);
-ValidationService.registerValidator(minValueValidator);
-ValidationService.registerValidator(numberValidator);
-ValidationService.registerValidator(organisationsnummerValidator);
-ValidationService.registerValidator(percentValidator);
-ValidationService.registerValidator(personnummerFormatValidator);
-ValidationService.registerValidator(personnummerLuhnValidator);
-ValidationService.registerValidator(personnummerNotSame);
-ValidationService.registerValidator(personnummerOlder);
-ValidationService.registerValidator(personnummerYounger);
-ValidationService.registerValidator(phoneNumberValidator);
-ValidationService.registerValidator(plusgiroValidator);
-ValidationService.registerValidator(postalCodeValidator);
-ValidationService.registerValidator(requiredValidator);
-ValidationService.registerValidator(whitelistValidator);
+/**
+ * List of all available builtin validators.
+ *
+ * @public
+ */
+export const availableValidators: Validator[] = [
+    allowListValidator,
+    bankAccountNumberValidator,
+    bankgiroValidator,
+    blacklistValidator,
+    clearingNumberValidator,
+    currencyValidator,
+    dateFormatValidator,
+    dateValidator,
+    decimalValidator,
+    emailValidator,
+    greaterThanValidator,
+    integerValidator,
+    invalidDatesValidator,
+    invalidWeekdaysValidator,
+    lessThanValidator,
+    matchesValidator,
+    maxDateValidator,
+    maxLengthValidator,
+    maxValueValidator,
+    minDateValidator,
+    minLengthValidator,
+    minValueValidator,
+    numberValidator,
+    organisationsnummerValidator,
+    percentValidator,
+    personnummerFormatValidator,
+    personnummerLuhnValidator,
+    personnummerNotSame,
+    personnummerOlder,
+    personnummerYounger,
+    phoneNumberValidator,
+    plusgiroValidator,
+    postalCodeValidator,
+    requiredValidator,
+    whitelistValidator,
+];

--- a/packages/logic/src/services/ValidationService/index.ts
+++ b/packages/logic/src/services/ValidationService/index.ts
@@ -32,6 +32,7 @@ export {
     type MaxLengthValidatorConfig,
     type MinDateValidatorConfig,
     type MinLengthValidatorConfig,
+    availableValidators,
     isInvalidDatesConfig,
     isInvalidWeekdaysConfig,
 } from "./Validators";

--- a/packages/logic/src/services/ValidationService/index.ts
+++ b/packages/logic/src/services/ValidationService/index.ts
@@ -1,8 +1,39 @@
 export { type Validator, type ValidatorName } from "./Validator";
 
-export * from "./ValidationService";
-export * from "./ValidationServiceInterface";
-export * from "./Validators";
+export {
+    ValidationService,
+    isValidatableHTMLElement,
+} from "./ValidationService";
+export {
+    type ElementValidatorsReference,
+    type PendingValidityEvent,
+    type ValidatableHTMLElement,
+    type ValidateEvent,
+    type ValidationConfigUpdateDetail,
+    type ValidationResult,
+    type ValidationServiceInterface,
+    type ValidationState,
+    type ValidatorConfig,
+    type ValidatorConfigs,
+    type ValidatorOptions,
+    type ValidityEvent,
+    type ValidityMode,
+    type ValidityNativeEvent,
+} from "./ValidationServiceInterface";
+export {
+    type AllowListValidatorConfig,
+    type BlacklistValidatorConfig,
+    type DecimalValidatorConfig,
+    type EmailValidatorConfig,
+    type InvalidDatesValidatorConfig,
+    type InvalidWeekdaysValidatorConfig,
+    type MatchesValidatorConfig,
+    type MaxDateValidatorConfig,
+    type MaxLengthValidatorConfig,
+    type MinDateValidatorConfig,
+    type MinLengthValidatorConfig,
+    isInvalidDatesConfig,
+    isInvalidWeekdaysConfig,
+} from "./Validators";
 export { getErrorMessages } from "./ValidationTranslations";
-export * from "./ValidationService";
-export * from "./ValidationErrorMessageBuilder";
+export { ValidationErrorMessageBuilder } from "./ValidationErrorMessageBuilder";

--- a/packages/logic/src/services/index.ts
+++ b/packages/logic/src/services/index.ts
@@ -1,4 +1,51 @@
-export * from "./TranslationService";
-export * from "./ValidationService";
-export * from "./ElementIdService";
-export * from "./PersistenceService";
+export {
+    type ElementIdServiceInterface,
+    ElementIdService,
+} from "./ElementIdService";
+export {
+    type PersistenceServiceInterface,
+    type SimplePersistenceServiceInterface,
+    PersistenceService,
+    SimplePersistenceService,
+} from "./PersistenceService";
+export {
+    type TranslateFunction,
+    type TranslationProviderInterface,
+    type TranslationServiceInterface,
+    TranslationService,
+} from "./TranslationService";
+export {
+    type AllowListValidatorConfig,
+    type BlacklistValidatorConfig,
+    type DecimalValidatorConfig,
+    type ElementValidatorsReference,
+    type EmailValidatorConfig,
+    type InvalidDatesValidatorConfig,
+    type InvalidWeekdaysValidatorConfig,
+    type MatchesValidatorConfig,
+    type MaxDateValidatorConfig,
+    type MaxLengthValidatorConfig,
+    type MinDateValidatorConfig,
+    type MinLengthValidatorConfig,
+    type PendingValidityEvent,
+    type ValidatableHTMLElement,
+    type ValidateEvent,
+    type ValidationConfigUpdateDetail,
+    type ValidationResult,
+    type ValidationServiceInterface,
+    type ValidationState,
+    type Validator,
+    type ValidatorConfig,
+    type ValidatorConfigs,
+    type ValidatorName,
+    type ValidatorOptions,
+    type ValidityEvent,
+    type ValidityMode,
+    type ValidityNativeEvent,
+    ValidationErrorMessageBuilder,
+    ValidationService,
+    getErrorMessages,
+    isInvalidDatesConfig,
+    isInvalidWeekdaysConfig,
+    isValidatableHTMLElement,
+} from "./ValidationService";

--- a/packages/logic/src/services/index.ts
+++ b/packages/logic/src/services/index.ts
@@ -44,6 +44,7 @@ export {
     type ValidityNativeEvent,
     ValidationErrorMessageBuilder,
     ValidationService,
+    availableValidators,
     getErrorMessages,
     isInvalidDatesConfig,
     isInvalidWeekdaysConfig,

--- a/packages/vue-labs/src/components/XTimeTextField/XTimeTextField.spec.ts
+++ b/packages/vue-labs/src/components/XTimeTextField/XTimeTextField.spec.ts
@@ -1,5 +1,6 @@
 import { defineComponent } from "vue";
 import { VueWrapper, mount } from "@vue/test-utils";
+import { ValidationPlugin } from "@fkui/vue";
 import XTimeTextField from "./XTimeTextField.vue";
 
 function createWrapper(
@@ -19,7 +20,11 @@ function createWrapper(
         template,
     });
 
-    return mount(TestComponent);
+    return mount(TestComponent, {
+        global: {
+            plugins: [ValidationPlugin],
+        },
+    });
 }
 
 describe("snapshots", () => {

--- a/packages/vue/src/components/FDatepickerField/FDatepickerField.spec.ts
+++ b/packages/vue/src/components/FDatepickerField/FDatepickerField.spec.ts
@@ -2,6 +2,7 @@ import "html-validate/jest";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { FDate } from "@fkui/date";
+import { ValidationPlugin } from "../../plugins";
 import FDatepickerField from "./FDatepickerField.vue";
 
 beforeEach(() => {
@@ -17,6 +18,9 @@ describe("transparency", () => {
         const wrapper = mount(FDatepickerField, {
             attrs: {
                 title: "foo",
+            },
+            global: {
+                plugins: [ValidationPlugin],
             },
         });
 
@@ -40,6 +44,9 @@ describe("textfield", () => {
         const wrapper = mount(FDatepickerField, {
             attrs: {
                 id: "foo",
+            },
+            global: {
+                plugins: [ValidationPlugin],
             },
         });
 

--- a/packages/vue/src/components/FPageLayout/webcomponent/page-layout.ts
+++ b/packages/vue/src/components/FPageLayout/webcomponent/page-layout.ts
@@ -1,3 +1,6 @@
+/* include typescript declarations for vite static asset handling (e.g. `?raw`) */
+/// <reference types="vite/client" />
+
 import {
     VAR_NAME_AREA,
     VAR_NAME_ATTACH_PANEL,

--- a/packages/vue/src/components/FTextField/FTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/FTextField.spec.ts
@@ -9,6 +9,7 @@ import {
 import flushPromises from "flush-promises";
 import { mount, VueWrapper } from "@vue/test-utils";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
+import { ValidationPlugin } from "../../plugins";
 import FTextField from "./FTextField.vue";
 
 function createWrapper({
@@ -25,6 +26,7 @@ function createWrapper({
         ...options,
         global: {
             stubs: ["f-icon"],
+            plugins: [ValidationPlugin],
         },
     });
 }

--- a/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.spec.ts
@@ -27,6 +27,7 @@ function createWrapper({
         ...options,
         global: {
             stubs: ["f-icon"],
+            plugins: [ValidationPlugin],
         },
     });
 }

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPercentTextField/FPercentTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPercentTextField/FPercentTextField.spec.ts
@@ -1,10 +1,14 @@
 import "html-validate/jest";
 import { mount, VueWrapper } from "@vue/test-utils";
+import { ValidationPlugin } from "../../../../plugins";
 import FPercentTextField from "./FPercentTextField.vue";
 
 function createWrapper(props = {}): VueWrapper {
     return mount(FPercentTextField, {
         props: { ...props },
+        global: {
+            plugins: [ValidationPlugin],
+        },
     });
 }
 

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.spec.ts
@@ -27,6 +27,7 @@ function createWrapper({
         ...options,
         global: {
             stubs: ["f-icon"],
+            plugins: [ValidationPlugin],
         },
     });
 }

--- a/packages/vue/src/plugins/validation/ValidationPlugin.ts
+++ b/packages/vue/src/plugins/validation/ValidationPlugin.ts
@@ -6,12 +6,13 @@ import {
 } from "vue";
 import isEqual from "lodash/isEqual";
 import {
-    isValidatableHTMLElement,
-    ValidationService,
     type ValidatableHTMLElement,
     type ValidatorName,
     type ValidatorConfigs,
     type ValidatorConfig,
+    availableValidators,
+    isValidatableHTMLElement,
+    ValidationService,
 } from "@fkui/logic";
 import { ComponentValidityEvent } from "../../types";
 
@@ -98,6 +99,11 @@ const ValidationPrefixDirective: Directive<HTMLElement, string> = {
  */
 export const ValidationPlugin: Plugin = {
     install(app: App) {
+        /* register all builtin validators */
+        for (const validator of availableValidators) {
+            ValidationService.registerValidator(validator);
+        }
+
         app.directive("validation", ValidationDirective);
         app.directive("validationPrefix", ValidationPrefixDirective);
     },


### PR DESCRIPTION
Given a simple testcase:

```ts
import { findCookie } from "@fkui/logic"
```

When bundled with esbuild the final bundle size is a staggering **96kb**. Rollup performs similarly.

This PR reduces the amount to "only" 40kb by:

* Removing the global registration of validators instead relying on `ValidationPlugin`. This is semi-breaking, I would argue though that there is no consumer using validators purely from `@fkui/logic` as it is such a pain in the ass to do so. If they do they must now use `availableValidators` and manually register. This removes the biggest chunk of the bundle.
* Using the `/* @__PURE__ */` annotation on as many globals as possible. This includes the awfule singletons we use, the pattern is by design not treeshakable but this mitigates it. The annotation is supported by both [rollup](https://rollupjs.org/configuration-options/#pure) and [esbuild](https://esbuild.github.io/api/#pure) and in turn Vite as well, as well as many other tools.

What is left in the bundle:

* `lodash`, not marked as side-effects free so it is always pulled into the bundle. We should get rid of the dependency alltogether.
* `dayjs`, not marked as side-effects free either, this surprises me a bit but haven't investigated it further.
* Typescript enums, I've ranted about them before for other reasons and this just adds fuel to my fire. They are not treeshakable and not sure if there is an easy fix for it but I couldn't make it work. This does include some pretty heavy i18n enums from `@fkui/date` with weekdays, date formats etc.
* `alertScreenReader` has side-effects which cannot be removed without refactoring how it works (it creates the `<div>` and attaches to `<body>`). I feel a bit guilty about this one but the better way would probably be to make the `alertScreenReader()` function create it the first time it is needed.
