### PR TITLE
fix: collapsed expandable rows in `FInteractiveTable` shown as white gaps in iOS browsers (fixes SFKUI-6984)

### DIFF
--- a/packages/design/src/components/table/_table.scss
+++ b/packages/design/src/components/table/_table.scss
@@ -97,7 +97,7 @@ $table-input-offset-horizontal: 0.25rem;
 }
 
 %table-row-collapsed {
-    visibility: collapse;
+    display: none;
 }
 
 #{$TABLE_SELECTOR} {

--- a/packages/design/src/components/table/_table.scss
+++ b/packages/design/src/components/table/_table.scss
@@ -233,7 +233,7 @@ $table-input-offset-horizontal: 0.25rem;
             @extend %table-row-normal;
 
             &--collapsed {
-                visibility: collapse;
+                display: none;
             }
         }
 

--- a/packages/design/src/components/table/_table.scss
+++ b/packages/design/src/components/table/_table.scss
@@ -97,7 +97,7 @@ $table-input-offset-horizontal: 0.25rem;
 }
 
 %table-row-collapsed {
-    display: none;
+    visibility: collapse;
 }
 
 #{$TABLE_SELECTOR} {


### PR DESCRIPTION
### Problem
![image](https://github.com/user-attachments/assets/2bc96d0c-ef16-4913-9520-fbee0e365f41)
Länk: https://designsystem.forsakringskassan.se/latest/components/table-and-list/table.html#interaktiv_tabell

### Orsak

> Safari on iOS treats `visibility: collapse` like `hidden`, leaving a white gap.

_Källa: https://developer.mozilla.org/en-US/docs/Web/CSS/visibility#browser_compatibility_
