### PR TITLE
chore(dx): enable runtime compiler so live examples can be run by vite devserver

### DIFF
--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -7,7 +7,7 @@
 @use "@fkui/design/src/core/mixins/breakpoints";
 @use "@fkui/design/src/fkui";
 @use "@forsakringskassan/docs-generator/style";
-@use "@forsakringskassan/docs-live-example/dist/main";
+@use "@forsakringskassan/docs-live-example";
 
 $fk-logo-small: "fk-logo-primary-small.svg";
 $fk-logo-large: "fk-logo-primary-large.svg";

--- a/packages/vue/src/local.scss
+++ b/packages/vue/src/local.scss
@@ -1,3 +1,4 @@
 @use "@fkui/theme-default";
 @use "@fkui/design";
 @use "@fkui/design/lib/fonts.css";
+@use "@forsakringskassan/docs-live-example";

--- a/packages/vue/vite.config.mts
+++ b/packages/vue/vite.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
     },
     resolve: {
         alias: {
+            vue: "vue/dist/vue.esm-bundler.js",
             "@fkui/vue": path.resolve("src/index.ts"),
         },
     },


### PR DESCRIPTION
Drar in Vue runtime compiler istället vilket då möjliggör att köra liveexempel direkt från Vite devserver. Viss styling från docs-generator saknas och vi behöver Forsakringskassan/docs-live-example#44 för att "Visa kod" fliken ska lira men annars är det helt funktionellt efter dessa ändringar.

---

> npm run vue start FTextFieldExample

![image](https://github.com/user-attachments/assets/f02cc839-f80b-42c7-8066-8a2fdb69cd7f)
---

Som ni kan se så lägger sig inställningarna under den körbara ytan istället då den stylingen ligger i docs-generator istället, vore nog bra om den bröts ut så man kan dra in bara den utan resten av all styling men tills dess så känner jag inte att det är en showstopper.