### PR TITLE
build(cypress): fix incorrectly cypress/vite prebundling monorepo packages (refs SFKUI-6500)

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -3,7 +3,10 @@
     "compilerOptions": {
         "types": ["cypress", "node", "cypress-html-validate/commands"],
         "paths": {
-            "@fkui/*": ["./packages/*"]
+            "@fkui/date": ["./packages/date/src/index.ts"],
+            "@fkui/logic": ["./packages/logic/src/index.ts"],
+            "@fkui/vue": ["./packages/vue/src/index.ts"],
+            "@fkui/vue-labs": ["./packages/vue-labs/src/index.ts"]
         }
     },
     "include": ["**/*.ts"]

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -5,7 +5,11 @@ import { vuePlugin } from "@forsakringskassan/vite-lib-config/vite";
 
 export default defineConfig({
     optimizeDeps: {
-        entries: ["packages/*/src/**/*.{ts,vue}", "cypress/**/*.{ts,vue}"],
+        entries: [
+            "packages/*/src/**/*.{ts,vue}",
+            "cypress/**/*.{ts,vue}",
+            "!**/*.spec.ts",
+        ],
         include: ["dayjs", "lodash", "vue", "vue-router"],
     },
     plugins: [vuePlugin()],

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,21 +1,12 @@
 /* This file is used by Cypress only, see `packages/vue/vite.config.ts` for the actual config */
-import path from "node:path";
+import * as path from "node:path";
 import { defineConfig } from "vite";
 import { vuePlugin } from "@forsakringskassan/vite-lib-config/vite";
 
 export default defineConfig({
     optimizeDeps: {
         entries: ["packages/*/src/**/*.{ts,vue}", "cypress/**/*.{ts,vue}"],
-        include: [
-            "@fkui/logic",
-            "@fkui/test-utils",
-            "@fkui/vue",
-            "@fkui/vue-labs",
-            "dayjs",
-            "lodash",
-            "vue",
-            "vue-router",
-        ],
+        include: ["dayjs", "lodash", "vue", "vue-router"],
     },
     plugins: [vuePlugin()],
     resolve: {
@@ -24,11 +15,13 @@ export default defineConfig({
             vue: "vue/dist/vue.esm-bundler.js",
 
             /* alias packages to source folders instead of compiled versions */
+            "@fkui/date": path.resolve("packages/date/src/index.ts"),
+            "@fkui/logic": path.resolve("packages/logic/src/index.ts"),
             "@fkui/vue/cypress": path.resolve(
                 "packages/vue/src/cypress/index.ts",
             ),
-            "@fkui/vue": "packages/vue/src/index.ts",
-            "@fkui/vue-labs": "packages/vue-labs/src/index.ts",
+            "@fkui/vue": path.resolve("packages/vue/src/index.ts"),
+            "@fkui/vue-labs": path.resolve("packages/vue-labs/src/index.ts"),
         },
     },
 });


### PR DESCRIPTION
Similar to #282 but for Cypress, solves issues with multiple versions on `@fkui/vue` being pulled into test cases (causing issues with global state)