### PR TITLE
docs: consistent look of footer links (fixes SFKUI-7183)

### DIFF
--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -5,7 +5,7 @@
     $asset-path-images: "./images"
 );
 @use "@fkui/design/src/core/mixins/breakpoints";
-@use "@fkui/design/src/fkui";
+@use "@fkui/design" as fkui;
 @use "@forsakringskassan/docs-generator/style";
 @use "@forsakringskassan/docs-live-example";
 
@@ -66,7 +66,8 @@ footer {
         padding: 0;
     }
 
-    li {
+    li,
+    #version button {
         margin-bottom: 0.5rem;
     }
 
@@ -74,6 +75,14 @@ footer {
         color: var(--fkds-color-text-inverted);
         font-weight: var(--f-font-weight-normal);
         text-decoration-color: var(--fkds-color-text-inverted);
+    }
+
+    .anchor,
+    #version button {
+        &:hover {
+            color: palette.$palette-color-fk-black-100;
+            text-decoration-color: palette.$palette-color-fk-black-100;
+        }
     }
 
     .footer__left {
@@ -91,6 +100,22 @@ footer {
     .version {
         color: var(--fkds-color-text-inverted);
         margin-left: 0;
+    }
+
+    #version {
+        button {
+            appearance: none;
+
+            &:focus {
+                @include fkui.focus-indicator;
+            }
+
+            &:hover,
+            &:active {
+                background: transparent;
+                cursor: pointer;
+            }
+        }
     }
 
     #version-dialog .list__item {


### PR DESCRIPTION
fixes #394

Före:

![image](https://github.com/user-attachments/assets/0895e849-9745-48b4-8c71-656810505e8b)

![image](https://github.com/user-attachments/assets/01b67bf6-9fdf-4eb4-a27c-68e39dc2a727)

Efter:

![image](https://github.com/user-attachments/assets/ed38cf4f-e926-47f3-8128-183e00081562)

![image](https://github.com/user-attachments/assets/0cb633d3-c0b0-4a6a-902c-2f812c1213e1)

---

Det grå sträcket under alla länkar får nu samma svarta färg som textfärgen istället för att de behåller den vita färgen. Marginalen runt byt version är justerad att matcha andra länkar.

Personligen tycker jag det ser ganska fult ut men tänker att det blir bättre (konsekvent) så här och sen får gärna någon annan justera så det faktiskt ser snyggt ut också.

Trodde att det här var löst för FPageHeader men där har vi inga text-länkar och därför ingen styling för det. Om konsumenten slottat in det så ser det trasigt ut (har för mig vi råkade ut för det i texteditorn och fix lösa det i applikationen).