### PR TITLE
chore(vue): disable html-validate `vue/prefer-slot-shorthand` (refs S…

### DIFF
--- a/internal/testbed-page-layout/src/App.vue
+++ b/internal/testbed-page-layout/src/App.vue
@@ -71,7 +71,6 @@ registerLayout({
         <template #left>
             <f-resize-pane min="150px" max="40%" initial="600px">
                 <!-- eslint-disable vue/no-deprecated-slot-attribute -- native slot -->
-                <!-- [html-validate-disable vue/prefer-slot-shorthand -- native slot] -->
                 <f-minimizable-panel>
                     <template #default="{ isOpen, header, footer, content }">
                         <template v-if="isOpen">

--- a/packages/vue/htmlvalidate/configs/recommended.js
+++ b/packages/vue/htmlvalidate/configs/recommended.js
@@ -14,5 +14,6 @@ module.exports = {
         "fkui/ftextfield-formatter-validation": "error",
         "fkui/no-template-modal": "error",
         "fkui/ftablecolumn-name": "error",
+        "vue/prefer-slot-shorthand": "off",
     },
 };

--- a/packages/vue/src/components/FDetailsPanel/FDetailsPanel.vue
+++ b/packages/vue/src/components/FDetailsPanel/FDetailsPanel.vue
@@ -57,7 +57,6 @@ function onClose(reason: string = "close"): void {
 <template>
     <component :is="tagName" v-if="visible" :data-panel-name="name" @closed="onClose()">
         <!-- eslint-disable vue/no-deprecated-slot-attribute -- native slot -->
-        <!-- [html-validate-disable-block vue/prefer-slot-shorthand -- native slot] -->
 
         <!--
                 @slot Panel content. Use native slots

--- a/packages/vue/src/components/FMinimizablePanel/FMinimizablePanel.vue
+++ b/packages/vue/src/components/FMinimizablePanel/FMinimizablePanel.vue
@@ -64,7 +64,6 @@ function onToggle(e: CustomEvent<[boolean, boolean, number?]>): void {
 
 <template>
     <!-- eslint-disable vue/no-deprecated-slot-attribute -- native slot -->
-    <!-- [html-validate-disable vue/prefer-slot-shorthand -- native slot] -->
     <ce-minimizable-panel :context="ceContext" :close-prefix :open-prefix @toggle="onToggle">
         <!--
             @slot Content

--- a/packages/vue/src/components/FMinimizablePanel/examples/FMinimizablePanelExample.vue
+++ b/packages/vue/src/components/FMinimizablePanel/examples/FMinimizablePanelExample.vue
@@ -7,7 +7,6 @@ import { FPageLayout, FResizePane, FMinimizablePanel } from "@fkui/vue";
         <template #left>
             <f-resize-pane min="150px" max="40%" initial="600px">
                 <!-- eslint-disable vue/no-deprecated-slot-attribute -- native-slot -->
-                <!-- [html-validate-disable vue/prefer-slot-shorthand -- native slot] -->
                 <f-minimizable-panel>
                     <template #default="{ isOpen, header, footer, content }">
                         <template v-if="isOpen">

--- a/packages/vue/src/components/FResizePane/FResizePane.vue
+++ b/packages/vue/src/components/FResizePane/FResizePane.vue
@@ -103,7 +103,6 @@ function onResize(event: CustomEvent<[size: number]>): void {
 <template>
     <component :is="tagName" :disabled :hidden :overlay :offset v-bind="props" @resize="onResize">
         <!-- eslint-disable vue/no-deprecated-slot-attribute -- native slot -->
-        <!-- [html-validate-disable vue/prefer-slot-shorthand -- native slot] -->
         <div slot="content">
             <!-- @slot Pane content -->
             <slot name="default"></slot>


### PR DESCRIPTION
…FKUI-6500)

A few components have started to expose native slots from underlying custom elements, so this rule is turned off.

Vue slot: `<template #my-slot>`
Native slot: `<div slot="my-slot">`