### PR TITLE
feat: updated semantic tokens for colors (refs SFKUI-7232)

### DIFF
--- a/packages/design/src/components/button/_variables.scss
+++ b/packages/design/src/components/button/_variables.scss
@@ -32,4 +32,4 @@ $button-tertiary-inverted-icon-color-content-focus: var(--fkds-icon-color-action
 $button-tertiary-inverted-color-background-focus: transparent;
 $button-tertiary-inverted-color-background-disabled: transparent;
 $button-tertiary-inverted-color-text-disabled: var(--fkds-color-text-disabled);
-$button-tertiary-inverted-icon-color-content-disabled: var(--fkds-icon-color-action-content-primary-disabled);
+$button-tertiary-inverted-icon-color-content-disabled: var(--fkds-icon-color-content-disabled);

--- a/packages/design/src/components/combobox/_variables.scss
+++ b/packages/design/src/components/combobox/_variables.scss
@@ -6,4 +6,4 @@ $combobox-color-text-selected: var(--fkds-color-text-inverted);
 $combobox-color-text: var(--fkds-color-text-primary);
 $combobox-color-border: var(--fkds-color-border-primary);
 $combobox-f-icon-arrow-down-color-content-default: var(--fkds-icon-color-action-content-primary-default);
-$combobox-f-icon-arrow-down-color-content-disabled: var(--fkds-icon-color-action-content-primary-disabled);
+$combobox-f-icon-arrow-down-color-content-disabled: var(--fkds-icon-color-content-disabled);

--- a/packages/design/src/components/select-field/_variables.scss
+++ b/packages/design/src/components/select-field/_variables.scss
@@ -13,6 +13,6 @@ $selectfield-color-background-focus: var(--fkds-color-background-primary);
 $selectfield-color-background-disabled: var(--fkds-color-background-disabled);
 
 // BORDER
-$selectfield-color-border-disabled: var(--fkds-color-border-primary);
+$selectfield-color-border-disabled: var(--fkds-color-border-disabled);
 $selectfield-color-border-default: var(--fkds-color-border-primary);
 $selectfield-color-border-error: var(--fkds-color-feedback-border-negative);

--- a/packages/design/src/components/text-field/_variables.scss
+++ b/packages/design/src/components/text-field/_variables.scss
@@ -4,7 +4,7 @@ $textfield-color-background-disabled: var(--fkds-color-background-disabled);
 
 // BORDER
 $textfield-color-border-default: var(--fkds-color-border-primary);
-$textfield-color-border-disabled: var(--fkds-color-border-primary);
+$textfield-color-border-disabled: var(--fkds-color-border-disabled);
 $textfield-color-border-error: var(--fkds-color-feedback-border-negative);
 
 // ICON

--- a/packages/design/src/components/textarea-field/_variables.scss
+++ b/packages/design/src/components/textarea-field/_variables.scss
@@ -4,7 +4,7 @@ $textareafield-color-background-disabled: var(--fkds-color-background-disabled);
 
 // BORDER
 $textareafield-color-border-default: var(--fkds-color-border-primary);
-$textareafield-color-border-disabled: var(--fkds-color-border-primary);
+$textareafield-color-border-disabled: var(--fkds-color-border-disabled);
 $textareafield-color-border-error: var(--fkds-color-feedback-border-negative);
 
 // TEXT

--- a/packages/design/src/core/mixins/_variables.scss
+++ b/packages/design/src/core/mixins/_variables.scss
@@ -1,4 +1,4 @@
 $button-color-border-default: transparent;
-$button-color-background-disabled: var(--fkds-color-action-background-disabled);
-$button-color-border-disabled: var(--fkds-color-action-border-disabled);
-$button-color-text-disabled: var(--fkds-color-action-text-disabled);
+$button-color-background-disabled: var(--fkds-color-background-disabled);
+$button-color-border-disabled: var(--fkds-color-border-disabled);
+$button-color-text-disabled: var(--fkds-color-text-disabled);

--- a/packages/theme-default/src/_semantic-tokens.scss
+++ b/packages/theme-default/src/_semantic-tokens.scss
@@ -2,9 +2,9 @@
 
 @mixin css-variables {
     // TEXT
-    --fkds-color-text-primary: #{$palette-color-fk-black-100}; /* Standard text färg */
+    --fkds-color-text-primary: #{$palette-color-fk-black-100};
     --fkds-color-text-secondary: #{$palette-color-fk-black-70};
-    --fkds-color-text-inverted: #{$palette-color-white-100}; /* Inverterad text färg */
+    --fkds-color-text-inverted: #{$palette-color-white-100};
     --fkds-color-text-disabled: #{$palette-color-fk-black-50};
 
     // BACKGROUND
@@ -21,6 +21,7 @@
     --fkds-color-border-primary: #{$palette-color-fk-black-50};
     --fkds-color-border-strong: #{$palette-color-fk-black-70};
     --fkds-color-border-weak: #{$palette-color-fk-black-15};
+    --fkds-color-border-disabled: #{$palette-color-fk-black-50};
 
     // ACTION - TEXT
     --fkds-color-action-text-primary-default: #{$palette-color-bluebell-100};
@@ -35,7 +36,6 @@
     --fkds-color-action-text-inverted-hover: #{$palette-color-white-100};
     --fkds-color-action-text-inverted-active: #{$palette-color-white-100};
     --fkds-color-action-text-inverted-focus: #{$palette-color-white-100};
-    --fkds-color-action-text-disabled: #{$palette-color-fk-black-50};
 
     // ACTION - BACKGROUND
     --fkds-color-action-background-primary-default: #{$palette-color-bluebell-100};
@@ -46,22 +46,12 @@
     --fkds-color-action-background-secondary-hover: #{$palette-color-bluebell-15};
     --fkds-color-action-background-secondary-active: #{$palette-color-bluebell-15};
     --fkds-color-action-background-secondary-focus: #{$palette-color-bluebell-15};
-    --fkds-color-action-background-accent-default: #{$palette-color-green-a-100};
-    --fkds-color-action-background-accent-hover: #{$palette-color-green-a-120};
-    --fkds-color-action-background-accent-active: #{$palette-color-green-a-120};
-    --fkds-color-action-background-accent-focus: #{$palette-color-green-a-120};
-    --fkds-color-action-background-disabled: #{$palette-color-fk-black-5};
 
     // ACTION - BORDER
     --fkds-color-action-border-primary-default: #{$palette-color-bluebell-100};
     --fkds-color-action-border-primary-hover: #{$palette-color-bluebell-120};
     --fkds-color-action-border-primary-active: #{$palette-color-bluebell-120};
     --fkds-color-action-border-primary-focus: #{$palette-color-bluebell-120};
-    --fkds-color-action-border-accent-default: #{$palette-color-green-a-100};
-    --fkds-color-action-border-accent-hover: #{$palette-color-green-a-120};
-    --fkds-color-action-border-accent-active: #{$palette-color-green-a-120};
-    --fkds-color-action-border-accent-focus: #{$palette-color-green-a-120};
-    --fkds-color-action-border-disabled: #{$palette-color-fk-black-50};
 
     // FEEDBACK - BACKGROUND
     --fkds-color-feedback-background-neutral: #{$palette-color-fk-black-5};
@@ -101,7 +91,6 @@
 
     // ICON - ACTION
     --fkds-icon-color-action-content-primary-default: #{$palette-color-bluebell-100};
-    --fkds-icon-color-action-content-primary-disabled: #{$palette-color-fk-black-50};
     --fkds-icon-color-action-content-primary-hover: #{$palette-color-bluebell-120};
     --fkds-icon-color-action-content-primary-active: #{$palette-color-bluebell-120};
     --fkds-icon-color-action-content-primary-focus: #{$palette-color-bluebell-120};
@@ -109,13 +98,11 @@
     --fkds-icon-color-action-content-secondary-hover: #{$palette-color-bluebell-120};
     --fkds-icon-color-action-content-secondary-active: #{$palette-color-bluebell-120};
     --fkds-icon-color-action-content-secondary-focus: #{$palette-color-bluebell-120};
-    --fkds-icon-color-action-content-accent-default: #{$palette-color-green-a-100};
-    --fkds-icon-color-action-content-accent-hover: #{$palette-color-green-a-120};
-    --fkds-icon-color-action-content-accent-active: #{$palette-color-green-a-120};
-    --fkds-icon-color-action-content-accent-focus: #{$palette-color-green-a-120};
     --fkds-icon-color-action-content-weak-default: #{$palette-color-fk-black-70};
     --fkds-icon-color-action-content-inverted-default: #{$palette-color-white-100};
     --fkds-icon-color-action-content-inverted-hover: #{$palette-color-white-100};
+    --fkds-icon-color-action-content-inverted-active: #{$palette-color-white-100};
+    --fkds-icon-color-action-content-inverted-focus: #{$palette-color-white-100};
 
     // ICON - FEEDBACK
     --fkds-icon-color-feedback-content-info: #{$palette-color-fk-black-100};

--- a/packages/theme-default/src/deprecated-variables.json
+++ b/packages/theme-default/src/deprecated-variables.json
@@ -146,5 +146,9 @@
     "--f-background-warning",
     "--f-background-modal-shelf",
     "--f-border-color-info",
-    "--f-border-color-warning"
+    "--f-border-color-warning",
+    "--fkds-color-action-text-disabled",
+    "--fkds-color-action-background-disabled",
+    "--fkds-color-action-border-disabled",
+    "--fkds-icon-color-action-content-primary-disabled"
 ]

--- a/packages/theme-default/src/fkui-css-variables-deprecated.scss
+++ b/packages/theme-default/src/fkui-css-variables-deprecated.scss
@@ -249,6 +249,12 @@ $palette-color-hav-20: #dbe0ec !default;
     --f-background-modal-shelf: #{$palette-color-white-100};
     --f-border-color-info: #{$palette-color-bluebell-100};
     --f-border-color-warning: #{$palette-color-yellow-100};
+
+    // Deprecated since 6.8.0
+    --fkds-color-action-text-disabled: #{$palette-color-fk-black-50};
+    --fkds-color-action-background-disabled: #{$palette-color-fk-black-5};
+    --fkds-color-action-border-disabled: #{$palette-color-fk-black-50};
+    --fkds-icon-color-action-content-primary-disabled: #{$palette-color-fk-black-50};
 }
 
 @if $global {


### PR DESCRIPTION
**Added and removed semantic tokens for colors and state disabled.**
New variable:
 --fkds-color-border-disabled
 
Deprecated:
--fkds-color-action-background-disabled
--fkds-color-action-border-disabled
--fkds-icon-color-action-content-primary-disable

Updated Button (and mixin) and Combobox according to above changes.
 
**Removed all semantic tokens for accent-color.** (not used by any component)