### PR TITLE
docs: group table live example options (refs SFKUI-7153)

### DIFF
--- a/packages/vue/src/components/FDataTable/examples/FDataTableLiveExample.vue
+++ b/packages/vue/src/components/FDataTable/examples/FDataTableLiveExample.vue
@@ -124,13 +124,35 @@ export default defineComponent({
 
 <template>
     <live-example :components :template :livedata>
-        <f-checkbox-field v-model="isStriped" :value="true"> Zebrarandig </f-checkbox-field>
-        <f-checkbox-field v-model="hasRowHeader" :value="true"> Radrubriker </f-checkbox-field>
-        <f-checkbox-field v-model="hasRowDescription" :value="true">
-            Kolumnbeskrivnig
-        </f-checkbox-field>
-        <f-checkbox-field v-model="hasHiddenCaption" :value="true"> Dold caption </f-checkbox-field>
-        <f-checkbox-field v-model="isEmpty" :value="true"> Tom tabell </f-checkbox-field>
+        <!-- Styling -->
+        <f-fieldset name="styling">
+            <template #label> Styling </template>
+            <f-checkbox-field v-model="isStriped" :value="true"> Zebrarandig </f-checkbox-field>
+            <f-checkbox-field v-model="hasRowHeader" :value="true"> Radrubriker </f-checkbox-field>
+            <f-checkbox-field v-model="hasRowDescription" :value="true">
+                Kolumnbeskrivnig
+            </f-checkbox-field>
+            <f-checkbox-field v-model="hasHiddenCaption" :value="true">
+                Dold caption
+            </f-checkbox-field>
+        </f-fieldset>
+
+        <!-- Interaktion -->
+        <f-fieldset name="interaktion">
+            <template #label> Interaktion </template>
+            <f-checkbox-field v-model="isEmpty" :value="true"> Tom tabell </f-checkbox-field>
+            <f-fieldset v-if="isEmpty" name="radio-empty-text">
+                <template #label> Meddelande för tom tabell </template>
+                <f-radio-field v-model="hasCustomEmptyText" :value="false">
+                    Standardmeddelande
+                </f-radio-field>
+                <f-radio-field v-model="hasCustomEmptyText" :value="true">
+                    Eget meddelande
+                </f-radio-field>
+            </f-fieldset>
+        </f-fieldset>
+
+        <!-- Skroll-->
         <f-select-field v-model="scroll">
             <template #label> Skroll </template>
             <template #default>
@@ -140,14 +162,5 @@ export default defineComponent({
                 <option value="both">Båda</option>
             </template>
         </f-select-field>
-        <f-fieldset v-if="isEmpty" name="radio-empty-text">
-            <template #label> Meddelande för tom tabell </template>
-            <f-radio-field v-model="hasCustomEmptyText" :value="false">
-                Standardmeddelande
-            </f-radio-field>
-            <f-radio-field v-model="hasCustomEmptyText" :value="true">
-                Eget meddelande
-            </f-radio-field>
-        </f-fieldset>
     </live-example>
 </template>

--- a/packages/vue/src/components/FInteractiveTable/examples/FInteractiveTableLiveExample.vue
+++ b/packages/vue/src/components/FInteractiveTable/examples/FInteractiveTableLiveExample.vue
@@ -244,34 +244,49 @@ export default defineComponent({
 
 <template>
     <live-example :components="components" :template="template" :livedata="livedata">
-        <f-checkbox-field v-model="isSelectable" :value="true"> Valbara rader </f-checkbox-field>
-        <f-checkbox-field v-model="isExpandable" :value="true">
-            Expanderbara rader
-        </f-checkbox-field>
-        <f-fieldset v-if="isExpandable" name="radio-expandable-type">
-            <template #label> Typ av expanderat innehåll </template>
-            <f-radio-field v-model="hasCustomExpandContent" :value="false">
-                Tabellrad
-            </f-radio-field>
-            <f-radio-field v-model="hasCustomExpandContent" :value="true">
-                Valfritt innehåll
-            </f-radio-field>
+        <!-- Styling -->
+        <f-fieldset name="styling">
+            <template #label> Styling </template>
+            <f-checkbox-field v-model="hasHover" :value="true"> Hover </f-checkbox-field>
+            <f-checkbox-field v-model="isStriped" :value="true"> Zebrarandig </f-checkbox-field>
+            <f-checkbox-field v-model="hasRowHeader" :value="true"> Radrubriker </f-checkbox-field>
+            <f-checkbox-field v-model="hasHiddenCaption" :value="true">
+                Dold caption
+            </f-checkbox-field>
+            <f-checkbox-field v-model="showActiveRow" :value="true">
+                Visa aktiv rad
+            </f-checkbox-field>
         </f-fieldset>
-        <f-checkbox-field v-model="hasHover" :value="true"> Hover </f-checkbox-field>
-        <f-checkbox-field v-model="isStriped" :value="true"> Zebrarandig </f-checkbox-field>
-        <f-checkbox-field v-model="hasActions" :value="true"> Åtgärdsknappar </f-checkbox-field>
-        <f-checkbox-field v-model="hasRowHeader" :value="true"> Radrubriker </f-checkbox-field>
-        <f-checkbox-field v-model="hasHiddenCaption" :value="true"> Dold caption </f-checkbox-field>
-        <f-checkbox-field v-model="isEmpty" :value="true"> Tom tabell </f-checkbox-field>
-        <f-fieldset v-if="isEmpty" name="radio-empty-text">
-            <template #label> Meddelande för tom tabell </template>
-            <f-radio-field v-model="hasCustomEmptyText" :value="false">
-                Standardmeddelande
-            </f-radio-field>
-            <f-radio-field v-model="hasCustomEmptyText" :value="true">
-                Eget meddelande
-            </f-radio-field>
+
+        <!-- Interaktion -->
+        <f-fieldset name="interaktion">
+            <template #label> Interaktion </template>
+            <f-checkbox-field v-model="isSelectable" :value="true">
+                Valbara rader
+            </f-checkbox-field>
+            <f-checkbox-field v-model="isExpandable" :value="true">
+                Expanderbara rader
+            </f-checkbox-field>
+            <f-fieldset v-if="isExpandable" name="radio-expandable-type">
+                <template #label> Typ av expanderat innehåll </template>
+                <f-radio-field v-model="hasCustomExpandContent" :value="false">
+                    Tabellrad
+                </f-radio-field>
+                <f-radio-field v-model="hasCustomExpandContent" :value="true">
+                    Valfritt innehåll
+                </f-radio-field>
+            </f-fieldset>
+            <f-checkbox-field v-model="hasActions" :value="true"> Åtgärdsknappar </f-checkbox-field>
+            <f-checkbox-field v-model="isEmpty" :value="true"> Tom tabell </f-checkbox-field>
+            <f-fieldset v-if="isEmpty" name="radio-empty-text">
+                <template #label> Meddelande för tom tabell </template>
+                <f-radio-field v-model="hasCustomEmptyText" :value="false">
+                    Standardmeddelande
+                </f-radio-field>
+                <f-radio-field v-model="hasCustomEmptyText" :value="true">
+                    Eget meddelande
+                </f-radio-field>
+            </f-fieldset>
         </f-fieldset>
-        <f-checkbox-field v-model="showActiveRow" :value="true"> Visa aktiv rad </f-checkbox-field>
     </live-example>
 </template>


### PR DESCRIPTION
Denna PR är splittrad från #458 som exploderade när jag försökte mig på `git rebase`.

# Ändringar
Grupperat alternativ för dessa liveexempel:

- Datatabell (https://forsakringskassan.github.io/designsystem/pr-preview/pr-469/components/table-and-list/table.html#datatabell)
- Interaktiv tabell (https://forsakringskassan.github.io/designsystem/pr-preview/pr-469/components/table-and-list/table.html#interaktiv_tabell)