### PR TITLE
docs: add option `Visa aktiv rad` in interactive table live example (refs SFKUI-7153)

### DIFF
--- a/packages/vue/src/components/FInteractiveTable/examples/FInteractiveTableLiveExample.vue
+++ b/packages/vue/src/components/FInteractiveTable/examples/FInteractiveTableLiveExample.vue
@@ -27,6 +27,7 @@ export default defineComponent({
             hasCustomExpandContent: false,
             hasHover: false,
             emptyItems: [],
+            showActiveRow: false,
         };
     },
     computed: {
@@ -204,6 +205,7 @@ export default defineComponent({
                     ${this.hover}
                     ${this.selectable}
                     ${this.expandable}
+                    ${this.showActive}
                     key-attribute="id"
                 >
                     <template #caption> ${this.caption} </template>
@@ -232,6 +234,9 @@ export default defineComponent({
                     ${this.empty}
                 </f-interactive-table>
             `;
+        },
+        showActive(): string {
+            return this.showActiveRow ? "" : `:showActive="false"`;
         },
     },
 });
@@ -267,5 +272,6 @@ export default defineComponent({
                 Eget meddelande
             </f-radio-field>
         </f-fieldset>
+        <f-checkbox-field v-model="showActiveRow" :value="true"> Visa aktiv rad </f-checkbox-field>
     </live-example>
 </template>


### PR DESCRIPTION
Denna PR är splittrad från #458 som exploderade när jag försökte mig på `git rebase`.

# Ändringar
Lagt till alternativet `Visa aktiv rad` i liveexemplet för interaktiv tabell (https://forsakringskassan.github.io/designsystem/pr-preview/pr-470/components/table-and-list/table.html#interaktiv_tabell)