### PR TITLE
feat: update semantic tokens for select (refs SFKUI-7236)

### DIFF
--- a/packages/design/src/components/chip/_variables.scss
+++ b/packages/design/src/components/chip/_variables.scss
@@ -6,9 +6,9 @@ $chip-color-text-hover: var(--fkds-color-text-primary);
 
 // BACKGROUND
 $chip-color-background-default: var(--fkds-color-background-primary);
-$chip-color-background-selected: var(--fkds-color-select-background-primary-default);
+$chip-color-background-selected: var(--fkds-color-select-background-secondary-default);
 $chip-color-background-disabled: var(--fkds-color-background-disabled);
-$chip-color-background-hover: var(--fkds-color-select-background-primary-hover);
+$chip-color-background-hover: var(--fkds-color-select-background-secondary-hover);
 
 // BORDER
 $chip-color-border-default: var(--fkds-color-border-primary);

--- a/packages/theme-default/src/_semantic-tokens.scss
+++ b/packages/theme-default/src/_semantic-tokens.scss
@@ -13,10 +13,6 @@
     --fkds-color-background-tertiary: #{$palette-color-fk-black-15};
     --fkds-color-background-disabled: #{$palette-color-fk-black-5};
 
-    // BACKGROUND - ACTION
-    --fkds-color-action-background-select-hover: #{$palette-color-green-a-15};
-    --fkds-color-action-background-select-default: #{$palette-color-green-a-85};
-
     // BORDER
     --fkds-color-border-primary: #{$palette-color-fk-black-50};
     --fkds-color-border-strong: #{$palette-color-fk-black-70};
@@ -77,10 +73,14 @@
     --fkds-color-feedback-text-positive: #{$palette-color-green-a-85};
 
     // SELECT - BACKGROUND
-    --fkds-color-select-background-primary-default: #{$palette-color-green-a-85};
-    --fkds-color-select-background-primary-hover: #{$palette-color-green-a-15};
-    --fkds-color-select-background-primary-active: #{$palette-color-green-a-15};
-    --fkds-color-select-background-primary-focus: #{$palette-color-green-a-15};
+    --fkds-color-select-background-primary-default: #{$palette-color-bluebell-100};
+    --fkds-color-select-background-primary-hover: #{$palette-color-bluebell-15};
+    --fkds-color-select-background-primary-active: #{$palette-color-bluebell-15};
+    --fkds-color-select-background-primary-focus: #{$palette-color-bluebell-15};
+    --fkds-color-select-background-secondary-default: #{$palette-color-green-a-85};
+    --fkds-color-select-background-secondary-hover: #{$palette-color-green-a-15};
+    --fkds-color-select-background-secondary-active: #{$palette-color-green-a-15};
+    --fkds-color-select-background-secondary-focus: #{$palette-color-green-a-15};
 
     // ICON
     --fkds-icon-color-content-primary: #{$palette-color-fk-black-100};

--- a/packages/theme-default/src/deprecated-variables.json
+++ b/packages/theme-default/src/deprecated-variables.json
@@ -150,5 +150,7 @@
     "--fkds-color-action-text-disabled",
     "--fkds-color-action-background-disabled",
     "--fkds-color-action-border-disabled",
-    "--fkds-icon-color-action-content-primary-disabled"
+    "--fkds-icon-color-action-content-primary-disabled",
+    "--fkds-color-action-background-select-hover",
+    "--fkds-color-action-background-select-default"
 ]

--- a/packages/theme-default/src/fkui-css-variables-deprecated.scss
+++ b/packages/theme-default/src/fkui-css-variables-deprecated.scss
@@ -255,6 +255,10 @@ $palette-color-hav-20: #dbe0ec !default;
     --fkds-color-action-background-disabled: #{$palette-color-fk-black-5};
     --fkds-color-action-border-disabled: #{$palette-color-fk-black-50};
     --fkds-icon-color-action-content-primary-disabled: #{$palette-color-fk-black-50};
+
+    // Deprecated since 6.9.0
+    --fkds-color-action-background-select-hover: #{$palette-color-green-a-15};
+    --fkds-color-action-background-select-default: #{$palette-color-green-a-85};
 }
 
 @if $global {


### PR DESCRIPTION
Deprekerat semantiska färgvariabler:
```
--fkds-color-action-background-select-hover
--fkds-color-action-background-select-default
```

Infört nya:
```
 --fkds-color-select-background-secondary-default
 --fkds-color-select-background-secondary-hover
 --fkds-color-select-background-secondary-active
 --fkds-color-select-background-secondary-focus
```
Ändrat Chip till att använda ...-secondary-default.