### PR TITLE
refactor: remove usage of button--discrete

### DIFF
--- a/cypress/pageobjects/wizardstep/MyOrderWizardStep.pageobject.ts
+++ b/cypress/pageobjects/wizardstep/MyOrderWizardStep.pageobject.ts
@@ -9,6 +9,6 @@ export class MyOrderWizardStepPageobject extends FWizardStepPageobject {
         super(selector);
 
         this.addBasket = () =>
-            cy.get(`${this.selector} button.button--discrete`);
+            cy.get(`${this.selector} button.button--tertiary`);
     }
 }

--- a/docs/templates/partials/selectable-version.html
+++ b/docs/templates/partials/selectable-version.html
@@ -8,7 +8,7 @@
     <dialog id="version-dialog">
         <div id="version-dialog-head">
             <h1>Välj version</h1>
-            <button type="button" class="button button--discrete button--discrete--black">
+            <button type="button" class="button button--tertiary button--tertiary--black">
                 <span>Stäng</span>
                 <svg class="button__icon icon f-icon-close" focusable="false" aria-hidden>
                     <use href="#f-icon-close"></use>

--- a/packages/vue/htmlvalidate/rules/classdeprecated.rule.js
+++ b/packages/vue/htmlvalidate/rules/classdeprecated.rule.js
@@ -1,25 +1,55 @@
 const { Rule, DOMTokenList } = require("html-validate");
 const { getDocumentationUrl } = require("./common");
 
+/**
+ * @typedef {import("html-validate").RuleDocumentation} RuleDocumentation
+ */
+
+/**
+ * @typedef {Object} Entry
+ * @property {string} name
+ * @property {string} [replacement]
+ * @property {string} [additionalMessage]
+ * @property {string} url
+ */
+
+/** @type {Entry[]} */
 const deprecatedClasses = [
     {
         name: "navbar",
-        description:
-            "`.navbar` and related classes are deprecated and should be replaced with Vue components `FPageHeader` and `FNavigationMenu` or their HTML and style.",
+        additionalMessage:
+            "It should be replaced with the Vue components `FPageHeader` and `FNavigationMenu`.",
         url: "/components/page-layout/fpageheader.html",
     },
     {
         name: "button--text",
-        description:
-            "`.button--text` class is deprecated and should be replaced with `button--discrete`",
+        replacement: "button--tertiary",
+        url: "/components/button.html",
+    },
+    {
+        name: "button--discrete",
+        replacement: "button--tertiary",
         url: "/components/button.html",
     },
 ];
 
+/**
+ * @extends {Rule<Entry, void>}
+ */
 class ClassDeprecated extends Rule {
-    documentation({ description, url }) {
+    /**
+     * @param {Entry} context
+     * @returns {RuleDocumentation}
+     */
+    documentation(context) {
+        const { url, replacement, additionalMessage } = context;
+        const message = replacement
+            ? `Class \`${context.name}\` is deprecated and should be replaced with \`${replacement}\``
+            : `Class \`${context.name}\` is deprecated.`;
         return {
-            description,
+            description: additionalMessage
+                ? `${message}\n\n${additionalMessage}`
+                : message,
             url: getDocumentationUrl(url),
         };
     }
@@ -35,16 +65,18 @@ class ClassDeprecated extends Rule {
             const tokens = new DOMTokenList(event.value, valueLocation);
 
             for (const { item, location } of tokens.iterator()) {
-                for (const deprecatedClass of deprecatedClasses) {
-                    if (deprecatedClass.name !== item) {
+                for (const entry of deprecatedClasses) {
+                    if (entry.name !== item) {
                         continue;
                     }
 
                     this.report({
                         node: event.target,
                         location,
-                        message: "`.{{ name }}` class is deprecated.",
-                        context: deprecatedClass,
+                        message: entry.replacement
+                            ? `class "{{ name }}" is deprecated and replaced with "{{ replacement }}"`
+                            : `class "{{ name }}" is deprecated`,
+                        context: entry,
                     });
                 }
             }

--- a/packages/vue/htmlvalidate/rules/classdeprecated.spec.ts
+++ b/packages/vue/htmlvalidate/rules/classdeprecated.spec.ts
@@ -7,79 +7,101 @@ const htmlvalidate = new HtmlValidate({
     rules: { "fkui/class-deprecated": "error" },
 });
 
-it("should not report warning on missing class", async () => {
+it("should not report error on missing class", async () => {
     expect.assertions(1);
     const markup = /* HTML */ ` <div></div> `;
     const report = await htmlvalidate.validateString(markup);
     expect(report).toBeValid();
 });
 
-it("should not report warning on empty class", async () => {
+it("should not report error on empty class", async () => {
     expect.assertions(1);
     const markup = /* HTML */ ` <div class></div> `;
     const report = await htmlvalidate.validateString(markup);
     expect(report).toBeValid();
 });
 
-it("should not report warning on `v-bind:class`", async () => {
+it("should not report error on `v-bind:class`", async () => {
     expect.assertions(1);
     const markup = /* HTML */ `
         <div :class></div>
+        <div :class="navbar"></div>
         <div v-bind:class></div>
+        <div v-bind:class="navbar"></div>
     `;
     const report = await htmlvalidate.validateString(markup);
     expect(report).toBeValid();
 });
 
-describe("`.button--text`", () => {
-    it("should report warning when `.button--text` is used instead of `.button--discrete`", async () => {
-        expect.assertions(2);
-        const markup = /* HTML */ `
-            <button type="button" class="button button--text"></button>
-        `;
-        const report = await htmlvalidate.validateString(markup);
-        expect(report).toBeInvalid();
-        expect(report).toMatchInlineCodeframe(`
-            "error: \`.button--text\` class is deprecated (fkui/class-deprecated) at inline:2:49:
-              1 |
-            > 2 |             <button type="button" class="button button--text"></button>
-                |                                                 ^^^^^^^^^^^^
-              3 |
-            Selector: button"
-        `);
-    });
-
-    it("should not report warning when `.button--discrete` is used instead of `.button--text`", async () => {
-        expect.assertions(1);
-        const markup = /* HTML */ `
-            <button type="button" class="button button--discrete"></button>
-        `;
-        const report = await htmlvalidate.validateString(markup);
-        expect(report).toBeValid();
-    });
+it("should not report error when non-deprecated class is used", async () => {
+    expect.assertions(1);
+    const markup = /* HTML */ `
+        <button type="button" class="button button--tertiary"></button>
+    `;
+    const report = await htmlvalidate.validateString(markup);
+    expect(report).toBeValid();
 });
 
-describe("`.navbar`", () => {
-    it("should report warning when `.navbar` is used", async () => {
-        expect.assertions(2);
-        const markup = /* HTML */ ` <div class="custom-navbar navbar"></div> `;
-        const report = await htmlvalidate.validateString(markup);
-        expect(report).toBeInvalid();
-        expect(report).toMatchInlineCodeframe(`
-            "error: \`.navbar\` class is deprecated (fkui/class-deprecated) at inline:1:28:
-            > 1 |  <div class="custom-navbar navbar"></div>
-                |                            ^^^^^^
-            Selector: div"
-        `);
-    });
+it("should report error when `.button--text` is used", async () => {
+    expect.assertions(3);
+    const markup = /* HTML */ `
+        <button type="button" class="button button--text"></button>
+    `;
+    const report = await htmlvalidate.validateString(markup);
+    expect(report).toBeInvalid();
+    expect(report).toMatchInlineCodeframe(`
+        "error: class "button--text" is deprecated and replaced with "button--tertiary" (fkui/class-deprecated) at inline:2:45:
+          1 |
+        > 2 |         <button type="button" class="button button--text"></button>
+            |                                             ^^^^^^^^^^^^
+          3 |
+        Selector: button"
+    `);
+    const error = report.results[0].messages[0];
+    const docs = await htmlvalidate.getContextualDocumentation(error);
+    expect(docs?.description).toMatchInlineSnapshot(
+        `"Class \`button--text\` is deprecated and should be replaced with \`button--tertiary\`"`,
+    );
+});
 
-    it("should not report warning when `navbar` is used with `v-bind:class`", async () => {
-        expect.assertions(1);
-        const markup = /* HTML */ `
-            <div :class="navbar"></div>
-            <div v-bind:class="navbar"></div>
-        `;
-        const report = await htmlvalidate.validateString(markup);
-        expect(report).toBeValid();
-    });
+it("should report error when `.button--discrete` is used", async () => {
+    expect.assertions(3);
+    const markup = /* HTML */ `
+        <button type="button" class="button button--discrete"></button>
+    `;
+    const report = await htmlvalidate.validateString(markup);
+    expect(report).toBeInvalid();
+    expect(report).toMatchInlineCodeframe(`
+        "error: class "button--discrete" is deprecated and replaced with "button--tertiary" (fkui/class-deprecated) at inline:2:45:
+          1 |
+        > 2 |         <button type="button" class="button button--discrete"></button>
+            |                                             ^^^^^^^^^^^^^^^^
+          3 |
+        Selector: button"
+    `);
+    const error = report.results[0].messages[0];
+    const docs = await htmlvalidate.getContextualDocumentation(error);
+    expect(docs?.description).toMatchInlineSnapshot(
+        `"Class \`button--discrete\` is deprecated and should be replaced with \`button--tertiary\`"`,
+    );
+});
+
+it("should report error when `.navbar` is used", async () => {
+    expect.assertions(3);
+    const markup = /* HTML */ ` <div class="custom-navbar navbar"></div> `;
+    const report = await htmlvalidate.validateString(markup);
+    expect(report).toBeInvalid();
+    expect(report).toMatchInlineCodeframe(`
+        "error: class "navbar" is deprecated (fkui/class-deprecated) at inline:1:28:
+        > 1 |  <div class="custom-navbar navbar"></div>
+            |                            ^^^^^^
+        Selector: div"
+    `);
+    const error = report.results[0].messages[0];
+    const docs = await htmlvalidate.getContextualDocumentation(error);
+    expect(docs?.description).toMatchInlineSnapshot(`
+        "Class \`navbar\` is deprecated.
+
+        It should be replaced with the Vue components \`FPageHeader\` and \`FNavigationMenu\`."
+    `);
 });

--- a/packages/vue/src/components/FCard/FCard.cy.ts
+++ b/packages/vue/src/components/FCard/FCard.cy.ts
@@ -30,14 +30,14 @@ function createComponent(): DefineComponent {
                 <template #footer>
                     <div class="button-group">
                         <button
-                            class="button button-group__item button--discrete"
+                            class="button button-group__item button--tertiary"
                             type="button"
                         >
                             <span> Ta bort </span>
                         </button>
 
                         <button
-                            class="button button-group__item button--discrete"
+                            class="button button-group__item button--tertiary"
                             type="button"
                         >
                             <span> Ändra </span>

--- a/packages/vue/src/components/FDatepickerField/FDatepickerField.vue
+++ b/packages/vue/src/components/FDatepickerField/FDatepickerField.vue
@@ -404,6 +404,7 @@ export default defineComponent({
                 </f-calendar>
 
                 <div class="datepicker-field__close">
+                    <!-- [html-validate-disable-next fkui/class-deprecated -- technical debt] -->
                     <button
                         class="button button--discrete button--discrete--black datepicker-field__close__button"
                         type="button"

--- a/packages/vue/src/components/FFileItem/FFileItem.cy.ts
+++ b/packages/vue/src/components/FFileItem/FFileItem.cy.ts
@@ -43,7 +43,7 @@ describe("FFileItem", () => {
                         <button
                             v-if="progress < 100"
                             type="button"
-                            class="button button--discrete file-item__file-remove file-item__abort"
+                            class="button button--tertiary file-item__file-remove file-item__abort"
                         >
                             <f-icon name="close" class="button__icon"></f-icon>
                             <span> Avbryt uppladdning </span>
@@ -51,7 +51,7 @@ describe("FFileItem", () => {
                         <button
                             v-else-if="progress === 100"
                             type="button"
-                            class="button button--discrete file-item__file-remove"
+                            class="button button--tertiary file-item__file-remove"
                         >
                             <f-icon
                                 name="trashcan"

--- a/packages/vue/src/components/FLoader/examples/FLoaderExample.vue
+++ b/packages/vue/src/components/FLoader/examples/FLoaderExample.vue
@@ -62,7 +62,7 @@ export default defineComponent({
             <button
                 v-test="'loader-toggle'"
                 type="button"
-                class="button button--discrete"
+                class="button button--tertiary"
                 @click="toggleLoader()"
             >
                 Toggla loader
@@ -70,7 +70,7 @@ export default defineComponent({
             <button
                 v-test="'loader-toggle-overlay'"
                 type="button"
-                class="button button--discrete"
+                class="button button--tertiary"
                 :disabled="Boolean(show)"
                 @click="toggleOverlay()"
             >
@@ -79,7 +79,7 @@ export default defineComponent({
             <button
                 v-test="'loader-toggle-delay'"
                 type="button"
-                class="button button--discrete"
+                class="button button--tertiary"
                 @click="toggleDelay()"
             >
                 Toggla delay
@@ -87,7 +87,7 @@ export default defineComponent({
             <button
                 v-test="'loader-toggle-text'"
                 type="button"
-                class="button button--discrete"
+                class="button button--tertiary"
                 @click="toggleCloseText()"
             >
                 Toggla text

--- a/packages/vue/src/components/FModal/FFormModal/FFormModal.cy.ts
+++ b/packages/vue/src/components/FModal/FFormModal/FFormModal.cy.ts
@@ -24,7 +24,7 @@ const TestComponent = defineComponent({
                 </f-text-field>
                 <button
                     type="button"
-                    class="button button--discrete"
+                    class="button button--tertiary"
                     data-test="add-dynamic-button"
                     @click="addDynamicButton"
                 >

--- a/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.vue
+++ b/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.vue
@@ -256,6 +256,7 @@ function filterResultset(): void {
                                 <span class="sr-only">{{ placeholderFilter }}</span>
                             </f-text-field>
 
+                            <!-- [html-validate-disable-next fkui/class-deprecated -- technical debt] -->
                             <button
                                 v-if="showClearButton"
                                 type="button"

--- a/packages/vue/src/components/FWizard/examples/FWizardExampleAddStep.vue
+++ b/packages/vue/src/components/FWizard/examples/FWizardExampleAddStep.vue
@@ -63,7 +63,7 @@ export default defineComponent({
         >
             <f-wizard-step key="fruktkorg-antal" v-test="'myOrderStep'" title="Min beställning">
                 <h3>Fruktkorg</h3>
-                <button type="button" class="button button--discrete" @click="addBasket">
+                <button type="button" class="button button--tertiary" @click="addBasket">
                     <f-icon class="button__icon" name="plus" /> Lägg till fruktkorg
                 </button>
             </f-wizard-step>
@@ -94,7 +94,7 @@ export default defineComponent({
                     </f-checkbox-field>
                 </f-fieldset>
 
-                <button type="button" class="button button--discrete" @click="removeBasket(item)">
+                <button type="button" class="button button--tertiary" @click="removeBasket(item)">
                     <f-icon name="trashcan" /> Ta bort fruktkorg
                 </button>
             </f-wizard-step>

--- a/packages/vue/src/design-component-tests/Button/examples/ButtonButtonGroupFullWidthExample.vue
+++ b/packages/vue/src/design-component-tests/Button/examples/ButtonButtonGroupFullWidthExample.vue
@@ -113,14 +113,14 @@ export default defineComponent({
                 <f-icon name="paper-clip" class="button__icon"></f-icon> Tertiary
             </button>
             <button
-                class="button button--discrete button-group__item"
+                class="button button--tertiary button-group__item"
                 :class="useFullWidth ? 'button--full-width' : ''"
                 type="button"
             >
                 Discrete
             </button>
             <button
-                class="button button--discrete-inverted button-group__item"
+                class="button button--tertiary-inverted button-group__item"
                 :class="useFullWidth ? 'button--full-width' : ''"
                 type="button"
             >

--- a/packages/vue/src/internal-components/IPopupError/IPopupError.vue
+++ b/packages/vue/src/internal-components/IPopupError/IPopupError.vue
@@ -163,6 +163,7 @@ export default defineComponent({
                     <!-- `tabindex="-1" is set since `IPopupError` has `aria-hidden`, wich cannot be used on focusable elements.
                         `IPopupError` will be closed on input-field `blur`, so the button is never focusable anyway .
                     -->
+                    <!-- [html-validate-disable-next fkui/class-deprecated -- technical debt] -->
                     <button
                         tabindex="-1"
                         type="button"


### PR DESCRIPTION
**EDIT:** tog bort allt kontroversiellt och nu är det bara testfall, exempel osv som är inkluderat här. Lägger ny PR senare med kontroversiella ändringar.

Regressionstestning:

* [x] ~~Filpresentatör (FFileItem) - OK~~
* [x] Datamängdsorterare (FSortFilterDataset) - OK
* [x] Datumväljare (FDatepickerField) - annan font-weight, hover skiljer - OK
* [x] Laddningsindikator (FLoader), dokumentation inte produktionskod - OK
* [x] Steg för steg (FWizard), dokumentation inte produktionskod - OK
* [x] Knapp - OK
* [x] Inmatningsfält i tabell - hover skiljer  - OK