### PR TITLE
fix: FInteractiveTable focus correct interactable on delete (fixes SFKUI-5257)

### DIFF
--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
@@ -365,15 +365,6 @@ onMounted(() => {
     registerCallbackBeforeItemDelete(callbackBeforeItemDelete);
 });
 
-function forceRepaintIE11(target: HTMLElement): void {
-    if (navigator.userAgent.includes("Trident")) {
-        target.style.display = "none";
-        /* eslint-disable-next-line @typescript-eslint/no-unused-expressions -- technical debt, this function is probably not needed any longer */
-        target.offsetHeight;
-        target.style.removeProperty("display");
-    }
-}
-
 function isActive(row: T): boolean {
     if (!props.showActive) {
         return false;
@@ -412,13 +403,7 @@ function activate(row: T, tr: HTMLElement | null): void {
         setActiveRow(row);
 
         if (tr) {
-            /* ie11: force focus on <tr> instead of <td> */
             tr.focus();
-
-            /* ie11 also needs to force repaint or the outline will not
-             * be rendered properly */
-            const td = tr.children[0] as HTMLElement;
-            forceRepaintIE11(td);
         }
     }
 }

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
@@ -502,14 +502,18 @@ function callbackBeforeItemDelete(item: T): void {
     if (internalRows.value.length === 0) {
         return;
     }
-    // Activate the item above the deleted one if it exists
+    // Focus the item above the deleted one if it exists
     let targetIndex = internalRows.value.indexOf(item) - 1;
     if (targetIndex < 0 && internalRows.value.length > 1) {
         targetIndex = 1;
     } else if (targetIndex < 0) {
         targetIndex = 0;
     }
-    activate(internalRows.value[targetIndex], tr.value[targetIndex]);
+
+    const target = tr.value[targetIndex];
+    if (target) {
+        target.focus();
+    }
 }
 
 function escapeNewlines(value: string): string {

--- a/packages/vue/src/components/FInteractiveTable/useExpandableTable.ts
+++ b/packages/vue/src/components/FInteractiveTable/useExpandableTable.ts
@@ -14,6 +14,7 @@ export interface ExpandableTable<T> {
     getExpandableDescribedby(row: T): string | undefined;
     expandableRows(row: T): T[] | undefined;
     hasExpandableContent(row: T): boolean;
+    getExpandedIndex(shallowIndex: number, rows: T[]): number;
 }
 
 type Emit<T> = ((evt: "expand", row: T) => void) &
@@ -114,6 +115,31 @@ export function useExpandableTable<T extends object>(
         return Boolean(expandableRows(row));
     }
 
+    /**
+     * Translate shallow row index to flattened row index including expandable rows.
+     */
+    function getExpandedIndex(shallowIndex: number, rows: T[]): number {
+        let expandedIndex = 0;
+
+        for (let i = 0; i < shallowIndex; i++) {
+            const row = rows[i];
+            expandedIndex++;
+
+            if (!hasExpandableContent(row)) {
+                continue;
+            }
+
+            const { length } = expandableRows(row) as T[];
+            if (length === 0) {
+                continue;
+            }
+
+            expandedIndex += length;
+        }
+
+        return expandedIndex;
+    }
+
     return {
         isExpandableTable,
         hasExpandableSlot,
@@ -124,5 +150,6 @@ export function useExpandableTable<T extends object>(
         getExpandableDescribedby,
         expandableRows,
         hasExpandableContent,
+        getExpandedIndex,
     };
 }


### PR DESCRIPTION
Ändrar fokusbeteendet vid borttaggning av rad så att den fokuserar föregående interagerbara element från den borttagna raden (eller nästa om detta inte existerar).

Har inte fått cypress att fungera för testning av fokuset (visar inget fokus), dock fungerat vid manuell testning.

- [x] Återställ sandbox efter test.