### PR TITLE
fix: use correct selector in `FWizardPageobject.turnOffAnimation()` (refs SB-4982)

### DIFF
--- a/packages/vue/src/cypress/FWizard/FWizard.pageobject.ts
+++ b/packages/vue/src/cypress/FWizard/FWizard.pageobject.ts
@@ -38,7 +38,7 @@ export class FWizardPageobject implements BasePageObject {
      * Turns off the animation att css class level.
      */
     public turnOffAnimation(): void {
-        cy.get(".wizard-step__connector").invoke("css", "transition", "none");
+        cy.get(".wizard-step__content").invoke("css", "transition", "none");
     }
 
     public constructor(selector: string) {


### PR DESCRIPTION
FWizard-pageobjektet misslyckas med att köra `turnOffAnimation` för att `.wizard-step__connector` inte hittas:
https://github.com/Forsakringskassan/designsystem/blob/398de6592c3c7a6d1e68fd4fcf524c35f7514a1d/packages/vue/src/cypress/FWizard/FWizard.pageobject.ts#L41

Jag har sökt i repot efter `wizard-step__connector` men får bara en träff och det är pageobjektet som jag får träff på.

`wizard-step__connector` har ersatts med `wizard-step__content` i https://github.com/Forsakringskassan/designsystem/blob/398de6592c3c7a6d1e68fd4fcf524c35f7514a1d/packages/vue/src/components/FWizard/FWizardStep.vue#L270 (vad jag kan tyda enligt historiken)