### PR TITLE
test: update `FInteractiveTablePageObject` (refs SFKUI-6500)

### DIFF
--- a/etc/vue-cypress.api.md
+++ b/etc/vue-cypress.api.md
@@ -339,24 +339,18 @@ export class FFormModalPageObject extends FModalPageObject implements BasePageOb
 
 // @public (undocumented)
 export class FInteractiveTablePageObject implements BasePageObject {
-    constructor(selector: string);
-    // (undocumented)
+    constructor(selector?: string);
     bodyRow(): DefaultCypressChainable;
-    // (undocumented)
     caption(): DefaultCypressChainable;
     cell(descriptor: {
         row: number;
         col: number;
     }): Cypress.Chainable<JQuery<HTMLTableCellElement>>;
     columnItem(index: number): FTableColumnPageObject;
-    // (undocumented)
-    el: () => DefaultCypressChainable;
-    // (undocumented)
+    el(): DefaultCypressChainable;
     getColumnSortedByIcon(index: number, order: "ascending" | "descending" | "unsorted"): DefaultCypressChainable;
     headerRowItem(): FTableColumnPageObject;
-    // (undocumented)
     headersRow(): DefaultCypressChainable;
-    // (undocumented)
     row(index: number): DefaultCypressChainable;
     // (undocumented)
     selector: string;

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.cy.ts
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.cy.ts
@@ -364,36 +364,3 @@ describe("when `rows` is empty", () => {
             .should("contain.text", "Amount");
     });
 });
-
-describe("FInteractiveTable pageobject", () => {
-    beforeEach(() => {
-        cy.mount(createComponent());
-    });
-
-    it("should contain caption", () => {
-        table.caption().should("contain", "Test caption");
-    });
-
-    it("should provide a page object that can access any necessary elements in table headers", () => {
-        table.headersRow().should("have.length", 2);
-
-        table
-            .headerRowItem()
-            .tableRowHeaderContent()
-            .eq(0)
-            .should("have.trimmedText", "Name");
-
-        table
-            .headerRowItem()
-            .tableRowHeaderContent()
-            .eq(1)
-            .should("have.trimmedText", "Amount");
-    });
-
-    it("should provide a page object that can access any necessary elements in a table body", () => {
-        table.bodyRow().should("have.length", 3);
-
-        table.cell({ row: 1, col: 1 }).should("contain.text", "Foo");
-        table.cell({ row: 1, col: 2 }).should("contain.text", "7");
-    });
-});

--- a/packages/vue/src/cypress/FInteractiveTable.pageobject.ts
+++ b/packages/vue/src/cypress/FInteractiveTable.pageobject.ts
@@ -6,14 +6,19 @@ import { FTableColumnPageObject } from "./FTableColumn.pageobject";
  */
 export class FInteractiveTablePageObject implements BasePageObject {
     public selector: string;
-    public el: () => DefaultCypressChainable;
 
     /**
-     * @param selector - table selector.
+     * @param selector - root element selector for `FInteractiveTable`, usually `.table`.
      */
-    public constructor(selector: string) {
+    public constructor(selector: string = ".table") {
         this.selector = selector;
-        this.el = () => cy.get(this.selector);
+    }
+
+    /**
+     * Get root element.
+     */
+    public el(): DefaultCypressChainable {
+        return cy.get(this.selector);
     }
 
     /**
@@ -52,24 +57,50 @@ export class FInteractiveTablePageObject implements BasePageObject {
         );
     }
 
+    /**
+     * Get `<caption>` element.
+     */
     public caption(): DefaultCypressChainable {
         return cy.get(`${this.selector} caption`);
     }
 
-    public bodyRow(): DefaultCypressChainable {
-        return cy.get(`${this.selector} tbody tr`);
-    }
-
-    public row(index: number): DefaultCypressChainable {
-        return cy.get(`${this.selector} tbody tr:nth(${index})`);
-    }
-
+    /**
+     * Get all table headers (`<th>` in `<thead>`).
+     *
+     * Includes the headers for checkboxes in selectable rows and markers in expandable rows.
+     */
     public headersRow(): DefaultCypressChainable {
         return cy.get(`${this.selector} thead th`);
     }
 
     /**
-     * Hämta page object för specifikt Table row item.
+     * Get all table body rows (`<tr>` in `<tbody>`).
+     *
+     * Includes expandable rows even if not expanded.
+     */
+    public bodyRow(): DefaultCypressChainable {
+        return cy.get(`${this.selector} tbody tr`);
+    }
+
+    /**
+     * Get row (`<tr>` in `<tbody>`) of given index.
+     *
+     * Includes expandable rows even if not expanded.
+     *
+     * @param index - Row number (0-indexed).
+     */
+    public row(index: number): DefaultCypressChainable {
+        return cy.get(`${this.selector} tbody tr:nth(${index})`);
+    }
+
+    /**
+     * Get page object for `FTableColumn` with selector targeting the given row number.
+     *
+     * Index includes the header row (index 0 selects the header row while 1 selects first row in table body).
+     * Index ignores expandable rows.
+     *
+     * @param index - Row number (0-indexed).
+     * @returns Page object for `FTableColumn`.
      */
     public columnItem(index: number): FTableColumnPageObject {
         return new FTableColumnPageObject(
@@ -79,12 +110,23 @@ export class FInteractiveTablePageObject implements BasePageObject {
     }
 
     /**
-     * Hämta page object för specifikt Header row item.
+     * Get page object for `FTableColumn` with selector targeting the header row.
+     *
+     * @returns Page object for `FTableColumn`.
      */
     public headerRowItem(): FTableColumnPageObject {
         return new FTableColumnPageObject(`${this.selector} .table__row`, 0);
     }
 
+    /**
+     * Get sort order icon in given column.
+     *
+     * Index includes the columns for checkboxes in selectable rows and markers in expandable rows.
+     *
+     * @param index - Column index (0-indexed).
+     * @param order - Column sort order.
+     * @returns icon of given sort order.
+     */
     public getColumnSortedByIcon(
         index: number,
         order: "ascending" | "descending" | "unsorted",


### PR DESCRIPTION
Bryter ut lite från test-arbete relaterat till tabell.
Ändrar ej något existerande beteende här utan uppdaterar bara dokumentation och tester för page object för `FInteractiveTable` baserat på hur det fungerar just nu.