### PR TITLE
fix: `FSortFilterDataset` respect sort attribute after dataset update

### DIFF
--- a/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.spec.ts
+++ b/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.spec.ts
@@ -281,6 +281,28 @@ it("should sort data when dropdown is changed", async () => {
     expect(rows[2].findAll("td")[0].text()).toBe("3");
 });
 
+it("should respect sort attribute after dataset change", async () => {
+    const wrapper = createTableWrapper();
+    const options = wrapper.find("select").findAll("option");
+
+    // Sort by Column B (Stigande)
+    await options[3].setValue();
+    let rows = wrapper.findAll("tr");
+    expect(rows[0].findAll("td")[1].text()).toBe("a");
+    expect(rows[1].findAll("td")[1].text()).toBe("k");
+    expect(rows[2].findAll("td")[1].text()).toBe("ö");
+
+    const newData = [...DATA, { a: 0, b: "b", c: "dummy", d: {} }];
+    await wrapper.setData({ data: newData });
+    await wrapper.vm.$nextTick();
+
+    rows = wrapper.findAll("tr");
+    expect(rows[0].findAll("td")[1].text()).toBe("a");
+    expect(rows[1].findAll("td")[1].text()).toBe("b");
+    expect(rows[2].findAll("td")[1].text()).toBe("k");
+    expect(rows[3].findAll("td")[1].text()).toBe("ö");
+});
+
 it("should emit event when dataset is sorted", async () => {
     const wrapper = createWrapper();
     await wrapper.vm.$nextTick();

--- a/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.vue
+++ b/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.vue
@@ -13,6 +13,7 @@ import { type SortOrder } from "./sort-order";
 
 const $t = useTranslate();
 
+const useDefaultSortOrder = ref(true);
 const searchString = ref("");
 const defaultSortValue = { attribute: "", name: "", ascendingName: "", ascending: false, id: 0 };
 const sortAttribute = ref<SortOrder>(defaultSortValue);
@@ -176,7 +177,7 @@ onMounted(() => {
 watch(
     () => props.data,
     () => {
-        if (props.defaultSortAttribute !== "") {
+        if (props.defaultSortAttribute !== "" && useDefaultSortOrder.value) {
             const foundAttribute = sortOrders.value.find((item) => {
                 return item.attribute === props.defaultSortAttribute && item.ascending === props.defaultSortAscending;
             });
@@ -205,6 +206,7 @@ function sortFilterData(): void {
 }
 
 function onChangeSortAttribute(): void {
+    useDefaultSortOrder.value = false;
     sortFilterData();
     emit("usedSortAttributes", sortAttribute.value);
 }


### PR DESCRIPTION
Behåller vald sorteringsordning även om datan uppdateras