### PR TITLE
feat: deprecate `FTableColumnPageObject` (refs SFKUI-6500)

### DIFF
--- a/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-cell.md
+++ b/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-cell.md
@@ -7,12 +7,13 @@ layout: api.method
 
 Hämtar en tabellcell från en {@link component:FInteractiveTable interaktiv tabell} (FInteractiveTable).
 
-Både rad och kolumn är 1-indexerade, dvs rad 1 kolumn 1 refererar till första cellen.
+Både rad och kolumn är 1-indexerade, vilket innebär att rad 1 kolumn 1 refererar till första cellen.
 
-Varken markören för expanderbara rader eller kryssrutan för valbara rader inkluderas i kolumnnummer, dvs kolumn 1 refererar till första cellen med innehåll.
+Varken markören för expanderbara rader eller kryssrutan för valbara rader inkluderas i kolumnnummer.
+Det innebär att kolumn 1 refererar till första cellen med innehåll.
 
 För expanderbara rader beror radnummer på om rader är expanderade eller ej.
-Om första raden är kollapsad refererar andra raden till nästa icke-expanderade rad medans om första raden är expanderd refererar andra raden till första expanderade raden under den första raden.
+Om första raden är kollapsad refererar andra raden till nästa icke-expanderade rad medans om första raden är expanderad refererar andra raden till första expanderade raden under den första raden.
 
 ## Syntax
 

--- a/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-checkbox.cy.ts
+++ b/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-checkbox.cy.ts
@@ -1,0 +1,13 @@
+import { FInteractiveTablePageObject } from "@fkui/vue/cypress";
+import Example from "./FInteractiveTablePageObject-checkbox.vue";
+
+it("header() should select correct element", () => {
+    cy.mount(Example);
+
+    /* --- cut above --- */
+    const table = new FInteractiveTablePageObject();
+    table.checkbox(1).label().should("contain.text", "Select row A1");
+    table.checkbox(2).label().should("contain.text", "Select row A2");
+    table.checkbox(3).label().should("contain.text", "Select row A3");
+    /* --- cut below --- */
+});

--- a/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-checkbox.md
+++ b/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-checkbox.md
@@ -1,0 +1,46 @@
+---
+name: FInteractiveTablePageObject.checkbox
+title: "FInteractiveTablePageObject: checkbox() method"
+short-title: checkbox()
+layout: api.method
+---
+
+Hämtar ut page objekt för en kryssruta i en valbar {@link component:FInteractiveTable interaktiv tabell} (FInteractiveTable).
+
+Radnumreringen är 1-indexerad och inkluderar rader som har expanderats i en expanderbar tabell.
+Det innebär att om första raden är kollapsad refererar andra raden till nästa icke-expanderade rad.
+Om första raden är expanderad refererar andra raden till den första expanderade raden under den första raden.
+
+## Syntax
+
+```ts nocompile nolint
+checkbox(row);
+```
+
+### Parametrar
+
+`row: number`
+: Radnummer (1-indexerat).
+
+### Returvärde
+
+`FCheckboxFieldPageObject` med selektor för kryssrutan på den givna raden.
+
+## Exempel
+
+```import nomarkup
+FInteractiveTablePageObject-checkbox.vue
+```
+
+```import static
+FInteractiveTablePageObject-checkbox.vue
+```
+
+```import static
+FInteractiveTablePageObject-checkbox.cy.ts
+```
+
+## Relaterat
+
+- {@link component:FInteractiveTable Interaktiv tabell} (FInteractiveTable)
+- {@link component:FCheckboxField Kryssruta} (FCheckboxField)

--- a/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-checkbox.vue
+++ b/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-checkbox.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { FInteractiveTable, FTableColumn } from "@fkui/vue";
+
+interface Row {
+    id: string;
+    a: string;
+    b: string;
+    c: string;
+}
+
+const rows: Row[] = [
+    { id: "1", a: "A1", b: "B1", c: "C1" },
+    { id: "2", a: "A2", b: "B2", c: "C2" },
+    { id: "3", a: "A3", b: "B3", c: "C3" },
+];
+</script>
+
+<template>
+    <!-- cut above -->
+    <f-interactive-table :rows selectable>
+        <template #caption> Tabell </template>
+        <template #checkbox-description="{ row }"> Select row {{ row.a }} </template>
+        <template #default="{ row }">
+            <f-table-column title="A"> {{ row.a }} </f-table-column>
+            <f-table-column title="B"> {{ row.b }} </f-table-column>
+            <f-table-column title="C"> {{ row.c }} </f-table-column>
+        </template>
+    </f-interactive-table>
+    <!-- cut below -->
+</template>

--- a/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-header.cy.ts
+++ b/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-header.cy.ts
@@ -1,0 +1,13 @@
+import { FInteractiveTablePageObject } from "@fkui/vue/cypress";
+import Example from "./FInteractiveTablePageObject-header.vue";
+
+it("header() should select correct element", () => {
+    cy.mount(Example);
+
+    /* --- cut above --- */
+    const table = new FInteractiveTablePageObject();
+    table.header(1).should("contain.text", "A");
+    table.header(2).should("contain.text", "B");
+    table.header(3).should("contain.text", "C");
+    /* --- cut below --- */
+});

--- a/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-header.md
+++ b/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-header.md
@@ -1,0 +1,43 @@
+---
+name: FInteractiveTablePageObject.header
+title: "FInteractiveTablePageObject: header() method"
+short-title: header()
+layout: api.method
+---
+
+Hämtar en cell i tabellhuvudet för en {@link component:FInteractiveTable interaktiv tabell} (FInteractiveTable).
+
+Kolumnumreringen är 1-indexerad och varken markören för expanderbara rader eller kryssrutan för valbara rader inkluderas i kolumnnummer. Detta innebär att kolumn 1 refererar till första kolumnen som har innehåll.
+
+## Syntax
+
+```ts nocompile nolint
+header(col);
+```
+
+### Parametrar
+
+`col: number`
+: Kolumnnummer (1-indexerat).
+
+### Returvärde
+
+`HTMLTableCellElement` med en cell från tabellhuvudet beskriven av `col`.
+
+## Exempel
+
+```import nomarkup
+FInteractiveTablePageObject-header.vue
+```
+
+```import static
+FInteractiveTablePageObject-header.vue
+```
+
+```import static
+FInteractiveTablePageObject-header.cy.ts
+```
+
+## Relaterat
+
+- {@link component:FInteractiveTable Interaktiv tabell} (FInteractiveTable)

--- a/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-header.vue
+++ b/docs/functions/cypress/pageobjects/FInteractiveTablePageObject/FInteractiveTablePageObject-header.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { FInteractiveTable, FTableColumn } from "@fkui/vue";
+
+interface Row {
+    id: string;
+    a: string;
+    b: string;
+    c: string;
+}
+
+const rows: Row[] = [
+    { id: "1", a: "A1", b: "B1", c: "C1" },
+    { id: "2", a: "A2", b: "B2", c: "C2" },
+    { id: "3", a: "A3", b: "B3", c: "C3" },
+];
+</script>
+
+<template>
+    <!-- cut above -->
+    <f-interactive-table :rows>
+        <template #caption> Tabell </template>
+        <template #default="{ row }">
+            <f-table-column title="A"> {{ row.a }} </f-table-column>
+            <f-table-column title="B"> {{ row.b }} </f-table-column>
+            <f-table-column title="C"> {{ row.c }} </f-table-column>
+        </template>
+    </f-interactive-table>
+    <!-- cut below -->
+</template>

--- a/etc/docs-manifest.md
+++ b/etc/docs-manifest.md
@@ -88,6 +88,8 @@ functions/cypress/pageobjects/FFileItemPageObject/filename.html
 functions/cypress/pageobjects/FFileItemPageObject/index.html
 functions/cypress/pageobjects/FFileItemPageObject/typeoffile.html
 functions/cypress/pageobjects/FInteractiveTablePageObject/cell.html
+functions/cypress/pageobjects/FInteractiveTablePageObject/checkbox.html
+functions/cypress/pageobjects/FInteractiveTablePageObject/header.html
 functions/cypress/pageobjects/FLabelPageObject/description.html
 functions/cypress/pageobjects/FLabelPageObject/error-icon.html
 functions/cypress/pageobjects/FLabelPageObject/error-message.html

--- a/etc/vue-cypress.api.md
+++ b/etc/vue-cypress.api.md
@@ -346,9 +346,13 @@ export class FInteractiveTablePageObject implements BasePageObject {
         row: number;
         col: number;
     }): Cypress.Chainable<JQuery<HTMLTableCellElement>>;
+    checkbox(row: number): FCheckboxFieldPageObject;
+    // @deprecated
     columnItem(index: number): FTableColumnPageObject;
     el(): DefaultCypressChainable;
     getColumnSortedByIcon(index: number, order: "ascending" | "descending" | "unsorted"): DefaultCypressChainable;
+    header(col: number): Cypress.Chainable<JQuery<HTMLTableCellElement>>;
+    // @deprecated
     headerRowItem(): FTableColumnPageObject;
     headersRow(): DefaultCypressChainable;
     row(index: number): DefaultCypressChainable;
@@ -618,10 +622,10 @@ export class FStaticFieldPageObject implements BasePageObject {
     tooltip: FTooltipPageObject;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class FTableColumnPageObject implements BasePageObject {
     constructor(selector: string, index: number);
-    // (undocumented)
+    // @deprecated (undocumented)
     checkbox(): FCheckboxFieldPageObject;
     // (undocumented)
     el: () => DefaultCypressChainable;
@@ -629,9 +633,9 @@ export class FTableColumnPageObject implements BasePageObject {
     index: number;
     // (undocumented)
     selector: string;
-    // (undocumented)
+    // @deprecated (undocumented)
     tableRowBodyContent(position: number): DefaultCypressChainable;
-    // (undocumented)
+    // @deprecated (undocumented)
     tableRowHeaderContent(): DefaultCypressChainable;
 }
 

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.cy.ts
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.cy.ts
@@ -105,9 +105,9 @@ describe("when selectable", () => {
         });
         cy.mount(TestComponent);
 
-        table.columnItem(1).checkbox().isSelected().should("be.true");
-        table.columnItem(2).checkbox().isSelected().should("be.false");
-        table.columnItem(3).checkbox().isSelected().should("be.true");
+        table.checkbox(1).isSelected().should("be.true");
+        table.checkbox(2).isSelected().should("be.false");
+        table.checkbox(3).isSelected().should("be.true");
     });
 
     it("should update checkboxes on `v-model` change", () => {
@@ -152,24 +152,24 @@ describe("when selectable", () => {
         });
         cy.mount(TestComponent);
 
-        table.columnItem(1).checkbox().isSelected().should("be.true");
-        table.columnItem(2).checkbox().isSelected().should("be.false");
-        table.columnItem(3).checkbox().isSelected().should("be.true");
+        table.checkbox(1).isSelected().should("be.true");
+        table.checkbox(2).isSelected().should("be.false");
+        table.checkbox(3).isSelected().should("be.true");
 
         cy.get("#remove-all").click();
-        table.columnItem(1).checkbox().isSelected().should("be.false");
-        table.columnItem(2).checkbox().isSelected().should("be.false");
-        table.columnItem(3).checkbox().isSelected().should("be.false");
+        table.checkbox(1).isSelected().should("be.false");
+        table.checkbox(2).isSelected().should("be.false");
+        table.checkbox(3).isSelected().should("be.false");
 
         cy.get("#add-one").click();
-        table.columnItem(1).checkbox().isSelected().should("be.false");
-        table.columnItem(2).checkbox().isSelected().should("be.true");
-        table.columnItem(3).checkbox().isSelected().should("be.false");
+        table.checkbox(1).isSelected().should("be.false");
+        table.checkbox(2).isSelected().should("be.true");
+        table.checkbox(3).isSelected().should("be.false");
 
         cy.get("#select-all").click();
-        table.columnItem(1).checkbox().isSelected().should("be.true");
-        table.columnItem(2).checkbox().isSelected().should("be.true");
-        table.columnItem(3).checkbox().isSelected().should("be.true");
+        table.checkbox(1).isSelected().should("be.true");
+        table.checkbox(2).isSelected().should("be.true");
+        table.checkbox(3).isSelected().should("be.true");
     });
 });
 
@@ -345,22 +345,14 @@ describe("when `rows` is empty", () => {
         cy.mount(TestComponent);
 
         table.cell({ row: 1, col: 1 }).should("have.attr", "colspan", "2");
-        table
-            .headerRowItem()
-            .tableRowHeaderContent()
-            .eq(1)
-            .should("contain.text", "Amount");
+        table.header(2).should("contain.text", "Amount");
 
         cy.get("#toggle-btn").click();
         table.cell({ row: 1, col: 1 }).should("have.attr", "colspan", "1");
-        table.columnItem(2).el().should("not.exist");
+        table.header(2).should("not.exist");
 
         cy.get("#toggle-btn").click();
         table.cell({ row: 1, col: 1 }).should("have.attr", "colspan", "2");
-        table
-            .headerRowItem()
-            .tableRowHeaderContent()
-            .eq(1)
-            .should("contain.text", "Amount");
+        table.header(2).should("contain.text", "Amount");
     });
 });

--- a/packages/vue/src/cypress/FInteractiveTable.pageobject.cy.ts
+++ b/packages/vue/src/cypress/FInteractiveTable.pageobject.cy.ts
@@ -46,7 +46,9 @@ const TestComponent = defineComponent({
             :expandable-attribute="expandable ? 'nested' : undefined"
         >
             <template #caption> Test table </template>
-            <template #checkbox-description> Select row </template>
+            <template #checkbox-description="{ row }">
+                Select row {{ row.a }}
+            </template>
             <template #default="{ row }">
                 <f-table-column :row-header title="A">
                     {{ row.a }}
@@ -186,6 +188,53 @@ it("`caption()` should get `<caption>` element", () => {
 
     table.caption().should("contain.text", "Test table");
     table.caption().should("have.prop", "tagName", "CAPTION");
+});
+
+describe("`header()`", () => {
+    it("should get correct `<th>` element in `<thead>`", () => {
+        cy.mount(TestComponent, {
+            props: {
+                rows,
+                rowHeader: false,
+                expandable: false,
+                selectable: false,
+            },
+        });
+
+        table.header(1).should("have.trimmedText", "A");
+        table.header(2).should("have.trimmedText", "B");
+        table.header(3).should("have.trimmedText", "C");
+    });
+
+    it("should not include column header for expandable marker", () => {
+        cy.mount(TestComponent, {
+            props: {
+                rows,
+                rowHeader: false,
+                expandable: true,
+                selectable: false,
+            },
+        });
+
+        table.header(1).should("have.trimmedText", "A");
+        table.header(2).should("have.trimmedText", "B");
+        table.header(3).should("have.trimmedText", "C");
+    });
+
+    it("should not include column header for selectable checkbox", () => {
+        cy.mount(TestComponent, {
+            props: {
+                rows,
+                rowHeader: false,
+                expandable: false,
+                selectable: true,
+            },
+        });
+
+        table.header(1).should("have.trimmedText", "A");
+        table.header(2).should("have.trimmedText", "B");
+        table.header(3).should("have.trimmedText", "C");
+    });
 });
 
 it("`headersRow()` should get all `<th>` elements in `<thead>`", () => {
@@ -341,6 +390,54 @@ describe("`row()`", () => {
         table.row(1).find("td").eq(1).should("have.trimmedText", "A1a");
         table.row(2).find("td").eq(1).should("have.trimmedText", "A1b");
         table.row(3).find("td").eq(1).should("have.trimmedText", "A1c");
+    });
+});
+
+describe("`checkbox()`", () => {
+    it("should get `FCheckboxFieldPageObject` for given row", () => {
+        cy.mount(TestComponent, {
+            props: {
+                rows,
+                rowHeader: false,
+                expandable: false,
+                selectable: true,
+            },
+        });
+
+        table.checkbox(1).label().should("contain.text", "Select row A1");
+        table.checkbox(2).label().should("contain.text", "Select row A2");
+        table.checkbox(3).label().should("contain.text", "Select row A3");
+    });
+
+    it("should count expanded rows", () => {
+        cy.mount(TestComponent, {
+            props: {
+                rows,
+                rowHeader: false,
+                expandable: true,
+                selectable: true,
+            },
+        });
+
+        table.row(0).click();
+        table.checkbox(1).label().should("contain.text", "Select row A1");
+        table.checkbox(5).label().should("contain.text", "Select row A2");
+        table.checkbox(6).label().should("contain.text", "Select row A3");
+    });
+
+    it("should ignore collapsed rows", () => {
+        cy.mount(TestComponent, {
+            props: {
+                rows,
+                rowHeader: false,
+                expandable: true,
+                selectable: true,
+            },
+        });
+
+        table.checkbox(1).label().should("contain.text", "Select row A1");
+        table.checkbox(2).label().should("contain.text", "Select row A2");
+        table.checkbox(3).label().should("contain.text", "Select row A3");
     });
 });
 

--- a/packages/vue/src/cypress/FTableColumn.pageobject.ts
+++ b/packages/vue/src/cypress/FTableColumn.pageobject.ts
@@ -3,6 +3,7 @@ import { FCheckboxFieldPageObject } from "./FCheckboxField.pageobject";
 
 /**
  * @public
+ * @deprecated Use methods on `FInteractiveTable` instead. Deprecated since %version%.
  */
 export class FTableColumnPageObject implements BasePageObject {
     public selector: string;
@@ -14,14 +15,23 @@ export class FTableColumnPageObject implements BasePageObject {
         this.el = () => cy.get(this.selector);
     }
 
+    /**
+     * @deprecated Use ´FInteractiveTablePageObject.cell()´ instead. Deprecated since %version%.
+     */
     public tableRowBodyContent(position: number): DefaultCypressChainable {
         return cy.get(`${this.selector} td:nth(${position})`);
     }
 
+    /**
+     * @deprecated Use ´FInteractiveTablePageObject.header()´ instead. Deprecated since %version%.
+     */
     public tableRowHeaderContent(): DefaultCypressChainable {
         return cy.get(`${this.selector} th`);
     }
 
+    /**
+     * @deprecated Use ´FInteractiveTablePageObject.checkbox()´ instead. Deprecated since %version%.
+     */
     public checkbox(): FCheckboxFieldPageObject {
         return new FCheckboxFieldPageObject(this.selector);
     }


### PR DESCRIPTION
Deprekerar page objektet för tabellkolumn då den är rätt svår att förstå och känns överflödig.
Lägger i samma veva till `header()` och `checkbox()` till page objekt för interaktiv tabell.

- [x] Se till att versionen för när deprekering genomfördes blir rätt innan merge.
- [x] Fixa [dokumentationen](https://github.com/Forsakringskassan/designsystem/tree/main/docs/functions/cypress/pageobjects/FInteractiveTablePageObject) för nya metoderna i `FInteractiveTablePageObject` (med exempel och testfall)