### PR TITLE
fix: fix `FCrudDataset` delete on nested items (fixes SFKUI-7084)

### DIFF
--- a/docs/components/table-and-list/FCrudDataset.md
+++ b/docs/components/table-and-list/FCrudDataset.md
@@ -76,6 +76,22 @@ Du behöver själv hantera vad klick på knappen ska utföra för åtgärd.
 FCrudDatasetAdditionalButtons.vue
 ```
 
+## Borttagning av nästlade objekt
+
+Om du har nästlade objekt ( till exempel för {@link table#expanderbara_rader expanderbara tabeller}) som du
+vill kunna ta bort behöver du även ange egenskapsnamnet (`key`) till callback funktionen `deleteItem()`.
+
+```js
+const items = [
+    { name: "Awesome item", nested: [{ name: "Awesome nested item" }] },
+];
+```
+
+```diff
+-<f-table-button icon="trashcan" @click="deleteItem(item)">
++<f-table-button icon="trashcan" @click="deleteItem(item, 'nested')">
+```
+
 ## Datatabell med lägg till-knapp
 
 ```import

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -2798,7 +2798,7 @@ export const FCrudDataset: <T>(__VLS_props: NonNullable<Awaited<typeof __VLS_set
     slots: {
         default?(_: {
             updateItem: (current: T) => void;
-            deleteItem: (current: T) => void;
+            deleteItem: (current: T, nested?: keyof T) => void;
         }): any;
         'add-button'?(_: {}): any;
         buttons?(_: {

--- a/packages/vue/src/components/FCrudDataset/FCrudDataset.cy.ts
+++ b/packages/vue/src/components/FCrudDataset/FCrudDataset.cy.ts
@@ -1,6 +1,14 @@
 import { defineComponent } from "vue";
-import { FModal, FConfirmModal, FFormModal } from "../FModal";
+import {
+    FConfirmModal,
+    FFormModal,
+    FInteractiveTable,
+    FModal,
+    FTableButton,
+    FTableColumn,
+} from "..";
 import { ListItem } from "../../types";
+import { FInteractiveTablePageObject } from "../../cypress";
 import ListExample from "./examples/FCrudDatasetListExample.vue";
 import FCrudDataset from "./FCrudDataset.vue";
 import FCrudButton from "./FCrudButton.vue";
@@ -138,6 +146,87 @@ describe("item delete", () => {
         cy.get(".modal .button--primary").click();
         // Check that row 1 and item with id item1 do not exist after delete
         cy.get("#item1").should("not.exist");
+    });
+
+    it("should delete nested item", () => {
+        const rows = [
+            {
+                name: "a",
+                nested: [{ name: "a1" }, { name: "a2" }],
+            },
+            { name: "b", nested: [] },
+        ];
+        const TestComponent = defineComponent({
+            components: {
+                FCrudDataset,
+                FInteractiveTable,
+                FTableButton,
+                FTableColumn,
+            },
+            data() {
+                return {
+                    rows,
+                };
+            },
+            template: /* HTML */ `
+                <f-crud-dataset v-model="rows">
+                    <template #default="{ deleteItem }">
+                        <f-interactive-table
+                            :rows
+                            expandable-attribute="nested"
+                        >
+                            <template #checkbox-description>
+                                Select row
+                            </template>
+                            <template #default="{ row }">
+                                <f-table-column :row-header title="Name">
+                                    {{ row.name }}
+                                </f-table-column>
+                                <f-table-column
+                                    title="Åtgärd"
+                                    shrink
+                                    type="action"
+                                >
+                                    <f-table-button
+                                        icon="pen"
+                                        @click="deleteItem(row, 'nested')"
+                                    >
+                                        Delete
+                                        <span class="sr-only">
+                                            {{ row.name }}
+                                        </span>
+                                    </f-table-button>
+                                </f-table-column>
+                            </template>
+                        </f-interactive-table>
+                    </template>
+                    <template #delete="{ item }">
+                        <span> Delete </span>
+                        {{ item.name }}?
+                    </template>
+                </f-crud-dataset>
+            `,
+        });
+        cy.mount(TestComponent);
+        const table = new FInteractiveTablePageObject();
+
+        table.row(0).click();
+
+        table.bodyRow().should("have.length", 4);
+        table.cell({ row: 1, col: 1 }).should("have.trimmedText", "a");
+        table.cell({ row: 2, col: 1 }).should("have.trimmedText", "a1");
+        table.cell({ row: 3, col: 1 }).should("have.trimmedText", "a2");
+        table.cell({ row: 4, col: 1 }).should("have.trimmedText", "b");
+        table.row(4).should("not.exist");
+
+        table.row(1).find(".button").click();
+        cy.get(".modal .button--primary").click();
+
+        table.bodyRow().should("have.length", 3);
+        table.cell({ row: 1, col: 1 }).should("have.trimmedText", "a");
+        table.cell({ row: 2, col: 1 }).should("have.trimmedText", "a2");
+        table.cell({ row: 3, col: 1 }).should("have.trimmedText", "b");
+        table.row(3).should("not.exist");
     });
 
     it("should emit deleted event when items are deleted", () => {

--- a/packages/vue/src/components/FCrudDataset/FCrudDataset.vue
+++ b/packages/vue/src/components/FCrudDataset/FCrudDataset.vue
@@ -15,6 +15,7 @@ const slots = useSlots();
 const result = ref<T[]>([]) as Ref<T[]>;
 const operation = ref<Operation>(Operation.NONE);
 const item = ref<T | null>(null);
+const nestedKey = ref<keyof T | null | undefined>(null);
 const originalItemToUpdate = ref<T | null>(null);
 const isFormModalOpen = ref(false);
 const isConfirmModalOpen = ref(false);
@@ -232,22 +233,23 @@ function createItem(): void {
     isFormModalOpen.value = true;
 }
 
-function deleteItem(current: T): void {
+function deleteItem(current: T, nested?: keyof T): void {
     if (!hasDeleteSlot.value) {
         throw Error("No template is defined for #delete");
     }
     operation.value = Operation.DELETE;
     item.value = current;
     isConfirmModalOpen.value = true;
+    nestedKey.value = nested;
 }
 
 function onDeleteConfirm(): void {
     if (!item.value) {
         return;
     }
-    callbackBeforeItemDelete.value(item.value);
-    result.value = result.value.filter((it) => it !== item.value);
 
+    callbackBeforeItemDelete.value(item.value);
+    result.value = filterItem(result.value, item.value, nestedKey.value);
     emit("deleted", item.value);
     emit("update:modelValue", result.value);
 
@@ -256,6 +258,35 @@ function onDeleteConfirm(): void {
     alertScreenReader(message, {
         assertive: true,
     });
+}
+
+function filterItem(items: T[], target: T, nested?: keyof T): T[] {
+    const newItems = [...items];
+
+    for (let i = 0; i < newItems.length; i++) {
+        const item = newItems[i];
+
+        // Filter shallow item.
+        if (item === target) {
+            newItems.splice(i, 1);
+            return newItems;
+        }
+
+        // Filter nested item.
+        if (nested && Array.isArray(item[nested])) {
+            const nestedItems = item[nested];
+            const nestedIndex = nestedItems.findIndex((it) => it === target);
+
+            if (nestedIndex !== -1) {
+                const clonedNested = [...nestedItems];
+                clonedNested.splice(nestedIndex, 1);
+                item[nested] = clonedNested as T[keyof T];
+                return newItems;
+            }
+        }
+    }
+
+    return newItems;
 }
 
 function onDeleteClose(e: { reason: string }): void {
@@ -320,7 +351,7 @@ function updateItem(current: T): void {
         <!--
              @slot Slot for displaying the data.
              @binding {(item: T) => void} updateItem Callback to trigger modification modal
-             @binding {(item: T) => void} deleteItem Callback to trigger deletion modal
+             @binding {(item: T, nested?: keyof T) => void} deleteItem Callback to trigger deletion modal
         -->
         <slot v-bind="{ updateItem, deleteItem }"></slot>
         <div v-if="hasAddSlot">

--- a/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetTableExample.vue
+++ b/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetTableExample.vue
@@ -35,7 +35,7 @@ export default defineComponent({
 <template>
     <f-crud-dataset v-model="fruits" @created="saveModel" @updated="saveModel" @deleted="saveModel">
         <template #default="{ updateItem, deleteItem }">
-            <f-interactive-table :rows="fruits" key-attribute="id">
+            <f-interactive-table :rows="fruits" expandable-attribute="variant" key-attribute="id">
                 <template #caption> <b>Frukter</b> </template>
                 <template #default="{ row }">
                     <f-table-column title="Namn" type="text" shrink>
@@ -51,7 +51,7 @@ export default defineComponent({
                         <f-table-button icon="pen" @click="updateItem(row)">
                             Ändra {{ row.name }}
                         </f-table-button>
-                        <f-table-button icon="trashcan" @click="deleteItem(row)">
+                        <f-table-button icon="trashcan" @click="deleteItem(row, 'variant')">
                             Ta bort {{ row.name }}
                         </f-table-button>
                     </f-table-column>
@@ -107,7 +107,7 @@ export default defineComponent({
         </template>
 
         <template #delete="{ item }">
-            Vill du verkligen radera fruken "{{ item.name }}" med ID {{ item.id }}
+            Vill du verkligen radera frukten "{{ item.name }}" med ID {{ item.id }}
         </template>
     </f-crud-dataset>
 </template>

--- a/packages/vue/src/components/FCrudDataset/examples/fruit-data.ts
+++ b/packages/vue/src/components/FCrudDataset/examples/fruit-data.ts
@@ -6,6 +6,7 @@ export interface FruitData {
     name: string;
     origin: string;
     description: string;
+    variant?: FruitData[];
 }
 
 /**
@@ -18,6 +19,20 @@ export const fruits: FruitData[] = [
         origin: "Sverige",
         description:
             "Rund, ofta röd eller grön frukt med söt eller syrlig smak.",
+        variant: [
+            {
+                id: "1a",
+                name: "Discovery",
+                origin: "Sverige",
+                description: "Rött och gulgrönt äpple. Krispig och smakrik.",
+            },
+            {
+                id: "1b",
+                name: "Ingrid Marie",
+                origin: "Sverige",
+                description: "Mörkrött äpple. Saftig och sötsyrlig.",
+            },
+        ],
     },
     {
         id: "2",

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
@@ -13,7 +13,7 @@ import {
     getCurrentInstance,
     watch,
 } from "vue";
-import { findTabbableElements } from "@fkui/logic";
+import { findTabbableElements, isVisible } from "@fkui/logic";
 import { useSlotUtils } from "../../composables";
 import { TableScroll, tableScrollClasses, itemEquals, includeItem, renderSlotText } from "../../utils";
 import { getInternalKey, setInternalKeys } from "../../utils/internal-key";
@@ -506,7 +506,13 @@ function callbackBeforeItemDelete(item: T): void {
         return;
     }
 
-    const index = internalRows.value.indexOf(item);
+    let index;
+    if (isExpandableTable) {
+        index = getExpandedIndex(item, internalRows.value);
+    } else {
+        index = internalRows.value.indexOf(item);
+    }
+
     const target = getPreviousFocus(index) ?? getNextFocus(index);
     if (target) {
         target.focus();
@@ -514,31 +520,27 @@ function callbackBeforeItemDelete(item: T): void {
 }
 
 function getPreviousFocus(currentIndex: number): HTMLElement | undefined {
-    const targetIndex = currentIndex - 1;
-    if (targetIndex < 0) {
+    const previousIndex = currentIndex - 1;
+    if (previousIndex < 0) {
         return undefined;
     }
 
-    const targetRow = tr.value[targetIndex];
+    let targetRow = trAll.value[previousIndex];
     if (!targetRow) {
         return undefined;
     }
 
-    const row = internalRows.value[targetIndex];
-    if (!isExpanded(row)) {
-        const tabbables = findTabbableElements(targetRow);
-        return tabbables[tabbables.length - 1];
-    }
+    for (let index = 0; index <= previousIndex; index++) {
+        const targetIndex = previousIndex - index;
+        targetRow = trAll.value[targetIndex];
 
-    // Get interactable in custom expandable rows, or parent row if none found.
-    const expandedIndex = getExpandedIndex(currentIndex, internalRows.value) - 1;
-    const { length } = expandableRows(row) as T[];
-    for (let i = 0; i <= length; i++) {
-        const targetExpandedRow = trAll.value[expandedIndex - i];
-        const tabbables = findTabbableElements(targetExpandedRow);
-        const target = tabbables[tabbables.length - 1];
-        if (target) {
-            return target;
+        if (!isVisible(targetRow)) {
+            continue;
+        }
+
+        const tabbables = findTabbableElements(targetRow);
+        if (tabbables.length > 0) {
+            return tabbables[tabbables.length - 1];
         }
     }
 

--- a/packages/vue/src/components/FInteractiveTable/useExpandableTable.ts
+++ b/packages/vue/src/components/FInteractiveTable/useExpandableTable.ts
@@ -14,7 +14,7 @@ export interface ExpandableTable<T> {
     getExpandableDescribedby(row: T): string | undefined;
     expandableRows(row: T): T[] | undefined;
     hasExpandableContent(row: T): boolean;
-    getExpandedIndex(shallowIndex: number, rows: T[]): number;
+    getExpandedIndex(row: T, rows: T[]): number;
 }
 
 type Emit<T> = ((evt: "expand", row: T) => void) &
@@ -116,28 +116,32 @@ export function useExpandableTable<T extends object>(
     }
 
     /**
-     * Translate shallow row index to flattened row index including expandable rows.
+     * Get the flattened index (including expandable rows) from a row.
      */
-    function getExpandedIndex(shallowIndex: number, rows: T[]): number {
-        let expandedIndex = 0;
+    function getExpandedIndex(row: T, rows: T[]): number {
+        let index = 0;
 
-        for (let i = 0; i < shallowIndex; i++) {
-            const row = rows[i];
-            expandedIndex++;
+        for (const currentRow of rows) {
+            if (currentRow === row) {
+                return index;
+            }
 
-            if (!hasExpandableContent(row)) {
+            index++;
+
+            if (!hasExpandableContent(currentRow) && !isExpanded(currentRow)) {
                 continue;
             }
 
-            const { length } = expandableRows(row) as T[];
-            if (length === 0) {
-                continue;
+            const nestedRows = expandableRows(currentRow) as T[];
+            for (const currentNestedRow of nestedRows) {
+                if (currentNestedRow === row) {
+                    return index;
+                }
+                index++;
             }
-
-            expandedIndex += length;
         }
 
-        return expandedIndex;
+        return -1;
     }
 
     return {


### PR DESCRIPTION
Fixar så att nästlade objekt kan tas bort med `FCrudDataset`. Kan då ta bort expanderbara rader med `FInteractiveTable`. Löste det genom att man får skicka med property name till delete funktionen, men tar gärna feedback om det finns bättre lösningar.

Uppdaterar också fokushanteringen vid delete för `FInteractiveTable` så att det hamnar rätt även när en expanderbar rad tas bort.