### PR TITLE
build: support `%version%` as a placeholder in code and documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "pretest": "npm run lint",
     "test": "lerna run test",
     "test:ct": "cypress run-ct --headless",
+    "version": "scripts/version",
+    "postversion": "npm run build",
     "vue": "npm run --workspace packages/vue --"
   },
   "commitlint": {

--- a/scripts/version
+++ b/scripts/version
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Finds all files matching any of the patterns and replaces the %version%
+# placeholder with the actual version from the new release.
+
+patterns=(
+	'**/*.css'
+	'**/*.md'
+	'**/*.scss'
+	'**/*.ts'
+	'**/*.vue'
+)
+
+for file in $(git ls-files "${patterns[@]}"); do
+	if [[ "${file}" == scripts/* || "${file}" == etc/* ]]; then
+		continue
+	fi
+
+	# inline global substitution with the 'w' flag to pipe the changes to grep
+	# which matches if any changes was made.
+	if sed "s/%version%/v${npm_new_version}/gw /dev/stdout" -i "${file}" | grep -q .; then
+		echo "${file}"
+		git add "${file}"
+	fi
+done


### PR DESCRIPTION
Inte provkört det här i ett monorepo så hoppas det lirar men tänker att vi kanske kan testa på en oskyldig fil och testa i releasen och se om det fungerar och anpassa om det inte lirar.