### PR TITLE
fix: use a public symbol for `useResize()` if consumer needs to recreate it

### DIFF
--- a/packages/vue/src/components/FResizePane/use-resize.ts
+++ b/packages/vue/src/components/FResizePane/use-resize.ts
@@ -30,7 +30,9 @@ export interface ResizeAPI {
 /**
  * @internal
  */
-export const injectionKey: InjectionKey<ResizeAPI> = Symbol("FResizePane");
+export const injectionKey: InjectionKey<ResizeAPI> = Symbol.for(
+    "FResizePane:useResize",
+);
 
 /**
  * Returned from `useResize()`.


### PR DESCRIPTION
Den är inte direkt dokumenterad men tänker att det kanske inte är SÅ nödvändigt att skylta med det? Eller vad tycker ni?