### PR TITLE
fix: unnecessary horizontal scroll bar shown for fieldsets with tooltips (fixes SFKUI-7292)

### DIFF
--- a/packages/design/src/components/label/_label.scss
+++ b/packages/design/src/components/label/_label.scss
@@ -14,6 +14,10 @@ $LABEL_SELECTOR: ".label" !default;
     margin-bottom: core.densify(size.$margin-025);
     width: var(--f-width-full);
 
+    &.sr-only {
+        width: auto;
+    }
+
     &__message {
         display: block;
         font-weight: var(--f-font-weight-normal);


### PR DESCRIPTION
Åtgärdar #544.

Problemet orsakas av definitionen `width: var(--f-width-full);` i selektorn `.label`.

https://github.com/user-attachments/assets/e399a180-c435-470e-baa9-a1550e27a1f3