### PR TITLE
refactor: remove selector variables (refs SFKUI-6500)

### DIFF
--- a/packages/design/src/components/anchor/_anchor.scss
+++ b/packages/design/src/components/anchor/_anchor.scss
@@ -1,11 +1,10 @@
-$ANCHOR_SELECTOR: ".anchor" !default;
 $anchor-svg-margin: 0.25rem;
 @use "../../core/mixins/anchor";
 
-#{$ANCHOR_SELECTOR} {
+.anchor {
     @include anchor.anchor;
 
-    &#{$ANCHOR_SELECTOR}--block {
+    &.anchor--block {
         display: inline-flex;
 
         & > svg,
@@ -15,7 +14,7 @@ $anchor-svg-margin: 0.25rem;
         }
     }
 
-    &#{$ANCHOR_SELECTOR}--discrete {
+    &.anchor--discrete {
         color: var(--f-text-color-link-discrete);
         text-decoration-color: var(--f-border-color-link-discrete);
 

--- a/packages/design/src/components/badge/_badge.scss
+++ b/packages/design/src/components/badge/_badge.scss
@@ -1,9 +1,7 @@
 @use "../../core";
 @use "variables" as *;
 
-$BADGE_SELECTOR: ".badge" !default;
-
-@mixin make-badge-variant($BADGE_SELECTOR, $text-color, $background-color, $border-color: "") {
+@mixin make-badge-variant($text-color, $background-color, $border-color: "") {
     color: $text-color;
     background-color: $background-color;
 
@@ -14,7 +12,7 @@ $BADGE_SELECTOR: ".badge" !default;
     }
 }
 
-#{$BADGE_SELECTOR} {
+.badge {
     border-radius: var(--f-border-radius-medium);
     border-style: solid;
     border-width: var(--f-border-width-small);
@@ -26,62 +24,42 @@ $BADGE_SELECTOR: ".badge" !default;
     padding: 0 0.5rem;
 
     &--default {
-        @include make-badge-variant($BADGE_SELECTOR, $badge-color-text-default, $badge-color-background-default);
+        @include make-badge-variant($badge-color-text-default, $badge-color-background-default);
     }
 
     &--default-inverted {
-        @include make-badge-variant(
-            $BADGE_SELECTOR,
-            $badge-color-text-default-inverted,
-            $badge-color-background-default-inverted,
-            $badge-color-border-default-inverted
-        );
+        @include make-badge-variant($badge-color-text-default-inverted, $badge-color-background-default-inverted, $badge-color-border-default-inverted);
     }
 
     &--warning {
-        @include make-badge-variant($BADGE_SELECTOR, $badge-color-text-warning, $badge-color-background-warning);
+        @include make-badge-variant($badge-color-text-warning, $badge-color-background-warning);
     }
 
     &--warning-inverted {
-        @include make-badge-variant(
-            $BADGE_SELECTOR,
-            $badge-color-text-warning-inverted,
-            $badge-color-background-warning-inverted,
-            $badge-color-border-warning-inverted
-        );
+        @include make-badge-variant($badge-color-text-warning-inverted, $badge-color-background-warning-inverted, $badge-color-border-warning-inverted);
     }
 
     &--error {
-        @include make-badge-variant($BADGE_SELECTOR, $badge-color-text-error, $badge-color-background-error);
+        @include make-badge-variant($badge-color-text-error, $badge-color-background-error);
     }
 
     &--error-inverted {
-        @include make-badge-variant(
-            $BADGE_SELECTOR,
-            $badge-color-text-error-inverted,
-            $badge-color-background-error-inverted,
-            $badge-color-border-error-inverted
-        );
+        @include make-badge-variant($badge-color-text-error-inverted, $badge-color-background-error-inverted, $badge-color-border-error-inverted);
     }
 
     &--success {
-        @include make-badge-variant($BADGE_SELECTOR, $badge-color-text-success, $badge-color-background-success);
+        @include make-badge-variant($badge-color-text-success, $badge-color-background-success);
     }
 
     &--success-inverted {
-        @include make-badge-variant(
-            $BADGE_SELECTOR,
-            $badge-color-text-success-inverted,
-            $badge-color-background-success-inverted,
-            $badge-color-border-success-inverted
-        );
+        @include make-badge-variant($badge-color-text-success-inverted, $badge-color-background-success-inverted, $badge-color-border-success-inverted);
     }
 
     &--info {
-        @include make-badge-variant($BADGE_SELECTOR, $badge-color-text-info, $badge-color-background-info);
+        @include make-badge-variant($badge-color-text-info, $badge-color-background-info);
     }
 
     &--info-inverted {
-        @include make-badge-variant($BADGE_SELECTOR, $badge-color-text-info-inverted, $badge-color-background-info-inverted, $badge-color-border-info-inverted);
+        @include make-badge-variant($badge-color-text-info-inverted, $badge-color-background-info-inverted, $badge-color-border-info-inverted);
     }
 }

--- a/packages/design/src/components/button/_button.scss
+++ b/packages/design/src/components/button/_button.scss
@@ -1,5 +1,3 @@
-$BUTTON_SELECTOR: ".button" !default;
-
 @use "../../core";
 @use "../../core/size";
 @use "variables" as *;
@@ -226,26 +224,26 @@ $button--tertiary: (
     }
 }
 
-#{$BUTTON_SELECTOR} {
+.button {
     @extend %button-template;
-    @include core.make-button-variant($BUTTON_SELECTOR, $button--standard...);
+    @include core.make-button-variant(".button", $button--standard...);
 
-    &#{$BUTTON_SELECTOR}--primary {
-        @include core.make-button-variant($BUTTON_SELECTOR, $button--primary...);
+    &.button--primary {
+        @include core.make-button-variant(".button", $button--primary...);
     }
 
-    &#{$BUTTON_SELECTOR}--secondary {
-        @include core.make-button-variant($BUTTON_SELECTOR, $button--secondary...);
+    &.button--secondary {
+        @include core.make-button-variant(".button", $button--secondary...);
     }
 
-    &#{$BUTTON_SELECTOR}--discrete {
+    &.button--discrete {
         width: inherit;
         min-width: 0;
         font-weight: var(--f-font-weight-bold);
         outline-offset: size.$padding-025;
         line-height: calc(1.25 * var(--f-font-size-standard));
 
-        @include core.make-button-variant($BUTTON_SELECTOR, $button--discrete...);
+        @include core.make-button-variant(".button", $button--discrete...);
 
         @include core.breakpoint-down(sm) {
             width: auto;
@@ -277,7 +275,7 @@ $button--tertiary: (
         }
     }
 
-    &#{$BUTTON_SELECTOR}--discrete-inverted {
+    &.button--discrete-inverted {
         width: inherit;
         min-width: 0;
         font-weight: var(--f-font-weight-bold);
@@ -290,7 +288,7 @@ $button--tertiary: (
         /* stylelint-enable declaration-block-no-redundant-longhand-properties */
         line-height: calc(1.25 * var(--f-font-size-standard));
 
-        @include core.make-button-variant($BUTTON_SELECTOR, $button--discrete-inverted...);
+        @include core.make-button-variant(".button", $button--discrete-inverted...);
 
         @include core.breakpoint-down(sm) {
             width: auto;
@@ -304,13 +302,13 @@ $button--tertiary: (
         }
     }
 
-    &#{$BUTTON_SELECTOR}--tertiary {
+    &.button--tertiary {
         width: inherit;
         min-width: 0;
         font-weight: var(--f-font-weight-medium);
         outline-offset: size.$padding-025;
 
-        @include core.make-button-variant($BUTTON_SELECTOR, $button--tertiary...);
+        @include core.make-button-variant(".button", $button--tertiary...);
 
         @include core.breakpoint-down(sm) {
             width: auto;
@@ -353,16 +351,16 @@ $button--tertiary: (
             }
         }
 
-        &#{$BUTTON_SELECTOR}--small {
+        &.button--small {
             min-width: 24px;
             padding: core.densify(0.375rem) size.$padding-025;
             text-underline-offset: 3.5px;
-            &#{$BUTTON_SELECTOR}--align-text {
+            &.button--align-text {
                 margin-left: -(size.$margin-025);
             }
         }
 
-        &#{$BUTTON_SELECTOR}--medium {
+        &.button--medium {
             min-width: 8rem;
             /* stylelint-disable declaration-block-no-redundant-longhand-properties -- readability */
             padding-top: core.densify(var(--f-button-tertiary-padding-top));
@@ -370,20 +368,20 @@ $button--tertiary: (
             padding-bottom: core.densify(var(--f-button-tertiary-padding-bottom));
             padding-left: var(--f-button-tertiary-padding-left);
             /* stylelint-enable declaration-block-no-redundant-longhand-properties */
-            &#{$BUTTON_SELECTOR}--align-text {
+            &.button--align-text {
                 margin-left: -(size.$margin-050);
             }
         }
 
-        &#{$BUTTON_SELECTOR}--large {
+        &.button--large {
             min-width: var(--f-button-min-width);
             padding: core.densify(1.125rem) 0.75rem;
-            &#{$BUTTON_SELECTOR}--align-text {
+            &.button--align-text {
                 margin-left: -(size.$margin-075);
             }
         }
 
-        &#{$BUTTON_SELECTOR}--align-text {
+        &.button--align-text {
             margin-left: -(size.$margin-050);
             min-width: 0;
         }
@@ -395,15 +393,15 @@ $button--tertiary: (
         }
     }
 
-    &#{$BUTTON_SELECTOR}--full-width {
+    &.button--full-width {
         min-width: var(--f-width-full);
     }
 
-    &#{$BUTTON_SELECTOR}--margin-bottom-0 {
+    &.button--margin-bottom-0 {
         margin-bottom: 0;
     }
 
-    &#{$BUTTON_SELECTOR}--small {
+    &.button--small {
         font-size: 14px;
         line-height: 1.25rem;
         min-width: 4rem;
@@ -421,7 +419,7 @@ $button--tertiary: (
         }
     }
 
-    &#{$BUTTON_SELECTOR}--medium {
+    &.button--medium {
         line-height: 1.5rem;
         min-width: 8rem;
         padding: core.densify(0.625rem) 1.25rem;
@@ -433,7 +431,7 @@ $button--tertiary: (
         }
     }
 
-    &#{$BUTTON_SELECTOR}--large {
+    &.button--large {
         line-height: 1.5rem;
         min-width: 9.5rem;
         padding: core.densify(1rem) 1.5rem;
@@ -463,7 +461,7 @@ $button--tertiary: (
     &.disabled:hover,
     &:disabled,
     &:disabled:hover,
-    &#{$BUTTON_SELECTOR}--disabled {
+    &.button--disabled {
         border-width: var(--f-border-width-medium);
         box-shadow: none;
         cursor: default;

--- a/packages/design/src/components/calendar-day/_calendar-day.scss
+++ b/packages/design/src/components/calendar-day/_calendar-day.scss
@@ -1,10 +1,9 @@
 @use "../../core/mixins/circle";
 @use "variables" as *;
 
-$CALENDAR_DAY_SELECTOR: ".calendar-day" !default;
 $calendar-highlight-border: var(--f-border-width-small) solid $calendarday-highlight-color-border-default;
 
-#{$CALENDAR_DAY_SELECTOR} {
+.calendar-day {
     align-items: center;
     display: inline-flex;
     font-weight: var(--f-font-weight-medium);

--- a/packages/design/src/components/card/_card.scss
+++ b/packages/design/src/components/card/_card.scss
@@ -2,9 +2,7 @@
 @use "../../core/size";
 @use "variables" as *;
 
-$CARD_SELECTOR: ".card" !default;
-
-#{$CARD_SELECTOR} {
+.card {
     padding: core.densify(size.$padding-100) size.$padding-100;
     margin: core.densify(size.$margin-100) 0;
 

--- a/packages/design/src/components/checkbox/_checkbox-group.scss
+++ b/packages/design/src/components/checkbox/_checkbox-group.scss
@@ -1,15 +1,13 @@
 @use "../../core/size";
 @use ".././radio-button/item";
 
-$CHECKBOX_GROUP_SELECTOR: ".checkbox-group" !default;
-
-#{$CHECKBOX_GROUP_SELECTOR} {
+.checkbox-group {
     &__content {
         display: flex;
         flex-direction: column;
     }
     &--border {
-        #{$CHECKBOX_GROUP_SELECTOR}__content {
+        .checkbox-group__content {
             .checkbox {
                 @extend %selectable-item;
             }

--- a/packages/design/src/components/checkbox/_checkbox.scss
+++ b/packages/design/src/components/checkbox/_checkbox.scss
@@ -5,14 +5,13 @@
 @use "variables" as *;
 
 $checkbox_label_offset: 0.1rem;
-$CHECKBOX_SELECTOR: ".checkbox" !default;
 
 %checkbox-icon {
     mask-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE3LjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9ImNoZWNrYm94LWljb24iIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgogICAgICAgICB2aWV3Qm94PSIwIDAgMjAgMjAiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDIwIDIwIiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHJlY3QgeD0iMy40NzQiIHk9IjkuMTk0IiBmaWxsPSIjM0M1NTkyIiB3aWR0aD0iMCIgaGVpZ2h0PSIwIi8+CjxwYXRoIGZpbGw9ImN1cnJlbnRDb2xvciIgZD0iTTguMzc2LDE1LjAwNWMtMC40MTYsMC0wLjgzMi0wLjE1OC0xLjE0OS0wLjQ3NWwtMy4yNS0zLjI0M2MtMC42MzUtMC42MzQtMC42MzUtMS42NiwwLTIuMjkzCiAgICAgICAgYzAuNjM1LTAuNjMzLDEuNjYzLTAuNjMzLDIuMjk4LDBsMi4xMDEsMi4wOTdsNS4zNTEtNS4zNGMwLjYzNS0wLjYzNCwxLjY2My0wLjYzNCwyLjI5OCwwYzAuNjM1LDAuNjMzLDAuNjM1LDEuNjU5LDAsMi4yOTMKICAgICAgICBsLTYuNSw2LjQ4N0M5LjIwNywxNC44NDcsOC43OTIsMTUuMDA1LDguMzc2LDE1LjAwNXoiLz4KPC9zdmc+Cg==");
     mask-repeat: no-repeat;
 }
 
-#{$CHECKBOX_SELECTOR} {
+.checkbox {
     min-height: var(--f-height-medium);
     margin-bottom: core.densify(size.$margin-100);
 
@@ -87,7 +86,7 @@ $CHECKBOX_SELECTOR: ".checkbox" !default;
             color: GrayText;
         }
 
-        #{$CHECKBOX_SELECTOR}__label {
+        .checkbox__label {
             cursor: default;
 
             &::before {
@@ -105,7 +104,7 @@ $CHECKBOX_SELECTOR: ".checkbox" !default;
             }
         }
 
-        input[type="checkbox"]:checked + #{$CHECKBOX_SELECTOR}__label::after {
+        input[type="checkbox"]:checked + .checkbox__label::after {
             background-color: $checkbox-icon-color-content-disabled;
         }
     }
@@ -119,11 +118,11 @@ $CHECKBOX_SELECTOR: ".checkbox" !default;
         }
     }
 
-    input[type="checkbox"]:checked + #{$CHECKBOX_SELECTOR}__label::after {
+    input[type="checkbox"]:checked + .checkbox__label::after {
         opacity: 1;
     }
 
-    input[type="checkbox"]:focus + #{$CHECKBOX_SELECTOR}__label {
+    input[type="checkbox"]:focus + .checkbox__label {
         @include focus-indicator;
     }
 }

--- a/packages/design/src/components/contextmenu/_contextmenu.scss
+++ b/packages/design/src/components/contextmenu/_contextmenu.scss
@@ -2,9 +2,7 @@
 @use "../../core/mixins/breakpoints";
 @use "../../core/config-variables";
 
-$CONTEXTMENU_SELECTOR: ".contextmenu" !default;
-
-#{$CONTEXTMENU_SELECTOR} {
+.contextmenu {
     min-width: 260px;
     background-color: var(--f-background-popupmenu);
 

--- a/packages/design/src/components/crud-dataset/_crud-dataset.scss
+++ b/packages/design/src/components/crud-dataset/_crud-dataset.scss
@@ -1,8 +1,7 @@
-$CRUD_DATASET_SELECTOR: ".crud-dataset" !default;
 $crud-dataset-add-button-margin-top: 0.5rem !default;
 $crud-dataset-add-button-margin-left: 2px !default; // to line up with table or list that has 2px border
 
-#{$CRUD_DATASET_SELECTOR} {
+.crud-dataset {
     margin: 0 0 var(--f-margin-component-bottom);
 
     &__add-button {

--- a/packages/design/src/components/datepicker-field/_datepicker-field.scss
+++ b/packages/design/src/components/datepicker-field/_datepicker-field.scss
@@ -4,14 +4,11 @@
 @use "../../core/mixins/breakpoints";
 @use "variables" as *;
 
-$DATEPICKER_FIELD_SELECTOR: ".datepicker-field" !default;
-$POPUP_SELECTOR: ".popup" !default;
-
 // 40px = popup spacing (20px) * 2
 $popup-spacing: 40px;
 $calendar-width: calc(100vw - #{$popup-spacing});
 
-#{$DATEPICKER_FIELD_SELECTOR} {
+.datepicker-field {
     &__button {
         background: transparent;
         border: 0;
@@ -58,14 +55,14 @@ $calendar-width: calc(100vw - #{$popup-spacing});
     }
 }
 
-#{$POPUP_SELECTOR}--overlay #{$DATEPICKER_FIELD_SELECTOR} {
+.popup--overlay .datepicker-field {
     &__popup {
         width: $calendar-width;
         max-width: 28rem;
     }
 }
 
-#{$POPUP_SELECTOR}--inline #{$DATEPICKER_FIELD_SELECTOR} {
+.popup--inline .datepicker-field {
     &__popup {
         width: 100%;
     }

--- a/packages/design/src/components/entrypoint/_entrypoint.scss
+++ b/packages/design/src/components/entrypoint/_entrypoint.scss
@@ -2,9 +2,7 @@
 @use "../../core/size";
 @use "variables" as *;
 
-$ENTRYPOINT_SELECTOR: ".entrypoint" !default;
-
-#{$ENTRYPOINT_SELECTOR} {
+.entrypoint {
     background-color: $entrypoint-color-background-default;
     color: $entrypoint-color-text-default;
     border: var(--f-border-width-medium) solid transparent; // forced-colors mode

--- a/packages/design/src/components/error-list/_error-list.scss
+++ b/packages/design/src/components/error-list/_error-list.scss
@@ -3,9 +3,7 @@
 @use "../../core/size";
 @use "variables" as *;
 
-$ERROR_LIST_SELECTOR: ".error-list" !default;
-
-#{$ERROR_LIST_SELECTOR} {
+.error-list {
     color: $errorlist-color-text;
     margin: 0 0 core.densify(var(--f-margin-component-bottom));
 

--- a/packages/design/src/components/expandable-panel/_expandable-panel.scss
+++ b/packages/design/src/components/expandable-panel/_expandable-panel.scss
@@ -4,12 +4,11 @@
 @use "../../core/size";
 @use "../icon/icon";
 
-$EXPANDABLE_PANEL_SELECTOR: ".expandable-panel" !default;
 $EXPANDABLE_PANEL_LINE_HEIGHT: var(--f-line-height-medium);
 $ICON_MARGIN: 0.5rem;
 $ICON_WIDTH: var(--f-icon-size-medium);
 
-#{$EXPANDABLE_PANEL_SELECTOR} {
+.expandable-panel {
     margin-bottom: core.densify(size.$margin-200);
 
     &__icon {

--- a/packages/design/src/components/expandable-paragraph/_expandable-paragraph.scss
+++ b/packages/design/src/components/expandable-paragraph/_expandable-paragraph.scss
@@ -3,13 +3,12 @@
 @use "../../core/size";
 @use "../../core/mixins/circle" as *;
 
-$EXPANDABLE_PARAGRAPH_SELECTOR: ".expandable-paragraph" !default;
 $ICON_WIDTH: var(--f-icon-size-small);
 $ICON_MARGIN: 0.5rem;
 $CONTENT_MARGIN: calc(#{$ICON_WIDTH} + #{$ICON_MARGIN});
 $EXPANDABLE_PARAGRAPH_LINE_HEIGHT: var(--f-line-height-medium);
 
-#{$EXPANDABLE_PARAGRAPH_SELECTOR} {
+.expandable-paragraph {
     margin: 0 0 core.densify(var(--f-margin-component-bottom));
     &__heading {
         line-height: $EXPANDABLE_PARAGRAPH_LINE_HEIGHT;
@@ -43,20 +42,20 @@ $EXPANDABLE_PARAGRAPH_LINE_HEIGHT: var(--f-line-height-medium);
         }
     }
 
-    &#{$EXPANDABLE_PARAGRAPH_SELECTOR}--open {
-        #{$EXPANDABLE_PARAGRAPH_SELECTOR}__icon {
+    &.expandable-paragraph--open {
+        .expandable-paragraph__icon {
             svg:nth-child(2) {
                 transform: rotate(0);
             }
         }
 
-        #{$EXPANDABLE_PARAGRAPH_SELECTOR}__container {
+        .expandable-paragraph__container {
             height: auto;
         }
     }
 
-    &#{$EXPANDABLE_PARAGRAPH_SELECTOR}--closed {
-        #{$EXPANDABLE_PARAGRAPH_SELECTOR}__icon {
+    &.expandable-paragraph--closed {
+        .expandable-paragraph__icon {
             svg:nth-child(2) {
                 transform: rotate(-90deg);
             }

--- a/packages/design/src/components/fieldset/_fieldset.scss
+++ b/packages/design/src/components/fieldset/_fieldset.scss
@@ -2,9 +2,7 @@
 @use "../../core/config-variables";
 @use "../../core/size";
 
-$FIELDSET_SELECTOR: ".fieldset" !default;
-
-#{$FIELDSET_SELECTOR} {
+.fieldset {
     border: 0;
     margin: 0 0 core.densify(var(--f-margin-component-bottom));
     min-width: 0;

--- a/packages/design/src/components/file-item/_file-item.scss
+++ b/packages/design/src/components/file-item/_file-item.scss
@@ -1,15 +1,12 @@
 @use "../anchor/anchor";
 @use "../../core/size";
 
-$FILE_ITEM_SELECTOR: ".file-item" !default;
-$FILE_LIST_ITEM_SELECTOR: ".file-item-list" !default;
-
-#{$FILE_LIST_ITEM_SELECTOR} {
+.file-item-list {
     list-style-type: none;
     padding-left: 0;
 }
 
-#{$FILE_ITEM_SELECTOR} {
+.file-item {
     .button--discrete {
         padding: 0;
         min-width: auto;

--- a/packages/design/src/components/file-selector/_file-selector.scss
+++ b/packages/design/src/components/file-selector/_file-selector.scss
@@ -1,9 +1,7 @@
 @use "../../core/mixins/focus" as *;
 @use "../../core/mixins/sr-only" as *;
 
-$FILE_SELECTOR_SELECTOR: ".file-selector" !default;
-
-#{$FILE_SELECTOR_SELECTOR} {
+.file-selector {
     svg {
         color: var(--f-icon-color-primary);
     }

--- a/packages/design/src/components/file-uploader/_file-uploader.scss
+++ b/packages/design/src/components/file-uploader/_file-uploader.scss
@@ -1,6 +1,4 @@
-$FILE_UPLOADER_SELECTOR: ".file-uploader" !default;
-
-#{$FILE_UPLOADER_SELECTOR} {
+.file-uploader {
     &__message-box {
         margin-top: 1.25rem;
     }

--- a/packages/design/src/components/icon/_icon.scss
+++ b/packages/design/src/components/icon/_icon.scss
@@ -2,8 +2,6 @@
 @use "../../core/size";
 @use "variables" as *;
 
-$ICON_SELECTOR: ".icon" !default;
-
 @at-root {
     %icon--base {
         display: inline-block;
@@ -29,13 +27,13 @@ $ICON_SELECTOR: ".icon" !default;
 
         position: relative;
 
-        #{$ICON_SELECTOR} {
+        .icon {
             position: absolute;
         }
     }
 }
 
-#{$ICON_SELECTOR} {
+.icon {
     @extend %icon--base;
 
     &--flip-horizontal {
@@ -59,8 +57,8 @@ $ICON_SELECTOR: ".icon" !default;
     }
 }
 
-#{$ICON_SELECTOR}-stack,
-#{$ICON_SELECTOR} {
+.icon-stack,
+.icon {
     &--new-window {
         // anchor icons to top-right and bottom-left
         .icon {
@@ -81,8 +79,8 @@ $ICON_SELECTOR: ".icon" !default;
     }
 }
 
-#{$ICON_SELECTOR}-stack,
-#{$ICON_SELECTOR}--stack {
+.icon-stack,
+.icon--stack {
     @extend %icon-stack;
 
     &--tooltip {

--- a/packages/design/src/components/indent/_indent.scss
+++ b/packages/design/src/components/indent/_indent.scss
@@ -1,9 +1,8 @@
 @use "../../core/size";
 
 $radio_button_label_offset: 0.1rem;
-$INDENT_SELECTOR: ".indent" !default;
 
-#{$INDENT_SELECTOR} {
+.indent {
     border-left: var(--f-border-width-medium) solid var(--f-border-color-separator);
     margin-bottom: size.$margin-100;
     margin-left: size.$margin-050;

--- a/packages/design/src/components/label/_label.scss
+++ b/packages/design/src/components/label/_label.scss
@@ -3,9 +3,7 @@
 @use "../icon/icon";
 @use "variables" as *;
 
-$LABEL_SELECTOR: ".label" !default;
-
-#{$LABEL_SELECTOR} {
+.label {
     color: $label-color-text;
     display: inline-block;
     font-size: var(--f-font-size-standard);

--- a/packages/design/src/components/layout-application-template/_layout-application-template.scss
+++ b/packages/design/src/components/layout-application-template/_layout-application-template.scss
@@ -3,10 +3,9 @@
 @use "../../core/config-variables" as vars;
 @use "../z-index";
 
-$LAYOUT_APPLICATION_SELECTOR: ".layout-application-template" !default;
 $ZINDEX: z-index.$MODAL_ZINDEX - 1 !default;
 
-#{$LAYOUT_APPLICATION_SELECTOR} {
+.layout-application-template {
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -34,17 +33,17 @@ $ZINDEX: z-index.$MODAL_ZINDEX - 1 !default;
     }
 }
 
-#{$LAYOUT_APPLICATION_SELECTOR}__body {
+.layout-application-template__body {
     margin: 0;
     padding: 0;
     min-height: 100vh;
 }
 
-#{$LAYOUT_APPLICATION_SELECTOR}__body > div {
+.layout-application-template__body > div {
     height: 100%;
 }
 
-#{$LAYOUT_APPLICATION_SELECTOR}__html {
+.layout-application-template__html {
     height: 100%;
 }
 

--- a/packages/design/src/components/layout-navigation/_layout-navigation.scss
+++ b/packages/design/src/components/layout-navigation/_layout-navigation.scss
@@ -1,6 +1,5 @@
 @use "../z-index";
 
-$LAYOUT_NAVIGATION_SELECTOR: ".layout-navigation" !default;
 $ZINDEX: z-index.$MODAL_ZINDEX - 1 !default;
 
 // parameters
@@ -20,7 +19,7 @@ $border-hover-navigation: #{$palette-color-bluebell-15};
 $border-dots-navigation: #{$palette-color-fk-black-50};
 $scrollbar-navigation: #{$palette-color-fk-black-50};
 
-#{$LAYOUT_NAVIGATION_SELECTOR} {
+.layout-navigation {
     min-height: 100%;
     width: 100%;
 

--- a/packages/design/src/components/layout-secondary/_layout-secondary.scss
+++ b/packages/design/src/components/layout-secondary/_layout-secondary.scss
@@ -1,6 +1,5 @@
 @use "../z-index";
 
-$LAYOUT_SECONDARY_SELECTOR: ".layout-secondary" !default;
 $ZINDEX: z-index.$MODAL_ZINDEX - 1 !default;
 
 // parameters
@@ -20,7 +19,7 @@ $border-hover-secondary: #{$palette-color-bluebell-15};
 $border-dots-secondary: #{$palette-color-fk-black-50};
 $scrollbar-secondary: #{$palette-color-fk-black-50};
 
-#{$LAYOUT_SECONDARY_SELECTOR} {
+.layout-secondary {
     width: 100%;
     min-height: 100%;
 

--- a/packages/design/src/components/list/_list.scss
+++ b/packages/design/src/components/list/_list.scss
@@ -2,8 +2,6 @@
 @use "../../core/config-variables";
 @use "../../core/size";
 
-$LIST_SELECTOR: ".list" !default;
-
 // list item specific variables
 $list-border: var(--f-border-width-medium) solid var(--f-border-color-grid);
 $list-padding: size.$padding-075;
@@ -27,7 +25,7 @@ $list-selectpane-padding: calc(var(--f-list-item-itempane-padding) - 0.2rem);
     background: var(--f-background-grid-active);
 }
 
-#{$LIST_SELECTOR} {
+.list {
     margin: $list-margin;
     padding-left: 0;
 
@@ -90,12 +88,12 @@ $list-selectpane-padding: calc(var(--f-list-item-itempane-padding) - 0.2rem);
     }
 
     &--hover {
-        #{$LIST_SELECTOR}__item:focus-within,
-        #{$LIST_SELECTOR}__item:hover {
+        .list__item:focus-within,
+        .list__item:hover {
             cursor: pointer;
             @extend %list-item-hover;
 
-            &#{$LIST_SELECTOR}__item {
+            &.list__item {
                 &--active {
                     @extend %list-item-active;
                 }

--- a/packages/design/src/components/loader/_loader.scss
+++ b/packages/design/src/components/loader/_loader.scss
@@ -1,8 +1,6 @@
 @use "../../core/size";
 @use "../z-index";
 
-$LOADER_SELECTOR: ".loader" !default;
-
 @keyframes bouncedelay {
     0%,
     80%,
@@ -25,7 +23,7 @@ $LOADER_SELECTOR: ".loader" !default;
     }
 }
 
-#{$LOADER_SELECTOR} {
+.loader {
     div[tabindex] {
         outline: none;
     }
@@ -66,7 +64,7 @@ $LOADER_SELECTOR: ".loader" !default;
     }
 
     &--overlay {
-        #{$LOADER_SELECTOR}__backdrop {
+        .loader__backdrop {
             align-items: center;
             background: var(--f-background-overlay);
             display: flex;
@@ -80,11 +78,11 @@ $LOADER_SELECTOR: ".loader" !default;
             z-index: z-index.$LOADER_OVERLAY_ZINDEX;
         }
 
-        #{$LOADER_SELECTOR}__wait-text {
+        .loader__wait-text {
             color: var(--f-text-color-default-inverted);
         }
 
-        #{$LOADER_SELECTOR}__circle {
+        .loader__circle {
             background-color: var(--f-icon-color-white);
         }
     }

--- a/packages/design/src/components/logo/_logo.scss
+++ b/packages/design/src/components/logo/_logo.scss
@@ -1,8 +1,6 @@
 @use "../../core/mixins/breakpoints";
 
-$LOGO_SELECTOR: ".logo" !default;
-
-#{$LOGO_SELECTOR} {
+.logo {
     display: inline-block;
 
     &--small {

--- a/packages/design/src/components/message-box/_message-box.scss
+++ b/packages/design/src/components/message-box/_message-box.scss
@@ -3,9 +3,7 @@
 @use "../../core/mixins/breakpoints";
 @use "variables" as *;
 
-$MESSAGE_BOX_SELECTOR: ".message-box" !default;
-
-@mixin make-box-variant($MESSAGE_BOX_SELECTOR, $background-color, $border-color, $short-layout: false) {
+@mixin make-box-variant($background-color, $border-color, $short-layout: false, $selector: ".message-box") {
     border: var(--f-border-width-medium) solid;
     border-color: $border-color;
     background-color: $background-color;
@@ -14,7 +12,7 @@ $MESSAGE_BOX_SELECTOR: ".message-box" !default;
     @if $short-layout {
         border-left: size.$padding-100 solid $border-color;
 
-        #{$MESSAGE_BOX_SELECTOR} {
+        #{$selector} {
             &__icon {
                 font-size: 0; // ignore any whitespaces in template affecting height
 
@@ -47,20 +45,20 @@ $MESSAGE_BOX_SELECTOR: ".message-box" !default;
     }
 }
 
-@mixin messagebox-banner-variant($selector, $short-layout: false) {
+@mixin messagebox-banner-variant($short-layout: false, $selector: ".message-box") {
     width: var(--f-width-full);
     box-shadow: var(--f-box-modal-shadow);
     border-collapse: separate;
     padding: core.densify(size.$padding-100) size.$padding-100;
 
-    @include make-box-variant($selector, $messagebox-error-color-background, $messagebox-error-color-border, $short-layout);
+    @include make-box-variant($messagebox-error-color-background, $messagebox-error-color-border, $short-layout, $selector: $selector);
 
     .iflex__item > p {
         margin-bottom: 0;
     }
 }
 
-#{$MESSAGE_BOX_SELECTOR} {
+.message-box {
     padding: core.densify(size.$padding-150) size.$padding-150;
     margin: size.$margin-050 0 core.densify(size.$margin-200) 0;
 
@@ -79,39 +77,39 @@ $MESSAGE_BOX_SELECTOR: ".message-box" !default;
     }
 
     &--info {
-        @include make-box-variant($MESSAGE_BOX_SELECTOR, $messagebox-info-color-background, $messagebox-info-color-border);
+        @include make-box-variant($messagebox-info-color-background, $messagebox-info-color-border);
     }
 
     &--info-short {
-        @include make-box-variant($MESSAGE_BOX_SELECTOR, $messagebox-info-color-background, $messagebox-info-color-border, $short-layout: true);
+        @include make-box-variant($messagebox-info-color-background, $messagebox-info-color-border, $short-layout: true);
     }
 
     &--error {
-        @include make-box-variant($MESSAGE_BOX_SELECTOR, $messagebox-error-color-background, $messagebox-error-color-border);
+        @include make-box-variant($messagebox-error-color-background, $messagebox-error-color-border);
     }
 
     &--error-short {
-        @include make-box-variant($MESSAGE_BOX_SELECTOR, $messagebox-error-color-background, $messagebox-error-color-border, $short-layout: true);
+        @include make-box-variant($messagebox-error-color-background, $messagebox-error-color-border, $short-layout: true);
     }
 
     &--warning {
-        @include make-box-variant($MESSAGE_BOX_SELECTOR, $messagebox-warning-color-background, $messagebox-warning-color-border);
+        @include make-box-variant($messagebox-warning-color-background, $messagebox-warning-color-border);
     }
 
     &--warning-short {
-        @include make-box-variant($MESSAGE_BOX_SELECTOR, $messagebox-warning-color-background, $messagebox-warning-color-border, $short-layout: true);
+        @include make-box-variant($messagebox-warning-color-background, $messagebox-warning-color-border, $short-layout: true);
     }
 
     &--success {
-        @include make-box-variant($MESSAGE_BOX_SELECTOR, $messagebox-success-color-background, $messagebox-success-color-border);
+        @include make-box-variant($messagebox-success-color-background, $messagebox-success-color-border);
     }
 
     &--success-short {
-        @include make-box-variant($MESSAGE_BOX_SELECTOR, $messagebox-success-color-background, $messagebox-success-color-border, $short-layout: true);
+        @include make-box-variant($messagebox-success-color-background, $messagebox-success-color-border, $short-layout: true);
     }
 
     &--banner {
-        @include messagebox-banner-variant($MESSAGE_BOX_SELECTOR);
+        @include messagebox-banner-variant;
     }
 
     @include breakpoints.breakpoint-down(sm) {

--- a/packages/design/src/components/modal/_modal.scss
+++ b/packages/design/src/components/modal/_modal.scss
@@ -4,7 +4,6 @@
 @use "../../core/mixins/breakpoints";
 @use "variables" as *;
 
-$MODAL_SELECTOR: ".modal" !default;
 $modal-sizes: (
     "small": var(--f-modal-size-small),
     "medium": var(--f-modal-size-medium),
@@ -13,7 +12,7 @@ $modal-sizes: (
 ) !default;
 $modal-width: calc(100vw - 40px) !default; // 100% - 20px each side;
 
-#{$MODAL_SELECTOR} {
+.modal {
     &__backdrop {
         background: var(--f-background-overlay);
         display: flex;
@@ -55,7 +54,7 @@ $modal-width: calc(100vw - 40px) !default; // 100% - 20px each side;
         margin-bottom: size.$margin-050;
         width: 100%;
 
-        #{$MODAL_SELECTOR}__title {
+        .modal__title {
             font-size: var(--f-modal-title-font-size);
             margin-bottom: 0;
             margin-top: 0;
@@ -86,17 +85,17 @@ $modal-width: calc(100vw - 40px) !default; // 100% - 20px each side;
                 width: 100%;
                 max-width: none;
 
-                #{$MODAL_SELECTOR}__dialog {
+                .modal__dialog {
                     min-height: 100vh;
                 }
 
-                #{$MODAL_SELECTOR}__dialog-inner {
+                .modal__dialog-inner {
                     flex: 1 1 auto;
                     display: flex;
                     flex-direction: column;
                 }
 
-                #{$MODAL_SELECTOR}__content {
+                .modal__content {
                     flex: 1 1 auto;
                 }
             }
@@ -115,7 +114,7 @@ $modal-width: calc(100vw - 40px) !default; // 100% - 20px each side;
         position: relative;
         z-index: z-index.$MODAL_ZINDEX;
 
-        #{$MODAL_SELECTOR}__dialog-inner {
+        .modal__dialog-inner {
             height: auto;
             margin: 0 size.$margin-150 size.$margin-150;
 
@@ -124,7 +123,7 @@ $modal-width: calc(100vw - 40px) !default; // 100% - 20px each side;
             }
         }
 
-        #{$MODAL_SELECTOR}__footer {
+        .modal__footer {
             margin-top: size.$margin-200;
 
             > .button-group {
@@ -153,18 +152,18 @@ $modal-width: calc(100vw - 40px) !default; // 100% - 20px each side;
         }
     }
 
-    &--information #{$MODAL_SELECTOR}__shelf {
+    &--information .modal__shelf {
         background-color: $modal-shelf-info-color-background;
         .close-button {
             color: $modal-color-closebutton-text-inverted;
         }
     }
 
-    &--warning #{$MODAL_SELECTOR}__shelf {
+    &--warning .modal__shelf {
         background-color: $modal-shelf-warning-color-background;
     }
 
-    &--error #{$MODAL_SELECTOR}__shelf {
+    &--error .modal__shelf {
         background-color: $modal-shelf-error-color-background;
         .close-button {
             color: $modal-color-closebutton-text-inverted;

--- a/packages/design/src/components/navigation-menu/_navigation-menu.scss
+++ b/packages/design/src/components/navigation-menu/_navigation-menu.scss
@@ -2,9 +2,7 @@
 @use "../../core/mixins/breakpoints";
 @use "../../core/config-variables";
 
-$IMENU_SELECTOR: ".imenu" !default;
-
-#{$IMENU_SELECTOR} {
+.imenu {
     &__list {
         background-color: var(--f-background-menu);
         margin: 0;
@@ -43,7 +41,7 @@ $IMENU_SELECTOR: ".imenu" !default;
     }
 }
 
-#{$IMENU_SELECTOR}--vertical {
+.imenu--vertical {
     .imenu__list {
         display: block;
 
@@ -68,7 +66,7 @@ $IMENU_SELECTOR: ".imenu" !default;
     }
 }
 
-#{$IMENU_SELECTOR}--horizontal {
+.imenu--horizontal {
     overflow: hidden;
 
     .imenu__list {

--- a/packages/design/src/components/offline/_offline.scss
+++ b/packages/design/src/components/offline/_offline.scss
@@ -3,16 +3,12 @@
 @use "../z-index";
 @use "../icon/icon";
 
-$OFFLINE_SELECTOR: ".offline" !default;
-
 // @at-root is used to set these classes globally due to styling scope issue where the component is used out of the styling scope
 @at-root {
-    #{$OFFLINE_SELECTOR} {
-        @include message-box.messagebox-banner-variant($selector: $OFFLINE_SELECTOR, $short-layout: true);
+    .offline {
+        @include message-box.messagebox-banner-variant($selector: ".offline", $short-layout: true);
 
-        & {
-            padding: size.$padding-150;
-        }
+        padding: size.$padding-150;
 
         // Since @at-root is used also icon classes being used by the component must be redefined,
         // because they might not exist at the global scope.

--- a/packages/design/src/components/output-field/_output-field.scss
+++ b/packages/design/src/components/output-field/_output-field.scss
@@ -1,9 +1,7 @@
 @use "../../core";
 @use "../../core/config-variables";
 
-$OUTPUT_FIELD_SELECTOR: ".output-field" !default;
-
-#{$OUTPUT_FIELD_SELECTOR} {
+.output-field {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;

--- a/packages/design/src/components/page-header/_page-header.scss
+++ b/packages/design/src/components/page-header/_page-header.scss
@@ -1,9 +1,8 @@
 @use "../../core/size";
 
-$PAGE_HEADER_SELECTOR: ".page-header" !default;
 $page-header-separator-width: 1px !default;
 
-#{$PAGE_HEADER_SELECTOR} {
+.page-header {
     display: flex;
     flex-direction: row;
     width: 100%;

--- a/packages/design/src/components/progressbar/_progressbar.scss
+++ b/packages/design/src/components/progressbar/_progressbar.scss
@@ -1,11 +1,10 @@
 @use "../../core/size";
 @use "variables" as *;
 
-$PROGRESS_BAR_SELECTOR: ".progress" !default;
 $progressbar-height: var(--f-height-small);
 $progressbar-border-width: var(--f-border-width-medium);
 
-#{$PROGRESS_BAR_SELECTOR} {
+.progress {
     background-color: $progressbar-color-background;
     border-radius: var(--f-border-radius-medium);
     height: $progressbar-height;

--- a/packages/design/src/components/radio-button/_item.scss
+++ b/packages/design/src/components/radio-button/_item.scss
@@ -1,8 +1,5 @@
 @use ".././list/list";
 
-$RADIO_BUTTON_SELECTOR: ".radio-button" !default;
-$CHECKBOX_SELECTOR: ".checkbox" !default;
-
 %selectable-item {
     border: list.$list-border;
     margin-bottom: 0;
@@ -39,8 +36,8 @@ $CHECKBOX_SELECTOR: ".checkbox" !default;
     }
 }
 
-#{$RADIO_BUTTON_SELECTOR,
-$CHECKBOX_SELECTOR} {
+.radio-button,
+.checkbox {
     &__details {
         display: block;
     }

--- a/packages/design/src/components/radio-button/_radio-button-group.scss
+++ b/packages/design/src/components/radio-button/_radio-button-group.scss
@@ -3,33 +3,31 @@
 @use "./radio-button";
 @use "./item";
 
-$RADIO_BUTTON_GROUP_SELECTOR: ".radio-button-group" !default;
-
-#{$RADIO_BUTTON_GROUP_SELECTOR} {
+.radio-button-group {
     &__content {
         display: flex;
         flex-direction: column;
     }
 
     &--horizontal {
-        #{$RADIO_BUTTON_GROUP_SELECTOR}__content {
+        .radio-button-group__content {
             flex-direction: row;
 
-            #{radio-button.$RADIO_BUTTON_SELECTOR} {
+            .radio-button {
                 margin-bottom: 0;
             }
 
             @include bp.breakpoint-down(sm) {
                 flex-direction: column;
 
-                #{radio-button.$RADIO_BUTTON_SELECTOR} {
+                .radio-button {
                     margin-bottom: size.$margin-100;
                 }
             }
         }
     }
     &--border {
-        #{$RADIO_BUTTON_GROUP_SELECTOR}__content {
+        .radio-button-group__content {
             .radio-button {
                 @extend %selectable-item;
             }

--- a/packages/design/src/components/radio-button/_radio-button.scss
+++ b/packages/design/src/components/radio-button/_radio-button.scss
@@ -6,9 +6,8 @@
 @use "variables" as *;
 
 $radio_button_label_offset: 0.1rem;
-$RADIO_BUTTON_SELECTOR: ".radio-button" !default;
 
-#{$RADIO_BUTTON_SELECTOR} {
+.radio-button {
     min-height: var(--f-height-medium);
     margin-bottom: core.densify(size.$margin-100);
     margin-right: size.$margin-150;
@@ -82,7 +81,7 @@ $RADIO_BUTTON_SELECTOR: ".radio-button" !default;
             color: GrayText;
         }
 
-        #{$RADIO_BUTTON_SELECTOR}__label {
+        .radio-button__label {
             cursor: default;
             &::before,
             &::after {

--- a/packages/design/src/components/select-field/_select-field.scss
+++ b/packages/design/src/components/select-field/_select-field.scss
@@ -4,9 +4,7 @@
 @use "../../core/utils/functions" as *;
 @use "variables" as *;
 
-$SELECT_FIELD_SELECTOR: ".select-field" !default;
-
-#{$SELECT_FIELD_SELECTOR} {
+.select-field {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
@@ -23,7 +21,7 @@ $SELECT_FIELD_SELECTOR: ".select-field" !default;
     }
 
     &--table-error {
-        #{$SELECT_FIELD_SELECTOR}__select {
+        .select-field__select {
             padding-right: calc(var(--f-icon-size-large) + 2.25rem);
         }
     }
@@ -82,7 +80,7 @@ $SELECT_FIELD_SELECTOR: ".select-field" !default;
         text-align: center;
     }
     &--error {
-        #{$SELECT_FIELD_SELECTOR}__select {
+        .select-field__select {
             border-color: $selectfield-color-border-error;
         }
     }

--- a/packages/design/src/components/sort-filter-dataset/_sort-filter-dataset.scss
+++ b/packages/design/src/components/sort-filter-dataset/_sort-filter-dataset.scss
@@ -1,8 +1,6 @@
 @use "../../core";
 @use "../../core/size";
 
-$SORT_FILTER_DATASET_SELECTOR: ".sort-filter-dataset" !default;
-
 // Selectfield
 $sortfilter-field-margin-bottom: 0.85rem !default;
 
@@ -14,7 +12,7 @@ $sortfilter-field-label-padding-top: size.$padding-050 !default;
 $sortfilter-header-font-size: var(--f-font-size-h2) !default;
 $sortfilter-header-padding-top: size.$padding-025 !default;
 
-#{$SORT_FILTER_DATASET_SELECTOR} {
+.sort-filter-dataset {
     &__sort {
         min-width: 80px;
     }

--- a/packages/design/src/components/static-panel/_static-panel.scss
+++ b/packages/design/src/components/static-panel/_static-panel.scss
@@ -1,8 +1,6 @@
 @use "../../core/size";
 
-$STATIC_PANEL_SELECTOR: ".static-panel" !default;
-
-#{$STATIC_PANEL_SELECTOR} {
+.static-panel {
     margin-bottom: 2.5rem;
 
     &__heading {

--- a/packages/design/src/components/table/_table.scss
+++ b/packages/design/src/components/table/_table.scss
@@ -1,8 +1,6 @@
 @use "../../core";
 @use "../../core/size";
 
-$TABLE_SELECTOR: ".table" !default;
-
 // General variables
 $table-font-size: var(--f-font-size-standard) !default;
 $table-focus-size: 2px !default;
@@ -95,7 +93,7 @@ $table-input-offset-horizontal: 0.25rem;
     visibility: collapse;
 }
 
-#{$TABLE_SELECTOR} {
+.table {
     border-collapse: separate;
     border-spacing: 0;
     font-size: $table-font-size;
@@ -143,7 +141,7 @@ $table-input-offset-horizontal: 0.25rem;
                 border-right: none;
             }
 
-            #{$TABLE_SELECTOR}__column__header__icon {
+            .table__column__header__icon {
                 color: var(--f-icon-color-table-header);
                 height: var(--f-icon-size-x-small);
                 width: var(--f-icon-size-x-small);
@@ -157,7 +155,7 @@ $table-input-offset-horizontal: 0.25rem;
     }
 
     tbody {
-        #{$TABLE_SELECTOR}__row {
+        .table__row {
             @extend %table-row-normal;
 
             &--normal {
@@ -188,7 +186,7 @@ $table-input-offset-horizontal: 0.25rem;
                 @extend %table-row-focus-within;
 
                 // these have higher priority
-                &#{$TABLE_SELECTOR}__row {
+                &.table__row {
                     &--active {
                         @extend %table-row-active;
                     }
@@ -200,7 +198,7 @@ $table-input-offset-horizontal: 0.25rem;
                 @extend %table-row-focus;
 
                 // these have higher priority
-                &#{$TABLE_SELECTOR}__row {
+                &.table__row {
                     &--active {
                         @extend %table-row-active;
                     }
@@ -212,7 +210,7 @@ $table-input-offset-horizontal: 0.25rem;
             }
         }
 
-        #{$TABLE_SELECTOR}__expandable-row {
+        .table__expandable-row {
             @extend %table-row-normal;
 
             &--collapsed {
@@ -238,7 +236,7 @@ $table-input-offset-horizontal: 0.25rem;
             line-height: $table-row-line-height;
         }
 
-        #{$TABLE_SELECTOR}__column {
+        .table__column {
             // apply monospace font only on tbody rows, not thead
             &--numeric,
             &--date {
@@ -307,11 +305,11 @@ $table-input-offset-horizontal: 0.25rem;
     }
 
     &--striped tbody {
-        #{$TABLE_SELECTOR}__row:nth-child(even) {
+        .table__row:nth-child(even) {
             @extend %table-row-striped;
 
             // these have higher priority
-            &#{$TABLE_SELECTOR}__row {
+            &.table__row {
                 &--active {
                     @extend %table-row-active;
                 }
@@ -320,11 +318,11 @@ $table-input-offset-horizontal: 0.25rem;
     }
 
     &--hover tbody {
-        #{$TABLE_SELECTOR}__row:hover {
+        .table__row:hover {
             @extend %table-row-hover;
 
             // these have higher priority
-            &#{$TABLE_SELECTOR}__row {
+            &.table__row {
                 &--active {
                     @extend %table-row-active;
                 }
@@ -332,7 +330,7 @@ $table-input-offset-horizontal: 0.25rem;
         }
     }
 
-    &--selectable #{$TABLE_SELECTOR}__row {
+    &--selectable .table__row {
         td:hover,
         th:hover {
             cursor: pointer;
@@ -353,7 +351,7 @@ $table-input-offset-horizontal: 0.25rem;
             white-space: nowrap;
         }
 
-        #{$TABLE_SELECTOR} {
+        .table {
             margin: 0;
         }
 

--- a/packages/design/src/components/text-field/_text-field.scss
+++ b/packages/design/src/components/text-field/_text-field.scss
@@ -3,9 +3,7 @@
 @use "../../core/utils/functions" as *;
 @use "variables" as *;
 
-$TEXT_FIELD_SELECTOR: ".text-field" !default;
-
-#{$TEXT_FIELD_SELECTOR} {
+.text-field {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
@@ -90,12 +88,12 @@ $TEXT_FIELD_SELECTOR: ".text-field" !default;
     }
 
     &--error {
-        #{$TEXT_FIELD_SELECTOR}__input {
+        .text-field__input {
             border-color: $textfield-color-border-error;
         }
     }
 
-    &--search + #{$TEXT_FIELD_SELECTOR}__append-inner {
+    &--search + .text-field__append-inner {
         display: flex;
         justify-content: center;
         align-items: center;

--- a/packages/design/src/components/textarea-field/_textarea-field.scss
+++ b/packages/design/src/components/textarea-field/_textarea-field.scss
@@ -3,9 +3,7 @@
 @use "../../core/utils/functions" as *;
 @use "variables" as *;
 
-$TEXTAREA_FIELD_SELECTOR: ".textarea-field" !default;
-
-#{$TEXTAREA_FIELD_SELECTOR} {
+.textarea-field {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
@@ -41,7 +39,7 @@ $TEXTAREA_FIELD_SELECTOR: ".textarea-field" !default;
     }
 
     &--error {
-        #{$TEXTAREA_FIELD_SELECTOR}__textarea {
+        .textarea-field__textarea {
             border-color: $textareafield-color-border-error;
         }
     }

--- a/packages/design/src/components/wizard/_wizard-step.scss
+++ b/packages/design/src/components/wizard/_wizard-step.scss
@@ -1,21 +1,19 @@
 @use "../../core";
 @use "variables" as *;
 
-$WIZARD_STEP_SELECTOR: ".wizard-step" !default;
-
 /* Selectors */
 $icon-success-selector: ".icon.f-icon-success" !default;
-$header-selector: "#{$WIZARD_STEP_SELECTOR}__header" !default;
+$header-selector: ".wizard-step__header" !default;
 $title-selector: "#{$header-selector}__title" !default;
 $anchor-selector: "#{$title-selector} .anchor" !default;
-$step-of-selector: "#{$WIZARD_STEP_SELECTOR}__step-of" !default;
-$line-up-selector: "#{$WIZARD_STEP_SELECTOR}__line-up" !default;
-$line-down-selector: "#{$WIZARD_STEP_SELECTOR}__line-down" !default;
-$icon-line-down-selector: "#{$WIZARD_STEP_SELECTOR}__icon-container__line-down" !default;
-$icon-container-selector: "#{$WIZARD_STEP_SELECTOR}__icon-container" !default;
-$circle-selector: "#{$WIZARD_STEP_SELECTOR}__icon-container__circle" !default;
-$number-selector: "#{$WIZARD_STEP_SELECTOR}__icon-container__number" !default;
-$form-body-selector: "#{$WIZARD_STEP_SELECTOR}-body" !default;
+$step-of-selector: ".wizard-step__step-of" !default;
+$line-up-selector: ".wizard-step__line-up" !default;
+$line-down-selector: ".wizard-step__line-down" !default;
+$icon-line-down-selector: ".wizard-step__icon-container__line-down" !default;
+$icon-container-selector: ".wizard-step__icon-container" !default;
+$circle-selector: ".wizard-step__icon-container__circle" !default;
+$number-selector: ".wizard-step__icon-container__number" !default;
+$form-body-selector: ".wizard-step-body" !default;
 $form-border-container: "#{$form-body-selector}__border-container" !default;
 
 /* position adjustments for lines */
@@ -26,7 +24,7 @@ $line-gap-to-circle: 4px;
 $line-width: 2px;
 $icon-size: 30px;
 
-#{$WIZARD_STEP_SELECTOR} {
+.wizard-step {
     display: grid;
     grid-template:
         "wizard-step__line-up wizard-step__step-of" min-content

--- a/packages/design/src/components/wizard/_wizard.scss
+++ b/packages/design/src/components/wizard/_wizard.scss
@@ -1,5 +1,3 @@
-$WIZARD_SELECTOR: ".wizard" !default;
-
-#{$WIZARD_SELECTOR} {
+.wizard {
     margin-top: 20px;
 }

--- a/packages/design/src/core/mixins/_label-inline.scss
+++ b/packages/design/src/core/mixins/_label-inline.scss
@@ -2,15 +2,14 @@
 @use "../mixins/breakpoints";
 @use "../utils";
 
-$LABEL_SELECTOR: ".label" !default;
-
 @mixin label-inline() {
     @include breakpoints.breakpoint-up(md) {
         margin-bottom: utils.densify(size.$margin-075);
         flex-direction: row;
         justify-content: flex-start;
         width: auto;
-        #{$LABEL_SELECTOR} {
+
+        .label {
             width: auto;
             margin-right: size.$margin-100;
             padding-top: utils.densify(size.$padding-050);

--- a/packages/design/src/internal-components/animate-expand/_animate-expand.scss
+++ b/packages/design/src/internal-components/animate-expand/_animate-expand.scss
@@ -1,6 +1,4 @@
-$ANIMATE_EXPAND_SELECTOR: ".animate-expand" !default;
-
-#{$ANIMATE_EXPAND_SELECTOR} {
+.animate-expand {
     transition: var(--f-animation-expand-close);
     overflow: hidden;
     visibility: hidden;

--- a/packages/design/src/internal-components/calendar-month/_calendar-month.scss
+++ b/packages/design/src/internal-components/calendar-month/_calendar-month.scss
@@ -1,12 +1,11 @@
 @use "../../components/z-index";
 @use "variables" as *;
 
-$MONTH_SELECTOR: ".calendar-month" !default;
 $days: 7;
 $week-width: 2%;
 $day-width: calc((100% - $week-width) / $days);
 
-#{$MONTH_SELECTOR} {
+.calendar-month {
     &__table {
         border-spacing: 2px;
         padding: 0 0.5rem 1rem;

--- a/packages/design/src/internal-components/calendar-navbar/_calendar-navbar.scss
+++ b/packages/design/src/internal-components/calendar-navbar/_calendar-navbar.scss
@@ -1,11 +1,10 @@
 @use "variables" as *;
 
-$CALENDAR_NAVBAR_SELECTOR: ".calendar-navbar" !default;
 $calendar-icon-padding: 5px;
 $calendar-icon-disabled-border-width: 1px;
 $calendar-icon-disabled-padding: calc($calendar-icon-padding - $calendar-icon-disabled-border-width);
 
-#{$CALENDAR_NAVBAR_SELECTOR} {
+.calendar-navbar {
     display: flex;
     flex-direction: row;
     justify-content: space-between;

--- a/packages/design/src/internal-components/calendar/_calendar.scss
+++ b/packages/design/src/internal-components/calendar/_calendar.scss
@@ -1,6 +1,4 @@
-$CALENDAR_SELECTOR: ".calendar" !default;
-
-#{$CALENDAR_SELECTOR} {
+.calendar {
     &__wrapper {
         width: 100%;
     }

--- a/packages/design/src/internal-components/flex/_flex.scss
+++ b/packages/design/src/internal-components/flex/_flex.scss
@@ -2,7 +2,6 @@
 @use "../../core/mixins/breakpoints";
 @use "../../core/config-variables";
 
-$IFLEX_SELECTOR: ".iflex" !default;
 $iflex-base-gap: 0.25rem;
 
 %iflex {
@@ -45,7 +44,7 @@ $iflex-base-gap: 0.25rem;
     align-self: flex-end;
 }
 
-#{$IFLEX_SELECTOR} {
+.iflex {
     @extend %iflex;
 
     &__item {
@@ -79,20 +78,20 @@ $iflex-base-gap: 0.25rem;
     }
 }
 
-#{$IFLEX_SELECTOR}--collapse {
+.iflex--collapse {
     @include breakpoints.breakpoint-down(sm) {
         display: block;
     }
 }
 
-#{$IFLEX_SELECTOR}--wrap {
+.iflex--wrap {
     flex-wrap: wrap;
 }
 
-#{$IFLEX_SELECTOR}--float-right {
+.iflex--float-right {
     justify-content: flex-end;
 }
 
-#{$IFLEX_SELECTOR}--float-center {
+.iflex--float-center {
     justify-content: center;
 }

--- a/packages/design/src/internal-components/popup-error/_popup-error.scss
+++ b/packages/design/src/internal-components/popup-error/_popup-error.scss
@@ -11,8 +11,7 @@
 
 // With inspiration from:
 // https://www.smashingmagazine.com/2024/03/modern-css-tooltips-speech-bubbles-part1/#comments-modern-css-tooltips-speech-bubbles-part1
-$POPUP_ERROR_SELECTOR: ".popup-error" !default;
-#{$POPUP_ERROR_SELECTOR} {
+.popup-error {
     --i-popup-error-offset: 24px;
 
     // Arrorw angle
@@ -36,7 +35,7 @@ $POPUP_ERROR_SELECTOR: ".popup-error" !default;
         // the page height when teleporting to bottom of body.
         top: 0;
 
-        #{$POPUP_ERROR_SELECTOR}__wrapper {
+        .popup-error__wrapper {
             left: -10000px;
             position: absolute;
             z-index: z-index.$POPUP_ZINDEX;
@@ -47,7 +46,7 @@ $POPUP_ERROR_SELECTOR: ".popup-error" !default;
     &--inline {
         position: static;
 
-        #{$POPUP_ERROR_SELECTOR}__wrapper {
+        .popup-error__wrapper {
             box-sizing: border-box;
             margin-top: size.$margin-050;
             margin-bottom: size.$margin-050;
@@ -63,7 +62,7 @@ $POPUP_ERROR_SELECTOR: ".popup-error" !default;
         line-height: 24px;
         position: relative;
 
-        #{$POPUP_ERROR_SELECTOR}__button {
+        .popup-error__button {
             margin: 0;
             min-height: 24px;
             min-width: 24px;

--- a/packages/design/src/internal-components/popup-menu/_popup-menu.scss
+++ b/packages/design/src/internal-components/popup-menu/_popup-menu.scss
@@ -2,9 +2,7 @@
 @use "../../core/mixins/breakpoints";
 @use "../../core/config-variables";
 
-$IPOPUPMENU_SELECTOR: ".ipopupmenu" !default;
-
-#{$IPOPUPMENU_SELECTOR} {
+.ipopupmenu {
     background-color: var(--f-background-popupmenu);
 
     &__list {
@@ -30,7 +28,7 @@ $IPOPUPMENU_SELECTOR: ".ipopupmenu" !default;
     }
 }
 
-#{$IPOPUPMENU_SELECTOR}--vertical {
+.ipopupmenu--vertical {
     .ipopupmenu__list {
         display: block;
 

--- a/packages/design/src/internal-components/popup/_popup.scss
+++ b/packages/design/src/internal-components/popup/_popup.scss
@@ -2,9 +2,7 @@
 @use "../../components/z-index";
 @use "../../core/config-variables";
 
-$POPUP_SELECTOR: ".popup" !default;
-
-#{$POPUP_SELECTOR} {
+.popup {
     &--overlay {
         position: absolute;
 
@@ -12,7 +10,7 @@ $POPUP_SELECTOR: ".popup" !default;
         // the page height when teleporting to bottom of body.
         top: 0;
 
-        #{$POPUP_SELECTOR}__wrapper {
+        .popup__wrapper {
             left: -10000px;
             max-width: fit-content;
             border-radius: var(--f-border-radius-small);
@@ -25,7 +23,7 @@ $POPUP_SELECTOR: ".popup" !default;
     &--inline {
         position: static;
 
-        #{$POPUP_SELECTOR}__wrapper {
+        .popup__wrapper {
             box-sizing: border-box;
             margin-top: size.$margin-050;
             margin-bottom: size.$margin-050;

--- a/packages/design/src/internal-components/skip-link/_skip-link.scss
+++ b/packages/design/src/internal-components/skip-link/_skip-link.scss
@@ -1,9 +1,7 @@
 @use "../../core/size";
 @use "../../core/config-variables";
 
-$ISKIPLINK_SELECTOR: ".iskiplink" !default;
-
-#{$ISKIPLINK_SELECTOR} {
+.iskiplink {
     position: absolute;
     top: -200px;
 


### PR DESCRIPTION
fixes #581

Diff från kompilerad fil:

```diff
--- packages/design/lib-main/fkui.css   2025-07-22 12:19:52.846872285 +0200
+++ packages/design/lib/fkui.css        2025-07-22 12:26:13.988451824 +0200
@@ -1848,10 +1848,12 @@
   width: 100%;
 }
 
-.radio-button__details, .checkbox__details {
+.radio-button__details,
+.checkbox__details {
   display: block;
 }
-.radio-button__width, .checkbox__width {
+.radio-button__width,
+.checkbox__width {
   width: 100%;
 }
 
@@ -4254,6 +4256,7 @@
   background-color: var(--fkds-color-feedback-background-negative, #fcf3f3);
   border-radius: var(--f-border-radius-small, 2px);
   border-left: 1rem solid var(--fkds-color-feedback-border-negative, #ca1515);
+  padding: 1.5rem;
 }
 .offline .offline__icon {
   font-size: 0;
@@ -4282,9 +4285,6 @@
 .offline .iflex__item > p {
   margin-bottom: 0;
 }
-.offline {
-  padding: 1.5rem;
-}
 .offline__wrapper {
   position: fixed;
   position: sticky;
```

---

Första två ändringarna är kosmetiska, sista är en selector som nu slås ihop. Vad jag kan se så påverkar det inte något.