### PR TITLE
fix: numeric table column headers not right aligned (refs SFKUI-6500)

### DIFF
--- a/packages/design/src/components/table/_table.scss
+++ b/packages/design/src/components/table/_table.scss
@@ -142,6 +142,10 @@ $table-input-offset-horizontal: 0.25rem;
                 }
             }
         }
+
+        .table__column--numeric {
+            text-align: right;
+        }
     }
 
     tbody {


### PR DESCRIPTION
Åtgärdar #599.

### Berörda komponenter
https://forsakringskassan.github.io/designsystem/pr-preview/pr-602/components/table-and-list/table.html#datatabell