### PR TITLE
feat: new `XSortFilterDatasetNg` component in labs (refs SFKUI-6500)

### DIFF
--- a/etc/vue-labs.api.md
+++ b/etc/vue-labs.api.md
@@ -17,6 +17,7 @@ import { PropType } from 'vue';
 import { PublicProps } from 'vue';
 import { Ref } from 'vue';
 import { ShallowUnwrapRef } from 'vue';
+import { UnwrapRefSimple } from '@vue/reactivity';
 import { ValidatorConfig } from '@fkui/logic';
 import { ValidatorConfigs } from '@fkui/logic';
 import { ValidityEvent } from '@fkui/logic';
@@ -61,6 +62,9 @@ export class HoursMinutesValidatorUtils {
     static validate(value: string, config: ValidatorConfig, name: string, compare: (value: number, limit: number) => boolean): boolean;
 }
 
+// @public (undocumented)
+export function matchPropertyValue<T, K extends keyof T = keyof T>(property: K): (item: T, value: T[K] | null) => boolean;
+
 // @public
 export function minutesToHoursFloat(...values: Array<number | undefined>): number;
 
@@ -104,6 +108,9 @@ export type TableColumnType = TableColumn<unknown, never> extends infer U ? U ex
     type: infer T;
 } ? T extends undefined ? never : T : never : never;
 
+// @public (undocumented)
+export function uniqueValues<T, K extends keyof T = keyof T>(items: T[], property: K): Array<T[K]>;
+
 // Warning: (ae-forgotten-export) The symbol "__VLS_export_2" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -112,7 +119,12 @@ export const XFileDragdrop: typeof __VLS_export_2;
 // Warning: (ae-forgotten-export) The symbol "__VLS_export_3" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const XTimeTextField: typeof __VLS_export_3;
+export const XSortFilterDatasetNg: typeof __VLS_export_3;
+
+// Warning: (ae-forgotten-export) The symbol "__VLS_export_4" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export const XTimeTextField: typeof __VLS_export_4;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/vue-labs/docs/components/XSortFilterDatasetNg.md
+++ b/packages/vue-labs/docs/components/XSortFilterDatasetNg.md
@@ -1,0 +1,17 @@
+---
+title: XSortFilterDatasetNg
+status: Draft
+layout: component
+component:
+    - XSortFilterDatasetNg
+---
+
+```import
+XSortFilterDatasetNgExample.vue
+```
+
+## Props, Events & Slots
+
+:::api
+vue:XSortFilterDatasetNg
+:::

--- a/packages/vue-labs/elements.js
+++ b/packages/vue-labs/elements.js
@@ -7,6 +7,10 @@ module.exports = defineMetadata({
         flow: true,
     },
 
+    "x-sort-filter-dataset-ng": {
+        flow: true,
+    },
+
     "x-time-text-field": {
         flow: true,
     },

--- a/packages/vue-labs/src/components/XSortFilterDatasetNg/XSortFilterDatasetNg.vue
+++ b/packages/vue-labs/src/components/XSortFilterDatasetNg/XSortFilterDatasetNg.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts" generic="T">
+import { type Ref, ref } from "vue";
+import { debounce } from "@fkui/logic";
+
+const props = withDefaults(
+    defineProps<{
+        data: T[];
+        sort?(data: T[]): T[];
+        filter?(data: T[]): T[];
+    }>(),
+    {
+        sort: (data: T[]) => {
+            return data;
+        },
+        filter: (data: T[]) => {
+            return data;
+        },
+    },
+);
+
+const filtered = ref(props.filter(props.data)) as unknown as Ref<T[]>;
+const result = ref<T[]>(props.data);
+const debouncedUpdate = debounce(update, 250);
+
+function update(): void {
+    filtered.value = props.filter(props.data);
+    result.value = props.sort(filtered.value);
+}
+</script>
+
+<template>
+    <div class="sort-filter-dataset-ng">
+        <slot name="filter" v-bind="{ update: debouncedUpdate }"></slot>
+        <slot name="default" v-bind="{ result }"></slot>
+    </div>
+</template>

--- a/packages/vue-labs/src/components/XSortFilterDatasetNg/examples/XSortFilterDatasetNgExample.vue
+++ b/packages/vue-labs/src/components/XSortFilterDatasetNg/examples/XSortFilterDatasetNgExample.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import { computed, ref, useTemplateRef } from "vue";
+import {
+    FCheckboxField,
+    FFieldset,
+    FSelectField,
+    FTextField,
+    findHTMLElementFromVueRef,
+} from "@fkui/vue";
+import { XSortFilterDatasetNg, matchPropertyValue, uniqueValues } from "@fkui/vue-labs";
+import { type FruitData, fruits } from "./fruit-data";
+
+const searchRef = useTemplateRef("search");
+const actualElement = computed<HTMLInputElement | null>(() => {
+    const searchEl = findHTMLElementFromVueRef(searchRef);
+    return searchEl ? searchEl.querySelector("input") : null;
+});
+
+const flag = ref(true);
+const country = ref<string | null>(null);
+const availableCountries = uniqueValues(fruits, "origin");
+const matchCountry = matchPropertyValue<FruitData>("origin");
+
+function filter(value: FruitData[]): FruitData[] {
+    const searchTerm = actualElement.value?.value.toLowerCase();
+    return value.filter((it) => {
+        if (flag.value && it.name === "Banan") {
+            return false;
+        }
+
+        if (!matchCountry(it, country.value)) {
+            return false;
+        }
+        if (searchTerm) {
+            const name = it.name.toLowerCase();
+            const description = it.description.toLowerCase();
+            return name.includes(searchTerm) || description.includes(searchTerm);
+        }
+        return true;
+    });
+}
+</script>
+
+<template>
+    <h2 id="frukter">Frukter</h2>
+    <x-sort-filter-dataset-ng :data="fruits" :filter>
+        <template #filter="{ update }">
+            <div class="filters">
+                <f-fieldset>
+                    <template #label> Inställningar </template>
+                    <template #default>
+                        <f-checkbox-field
+                            v-model="flag"
+                            :value="true"
+                            @update:model-value="update()"
+                        >
+                            <template #default>Bara goda frukter</template>
+                        </f-checkbox-field>
+                    </template>
+                </f-fieldset>
+                <f-select-field v-model="country" @update:model-value="update()">
+                    <template #label>Land</template>
+                    <template #default>
+                        <option :value="null">-</option>
+                        <option v-for="value in availableCountries" :key="value">
+                            {{ value }}
+                        </option>
+                    </template>
+                </f-select-field>
+                <f-text-field ref="search" maxlength="40" @input="update">
+                    <template #default> Sök </template>
+                </f-text-field>
+            </div>
+        </template>
+        <template #default="{ result }">
+            <pre>{{ result }}</pre>
+        </template>
+    </x-sort-filter-dataset-ng>
+</template>
+
+<style>
+.filters {
+    @media (width > 640px) {
+        display: flex;
+        gap: 1rem;
+
+        > * {
+            flex: 0 1 auto;
+        }
+
+        .select-field {
+            width: 20rem;
+        }
+
+        .text-field {
+            width: 40rem;
+        }
+
+        label {
+            white-space: nowrap;
+        }
+    }
+}
+</style>

--- a/packages/vue-labs/src/components/XSortFilterDatasetNg/examples/fruit-data.ts
+++ b/packages/vue-labs/src/components/XSortFilterDatasetNg/examples/fruit-data.ts
@@ -1,0 +1,49 @@
+/**
+ * @internal
+ */
+export interface FruitData {
+    id: string;
+    name: string;
+    origin: string;
+    description: string;
+}
+
+/**
+ * @internal
+ */
+export const fruits: FruitData[] = [
+    {
+        id: "1",
+        name: "Äpple",
+        origin: "Sverige",
+        description:
+            "Rund, ofta röd eller grön frukt med söt eller syrlig smak.",
+    },
+    {
+        id: "2",
+        name: "Jordgubbe",
+        origin: "Sverige",
+        description:
+            "En liten, röd bärfrukt med söt smak och små frön på ytan.",
+    },
+    {
+        id: "3",
+        name: "Banan",
+        origin: "Colombia",
+        description: "Lång, gul frukt med mjukt och sött fruktkött.",
+    },
+    {
+        id: "4",
+        name: "Vattenmelon",
+        origin: "Spanien",
+        description:
+            "Stor, rund frukt med grönt skal och saftigt, rött fruktkött.",
+    },
+    {
+        id: "5",
+        name: "Grapefrukt",
+        origin: "Turkiet",
+        description:
+            "Stor, rund citrusfrukt med tjockt skal och saftig, syrlig smak.",
+    },
+];

--- a/packages/vue-labs/src/components/XSortFilterDatasetNg/index.ts
+++ b/packages/vue-labs/src/components/XSortFilterDatasetNg/index.ts
@@ -1,0 +1,3 @@
+export { matchPropertyValue } from "./match-property-value";
+export { uniqueValues } from "./unique-values";
+export { default as XSortFilterDatasetNg } from "./XSortFilterDatasetNg.vue";

--- a/packages/vue-labs/src/components/XSortFilterDatasetNg/match-property-value.ts
+++ b/packages/vue-labs/src/components/XSortFilterDatasetNg/match-property-value.ts
@@ -1,0 +1,10 @@
+/**
+ * @public
+ */
+export function matchPropertyValue<T, K extends keyof T = keyof T>(
+    property: K,
+): (item: T, value: T[K] | null) => boolean {
+    return (item, value) => {
+        return value === null || item[property] === value;
+    };
+}

--- a/packages/vue-labs/src/components/XSortFilterDatasetNg/unique-values.ts
+++ b/packages/vue-labs/src/components/XSortFilterDatasetNg/unique-values.ts
@@ -1,0 +1,13 @@
+/**
+ * @public
+ */
+export function uniqueValues<T, K extends keyof T = keyof T>(
+    items: T[],
+    property: K,
+): Array<T[K]> {
+    const values = items.map((it) => it[property]);
+    const unique = Array.from(new Set(values));
+    // eslint-disable-next-line sonarjs/no-alphabetical-sort -- leave as is for now
+    unique.sort(); // until we can use toSorted()
+    return unique;
+}

--- a/packages/vue-labs/src/components/index.ts
+++ b/packages/vue-labs/src/components/index.ts
@@ -7,4 +7,9 @@ export {
     defineTableColumns,
 } from "./FTable";
 export { XFileDragdrop } from "./XFileDragdrop";
+export {
+    XSortFilterDatasetNg,
+    matchPropertyValue,
+    uniqueValues,
+} from "./XSortFilterDatasetNg";
 export * from "./XTimeTextField";


### PR DESCRIPTION
Försökte använda `FSortFilterDataset` men tycker den är väldigt oflexibel då man inte kan göra något custom med den, jag ville exempelvis ha en dropdown för att välja ut rader med bara valt värde (tänk land i våra fruktexempel). Även söken känns lite sådär, den fungerar men jag vill ha fuzzy sök och jag vill ha mer kontroll över vad den söker i (det går med `filterAttributes` propen dock).

Blev också ganska tröttsamt att man behöver tusen propar för att överhuvudtaget göra något och det är opt-out på allt.

<img width="300" src="https://github.com/user-attachments/assets/9504611e-d58b-4186-93a2-a764d2a2a7b5" />

Den har inte 100% stöd för sort (än) för det behövde jag inte själv i mitt use-case men annars är den baserad på:

* Det är konsumenten som passar in alla inmatningsfält och hur de ska vara positionerade. Ska sök vara högerjusterat i desktop, ja då lägger konsumenten själv på flexbox och `flex-end`. Man skulle kunna tänka sig att det finns en layout-komponent (helt utanför `XSortFilterDatasetNg` som löser det).
* Filtrering och sortering är callbacks (propar), komponenten befattar sig egentligen inte med själva filteringen utan anropar bara callbacks. Det är konsumenten själv som måste utföra jobbet. Bonus: då slipper vi tjafs med att jämföra kolumner med olika datatyper och whatnot som vi haft problem med.

Så här används den:

```html
<script setup>
const data = [ /* ... */ ];
const country = ref("");

function filter(items) {
  return items.filter(item => {
    if (country.value !== "" && item.country !== country.value) {
      return false;
    }
    if (search.value !== "" && !fuzzySearch(item, search.value)) {
      return false;
    }
    return true;
  });
}
</script>

<template>
  <h2 id="awesome-header">Rubrik</h2>
  <x-sort-filter-dataset-ng :data :filter>
    <template #filter="{ update }">
      <!-- inmatningsfält, anropar update() när något ändrats -->
    </template>
    <template #default="{ result }">
      <f-data-table aria-labelledby="awesome-header">
        <!-- presentation -->
      </f-data-table>
    </template>
  </x-sort-filter-dataset-ng>
</template>
```

Bonus: nu kan man semantiskt koppla ihop rubriken med tabellen.

Komponenten är mycket enklare och dummare men blir mycket smidigare och flexiblare, in my opinion.

Sök behöver lite extra hantering eftersom den ska söka direkt vid inmatning och inte vid blur, det hade varit nice om `FTextField` hade haft typ `v-model:instant` eller dyl för att direkt kunna binda sig på det direkta värdet men i exemplet här i PR så hämtas värdet ut via en template ref och `HTMLInputElement.value`.