### PR TITLE
refactor: remove unused method (refs SFKUI-6500)

### DIFF
--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -6919,7 +6919,6 @@ contentStyle(): Record<string, string>;
 }, {
 onOpenSecondary(): Promise<void>;
 onCloseSecondary(): void;
-openSecondary(): void;
 onClickCloseSecondary(): void;
 onResize(): void;
 }, ComponentOptionsMixin, ComponentOptionsMixin, {}, string, PublicProps, Readonly<ExtractPropTypes<    {

--- a/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.spec.ts
+++ b/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.spec.ts
@@ -3,6 +3,7 @@ import "@fkui/test-utils/jest";
 import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
 import FLayoutRightPanel from "./FLayoutRightPanel.vue";
+import { FLayoutRightPanelService } from "./services/FLayoutRightPanelService";
 
 let wrapper: VueWrapper;
 
@@ -22,8 +23,7 @@ async function createWrapper(): Promise<VueWrapper> {
         },
         attachTo: createPlaceholderInDocument(),
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- technical debt, should not test methods this way, should interact with the component the same way an actual user does
-    (wrapper.vm as any).openSecondary();
+    FLayoutRightPanelService.open();
     // wait for it to open
     await wrapper.vm.$nextTick();
     await flushPromises();

--- a/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.vue
+++ b/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.vue
@@ -97,9 +97,6 @@ export default defineComponent({
         onCloseSecondary(): void {
             this.isOpen = false;
         },
-        openSecondary(): void {
-            FLayoutRightPanelService.open();
-        },
         onClickCloseSecondary(): void {
             FLayoutRightPanelService.close();
         },


### PR DESCRIPTION
Snubblade över denna oanvända metoden (som visade sig användas i testfallet), slänger bort den.