### PR TITLE
test: fix `FBadgePageObject-is-inverted.cy.ts` spelling error (refs SFKUI-6500)

### DIFF
--- a/docs/functions/cypress/pageobjects/FBadgePageObject/FBadgePageObject-is-inverted.cy.ts
+++ b/docs/functions/cypress/pageobjects/FBadgePageObject/FBadgePageObject-is-inverted.cy.ts
@@ -5,10 +5,10 @@ it("should check if the badge is inverted or not ", () => {
     cy.mount(Example);
 
     /* --- cut above --- */
-    const myBadgeNotIverted = new FBadgePageObject(
+    const myBadgeNotInverted = new FBadgePageObject(
         "[data-test=my-badge-not-inverted]",
     );
-    myBadgeNotIverted.isInverted().should("be.equal", false);
+    myBadgeNotInverted.isInverted().should("be.equal", false);
 
     const myBadgeInverted = new FBadgePageObject(
         "[data-test=my-badge-inverted]",


### PR DESCRIPTION
https://forsakringskassan.github.io/designsystem/pr-preview/pr-614/functions/cypress/pageobjects/FBadgePageObject/is-inverted.html#exempel