### PR TITLE
docs: remove `@model` (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FCalendar/FCalendar.vue
+++ b/packages/vue/src/components/FCalendar/FCalendar.vue
@@ -13,7 +13,6 @@ export default defineComponent({
     props: {
         /**
          * Active month.
-         * @model
          */
         modelValue: {
             type: Object as PropType<FDate>,

--- a/packages/vue/src/components/FCheckboxField/FCheckboxField.vue
+++ b/packages/vue/src/components/FCheckboxField/FCheckboxField.vue
@@ -32,7 +32,6 @@ export default defineComponent({
         },
         /**
          * The value for the input checked attribute.
-         * @model
          */
         // ? The rule is disabled so that the `checked` prop can be undefined or null.
         /* eslint-disable-next-line vue/require-default-prop -- technical debt,

--- a/packages/vue/src/components/FCrudDataset/FCrudDataset.vue
+++ b/packages/vue/src/components/FCrudDataset/FCrudDataset.vue
@@ -25,7 +25,6 @@ const props = defineProps({
     /**
      * The list of items that should be deleted, modified or added to.
      * If the prop is not set an empty array will be used.
-     * @model
      */
     modelValue: {
         type: Array as PropType<T[]>,

--- a/packages/vue/src/components/FDatepickerField/FDatepickerField.vue
+++ b/packages/vue/src/components/FDatepickerField/FDatepickerField.vue
@@ -36,7 +36,6 @@ export default defineComponent({
     inheritAttrs: false,
     props: {
         /** Selected day.
-         * @model
          */
         modelValue: {
             type: String,

--- a/packages/vue/src/components/FDialogueTree/FDialogueTree.vue
+++ b/packages/vue/src/components/FDialogueTree/FDialogueTree.vue
@@ -20,7 +20,6 @@ export default defineComponent({
     props: {
         /**
          * Current dialogue question
-         * @model
          */
         modelValue: {
             type: Object as PropType<FDialogueTreeUserProgress>,

--- a/packages/vue/src/components/FRadioField/FRadioField.vue
+++ b/packages/vue/src/components/FRadioField/FRadioField.vue
@@ -32,7 +32,6 @@ export default defineComponent({
         },
         /**
          * The value for the input checked attribute.
-         * @model
          */
         modelValue: {
             type: anyType,

--- a/packages/vue/src/components/FSelectField/FSelectField.vue
+++ b/packages/vue/src/components/FSelectField/FSelectField.vue
@@ -32,7 +32,6 @@ export default defineComponent({
         /**
          * The value for the input.
          * If the prop is not set undefined will be used.
-         * @model
          */
         modelValue: {
             type: [String, Number, Object, Array, Boolean, null],

--- a/packages/vue/src/components/FTextField/FTextField.vue
+++ b/packages/vue/src/components/FTextField/FTextField.vue
@@ -37,7 +37,6 @@ export default defineComponent({
          * The value for the input.
          * If the prop is not used or set to undefined
          * or null then the default value will be used.
-         * @model
          */
         modelValue: {
             type: [String, Number, null],

--- a/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.vue
@@ -30,7 +30,6 @@ export default defineComponent({
         /**
          * The value for the input.
          * If the prop is not set undefined will be used.
-         * @model
          */
         modelValue: {
             type: [String, null],

--- a/packages/vue/src/components/FTextField/extendedTextFields/FNumericTextField/FNumericTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FNumericTextField/FNumericTextField.vue
@@ -16,7 +16,6 @@ export default defineComponent({
     props: {
         /**
          * The number of decimals to format number as.
-         * @model
          */
         decimals: {
             type: Number,

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.vue
@@ -25,7 +25,6 @@ export default defineComponent({
          * The value for the input.
          * If the prop is not used or set to undefined
          * or null then the default value will be used.
-         * @model
          */
         modelValue: {
             type: [String, null],

--- a/packages/vue/src/components/FTextareaField/FTextareaField.vue
+++ b/packages/vue/src/components/FTextareaField/FTextareaField.vue
@@ -24,7 +24,6 @@ export default defineComponent({
         /**
          * The value for the input.
          * If the prop is not set undefined will be used.
-         * @model
          */
         modelValue: {
             type: String,

--- a/packages/vue/src/components/FTooltip/FTooltip.vue
+++ b/packages/vue/src/components/FTooltip/FTooltip.vue
@@ -27,8 +27,6 @@ export default defineComponent({
         },
         /**
          * State (expanded or collapsed) of the tooltip. The value is `true` if the tooltip is expanded.
-         *
-         * @model
          */
         modelValue: {
             type: Boolean,

--- a/packages/vue/src/components/FValidationGroup/FValidationGroup.vue
+++ b/packages/vue/src/components/FValidationGroup/FValidationGroup.vue
@@ -15,7 +15,6 @@ export default defineComponent({
          *   `componentsWithError`: a list of components with errors sorted in DOM order
          *
          *   `componentCount`: number of registered components
-         * @model
          */
         modelValue: {
             type: Object as PropType<GroupValidityEvent>,

--- a/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.vue
+++ b/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.vue
@@ -14,8 +14,6 @@ export default defineComponent({
     props: {
         /**
          * Key of the currently selected and highlighted item.
-         *
-         * @model
          */
         modelValue: {
             type: String,
@@ -25,8 +23,6 @@ export default defineComponent({
         /**
          * Key of the currently focused item.
          * Sets focus on matching item element when value changes.
-         *
-         * @model
          */
         focusedItem: {
             type: String,

--- a/packages/vue/src/internal-components/calendar/ICalendarMonth.vue
+++ b/packages/vue/src/internal-components/calendar/ICalendarMonth.vue
@@ -18,7 +18,6 @@ export default defineComponent({
     props: {
         /**
          * Active month.
-         * @model
          */
         modelValue: {
             type: Object as PropType<FDate>,

--- a/packages/vue/src/internal-components/calendar/ICalendarMonthGrid.vue
+++ b/packages/vue/src/internal-components/calendar/ICalendarMonthGrid.vue
@@ -9,7 +9,6 @@ export default defineComponent({
     props: {
         /**
          * Focused month.
-         * @model
          */
         value: {
             type: Object as PropType<FDate>,

--- a/packages/vue/tsdoc.json
+++ b/packages/vue/tsdoc.json
@@ -6,10 +6,6 @@
             "syntaxKind": "modifier"
         },
         {
-            "tagName": "@model",
-            "syntaxKind": "modifier"
-        },
-        {
             "tagName": "@slot",
             "syntaxKind": "block"
         }


### PR DESCRIPTION
Håller på att fixa tabell för `v-model` i `docs-generator` och vore enklare att inte ta hänsyn till `@model`. Vad jag förstår så tillför inte `@model` nånting i dagsläget, så tar bort det.

Ändringen ska inte påverka dokumentationen i sig förutom i vissa fall där `@model` verkar ha använts oavsiktligen för props som inte är model (`FNumericTextField` och `ICalendarMonthGrid`).