### PR TITLE
fix: `FSortFilterDataset` use current sort on data change (fixes SFKUI-7310)

### DIFF
--- a/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.spec.ts
+++ b/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.spec.ts
@@ -281,26 +281,51 @@ it("should sort data when dropdown is changed", async () => {
     expect(rows[2].findAll("td")[0].text()).toBe("3");
 });
 
-it("should respect sort attribute after dataset change", async () => {
-    const wrapper = createTableWrapper();
-    const options = wrapper.find("select").findAll("option");
+describe("should keep sort on data change", () => {
+    it("when sort was selected using dropdown", async () => {
+        const wrapper = createTableWrapper();
+        const options = wrapper.find("select").findAll("option");
 
-    // Sort by Column B (Stigande)
-    await options[3].setValue();
-    let rows = wrapper.findAll("tr");
-    expect(rows[0].findAll("td")[1].text()).toBe("a");
-    expect(rows[1].findAll("td")[1].text()).toBe("k");
-    expect(rows[2].findAll("td")[1].text()).toBe("ö");
+        // Sort by Column B (Stigande)
+        await options[3].setValue();
+        let rows = wrapper.findAll("tr");
+        expect(rows[0].findAll("td")[1].text()).toBe("a");
+        expect(rows[1].findAll("td")[1].text()).toBe("k");
+        expect(rows[2].findAll("td")[1].text()).toBe("ö");
 
-    const newData = [...DATA, { a: 0, b: "b", c: "dummy", d: {} }];
-    await wrapper.setData({ data: newData });
-    await wrapper.vm.$nextTick();
+        const newData = [...DATA, { a: 0, b: "b", c: "dummy", d: {} }];
+        await wrapper.setData({ data: newData });
+        await wrapper.vm.$nextTick();
 
-    rows = wrapper.findAll("tr");
-    expect(rows[0].findAll("td")[1].text()).toBe("a");
-    expect(rows[1].findAll("td")[1].text()).toBe("b");
-    expect(rows[2].findAll("td")[1].text()).toBe("k");
-    expect(rows[3].findAll("td")[1].text()).toBe("ö");
+        rows = wrapper.findAll("tr");
+        expect(rows[0].findAll("td")[1].text()).toBe("a");
+        expect(rows[1].findAll("td")[1].text()).toBe("b");
+        expect(rows[2].findAll("td")[1].text()).toBe("k");
+        expect(rows[3].findAll("td")[1].text()).toBe("ö");
+    });
+
+    it("when sort was selected using inject method", async () => {
+        const wrapper = createTableWrapper();
+
+        // Sort by Column B (Stigande)
+        getUnderlyingComponent(wrapper).triggersort("b", true);
+        await wrapper.vm.$nextTick();
+
+        let rows = wrapper.findAll("tr");
+        expect(rows[0].findAll("td")[1].text()).toBe("a");
+        expect(rows[1].findAll("td")[1].text()).toBe("k");
+        expect(rows[2].findAll("td")[1].text()).toBe("ö");
+
+        const newData = [...DATA, { a: 0, b: "b", c: "dummy", d: {} }];
+        await wrapper.setData({ data: newData });
+        await wrapper.vm.$nextTick();
+
+        rows = wrapper.findAll("tr");
+        expect(rows[0].findAll("td")[1].text()).toBe("a");
+        expect(rows[1].findAll("td")[1].text()).toBe("b");
+        expect(rows[2].findAll("td")[1].text()).toBe("k");
+        expect(rows[3].findAll("td")[1].text()).toBe("ö");
+    });
 });
 
 it("should emit event when dataset is sorted", async () => {

--- a/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.vue
+++ b/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.vue
@@ -185,6 +185,7 @@ watch(
             if (foundAttribute) {
                 sortAttribute.value = foundAttribute;
             }
+            useDefaultSortOrder.value = false;
         }
         sortFilterData();
     },
@@ -207,7 +208,6 @@ function sortFilterData(): void {
 }
 
 function onChangeSortAttribute(): void {
-    useDefaultSortOrder.value = false;
     sortFilterData();
     emit("usedSortAttributes", sortAttribute.value);
 }


### PR DESCRIPTION
Problemet: om man har default sortering igång, sedan väljer annan sortering, och därefter ändrar `data` så återgår sorteringen till default.

Ändrar så att komponenten behåller vald sortering även om man ändrar `data`.

Jag har inte lyckats reproducera buggen i cypress oavsett `wait()`, invänta och dubbelkolla värden med `should()` innan, eller testa manuellt i cypress, så jag har inte kunnat skapa några tester för att säkerställa rätt beteende. Edit: la till jest test istället.