### PR TITLE
[MERGA INTE], Badge slot in FCard (refs SB-4982)

### DIFF
--- a/docs/components/FCard.md
+++ b/docs/components/FCard.md
@@ -11,6 +11,12 @@ Använd ett kort för att representera ett objekt eller en person, till exempel 
 FCardExample.vue
 ```
 
+TBD: Se över dokumentation, enbart inlagt här för att synliggöra förändringen.
+
+```import
+FCardBadgeExample.vue
+```
+
 Ett kort innehåller information och åtgärder. Ett kort ska kunna stå ensamt utan att förlita sig på sammanhanget, till exempel rubriker. Ett kort kan inte slås samman med ett annat kort, eller delas upp i flera. Om du behöver en underrubrik i ett kort så är det ett tecken på att du borde dela upp kortet i flera kort.
 
 Om det är mycket information som ska presenteras kan kortet visa en sammanfattning medan all information visas på en egen sida som öppnas från kortet. Undvik att expanderbara kort för att visa ytterligare information. Ett kort ska aldrig öppna ytterligare kort.

--- a/packages/vue/src/components/FCard/FCard.vue
+++ b/packages/vue/src/components/FCard/FCard.vue
@@ -11,6 +11,7 @@ const validationMessage = ref("");
 const hasError = ref(false);
 const isMounted = ref(false);
 
+const hasBadgeSlot = computed(() => hasSlot("badge"));
 const hasHeaderSlot = computed(() => hasSlot("header"));
 const hasFooterSlot = computed(() => hasSlot("footer"));
 const cardClass = computed(() => `card card--${hasError.value ? "error" : "default"}`);
@@ -70,6 +71,12 @@ async function onValidity({ detail }: CustomEvent<ValidityEvent>): Promise<void>
 
 <template>
     <div :id :class="cardClass" @validity="onValidity">
+        <div v-if="hasBadgeSlot" class="card__badge">
+            <!--
+                @slot Slot for status badge.
+            -->
+            <slot name="badge"></slot>
+        </div>
         <div v-if="hasHeaderSlot" class="card__header">
             <!--
             @slot Slot for the title.

--- a/packages/vue/src/components/FCard/examples/FCardBadgeExample.vue
+++ b/packages/vue/src/components/FCard/examples/FCardBadgeExample.vue
@@ -1,0 +1,32 @@
+<script>
+import { defineComponent } from "vue";
+import { FCard, FBadge } from "@fkui/vue";
+
+export default defineComponent({
+    name: "FCardExample",
+    components: { FCard, FBadge },
+});
+</script>
+
+<template>
+    <f-card>
+        <template #badge>
+            <f-badge status="success"> Nytt </f-badge>
+        </template>
+        <template #header="{ headingSlotClass }">
+            <h3 :class="headingSlotClass">Arbete</h3>
+        </template>
+        <template #default>
+            <p>Arbetsgivare</p>
+            <p>
+                Gatan 1 <br />
+                123 45 Staden <br />
+                Sverige
+            </p>
+            <p>
+                <label class="label"> Telefonnummer </label>
+                <span> 0109999999 </span>
+            </p>
+        </template>
+    </f-card>
+</template>


### PR DESCRIPTION
(OBS ej pixelperfekt bild, enbart för diskussion)
<img width="374" height="289" alt="image" src="https://github.com/user-attachments/assets/8740bc92-abec-47ec-9a1d-61f09be14343" />


Mina Sidor har behov utav Kort med status-brickor och vid test så har det inte fungerat att peta in i header-slot utan att vi skriver över befintlig CSS, vilket känns sådär.

@jaken22 var inte helt anti till att jag uttökar funktionaliteten i FKUI för att tillgodose dessa scenarios, och jag vill nu bolla lite med er innan jag kör vidare.

Skulle det vara ok med en ny slot, fast där ändå konsumenten får skicka in badge-komponenten? Eller borde jag åtgärda briserna/buggarna i header-slotten så att du kan skicka in båda elementet därifrån? 

Min personliga åsikt är en egen slot i någon form, för att kunna säkerhetsställa att marginaler och dylikt runtom blir enligt förväntan.