### PR TITLE
fix: FTableColumn do not render content if header (fixes SFKUI-7322)

### DIFF
--- a/internal/vue-sandbox/src/views/DefaultView.vue
+++ b/internal/vue-sandbox/src/views/DefaultView.vue
@@ -1,52 +1,94 @@
-<script lang="ts">
-import { defineComponent } from "vue";
-import { FTextField } from "@fkui/vue";
+<script setup lang="ts">
+import { ref } from "vue";
+import { FInteractiveTable, FTableColumn, FSortFilterDataset } from "@fkui/vue";
 
-export default defineComponent({
-    components: { FTextField },
-    data() {
-        return {
-            awesomeModel: "",
-        };
+interface FruitData {
+    id: string;
+    name: string;
+    origin: FruitOrigin;
+    description: string;
+    price: number;
+}
+
+interface FruitOrigin {
+    country: string;
+}
+
+const data = ref<FruitData[]>([
+    {
+        id: "1",
+        name: "Äpple",
+        origin: { country: "Sverige" },
+        description: "rund, ofta röd eller grön frukt med söt eller syrlig smak.",
+        price: 1980,
     },
+    {
+        id: "2",
+        name: "Banan",
+        origin: { country: "Colombia" },
+        description: "lång, gul frukt med mjukt och sött fruktkött.",
+        price: 15,
+    },
+    {
+        id: "3",
+        name: "Vattenmelon",
+        origin: { country: "Spanien" },
+        description: "stor, rund frukt med grönt skal och saftigt, rött fruktkött.",
+        price: 20,
+    },
+    {
+        id: "4",
+        name: "Grapefrukt",
+        origin: { country: "Turkiet" },
+        description: "stor, rund citrusfrukt med tjockt skal och saftig, syrlig smak.",
+        price: 164500,
+    },
+]);
+
+const sortableAttributes = ref({
+    name: "Namn",
 });
 </script>
 
 <template>
-    <div class="sandbox-root">
-        <h1>FKUI Sandbox</h1>
-        <p>
-            Ett internt paket som innehåller en avskalad Vue-applikation. Applikationen är konsument av övriga
-            FKUI-paket och innehåller enbart ett tomt exempel.
-        </p>
-        <p>
-            <strong>Ändra och labba gärna här men glöm inte återställa innan merge!</strong>
-        </p>
-        <hr />
-        <f-text-field
-            id="awesome-field"
-            v-model="awesomeModel"
-            v-validation.required.maxLength="{ maxLength: { length: 10 } }"
-        >
-            <template #default> Inmatningsfält. </template>
-            <template #description="{ descriptionClass }">
-                <span :class="descriptionClass"> Lorem ipsum dolor sit amet. </span>
-            </template>
-        </f-text-field>
-    </div>
+    <h3>Frukter</h3>
+    <f-sort-filter-dataset
+        :data
+        default-sort-attribute="name"
+        :default-sort-ascending="true"
+        :sortable-attributes="sortableAttributes"
+    >
+        <template #header="{ slotClass }">
+            <h3 :class="slotClass">Frukter</h3>
+        </template>
+        <template #default="{ sortFilterResult }">
+            <f-interactive-table :rows="sortFilterResult">
+                <template #caption>
+                    <span class="sr-only"> Frukter </span>
+                </template>
+                <template #default="{ row }">
+                    <f-table-column name="name" title="Namn" type="text" shrink>
+                        {{ row.name }}
+                    </f-table-column>
+                    <f-table-column name="origin" title="Land" type="text" shrink>
+                        {{ row.origin.country }}
+                    </f-table-column>
+                    <f-table-column
+                        v-format:text="row.description"
+                        name="description"
+                        title="Beskrivning"
+                        type="text"
+                        expand
+                    ></f-table-column>
+                    <f-table-column
+                        v-format:number="row.price"
+                        name="price"
+                        title="Pris"
+                        type="numeric"
+                        shrink
+                    ></f-table-column>
+                </template>
+            </f-interactive-table>
+        </template>
+    </f-sort-filter-dataset>
 </template>
-
-<style>
-.sandbox-root {
-    width: min(100% - 2rem, 80ch);
-    margin: auto;
-}
-
-h1 {
-    margin-top: 2rem;
-}
-
-hr {
-    margin-bottom: 2rem;
-}
-</style>

--- a/packages/design/src/components/table/_table.scss
+++ b/packages/design/src/components/table/_table.scss
@@ -296,6 +296,13 @@ $table-input-offset-horizontal: 0.25rem;
             color: $table-description-foreground;
             font-weight: $table-description-font-weight;
         }
+        &__wrapper {
+            pointer-events: none;
+
+            & > * {
+                pointer-events: auto;
+            }
+        }
     }
 
     &--striped tbody {

--- a/packages/vue/src/components/FDataTable/__snapshots__/FDataTable.spec.ts.snap
+++ b/packages/vue/src/components/FDataTable/__snapshots__/FDataTable.spec.ts.snap
@@ -69,12 +69,20 @@ exports[`should match snapshot tbody 1`] = `
   <!--v-if-->
   <!--v-if-->
   <tr class="table__row">
-    <td class="table__column table__column--text">1<span class="sr-only">&nbsp;</span></td>
-    <td class="table__column table__column--numeric">2<span class="sr-only">&nbsp;</span></td>
+    <td class="table__column table__column--text">
+      <div class="table__column__wrapper">1<span class="sr-only">&nbsp;</span></div>
+    </td>
+    <td class="table__column table__column--numeric">
+      <div class="table__column__wrapper">2<span class="sr-only">&nbsp;</span></div>
+    </td>
   </tr>
   <tr class="table__row">
-    <td class="table__column table__column--text">3<span class="sr-only">&nbsp;</span></td>
-    <td class="table__column table__column--numeric">4<span class="sr-only">&nbsp;</span></td>
+    <td class="table__column table__column--text">
+      <div class="table__column__wrapper">3<span class="sr-only">&nbsp;</span></div>
+    </td>
+    <td class="table__column table__column--numeric">
+      <div class="table__column__wrapper">4<span class="sr-only">&nbsp;</span></div>
+    </td>
   </tr>
 </tbody>
 `;

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.spec.ts
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.spec.ts
@@ -718,7 +718,7 @@ it("should call provided sort method when clicking columnheader that is registra
 });
 
 describe("Expandable rows", () => {
-    it("Should handle slot content in expanded rows", () => {
+    it("Should handle slot content in expanded rows", async () => {
         expect.assertions(3);
         const TestComponent = defineComponent({
             components: { FInteractiveTable, FTableColumn },
@@ -752,6 +752,8 @@ describe("Expandable rows", () => {
             },
         });
         const wrapper = mount(TestComponent);
+        await wrapper.vm.$nextTick();
+
         const tr = wrapper.findAll("tr");
         tr[0].element.click();
         expect(tr[1].text()).toBe("Juicy apples");

--- a/packages/vue/src/components/FInteractiveTable/__snapshots__/FInteractiveTable.spec.ts.snap
+++ b/packages/vue/src/components/FInteractiveTable/__snapshots__/FInteractiveTable.spec.ts.snap
@@ -5,15 +5,23 @@ exports[`should match snapshot tbody 1`] = `
   <tr class="table__row" tabindex="0">
     <!--v-if-->
     <!--v-if-->
-    <td class="table__column table__column--text">1<span class="sr-only">&nbsp;</span></td>
-    <td class="table__column table__column--numeric">2<span class="sr-only">&nbsp;</span></td>
+    <td class="table__column table__column--text">
+      <div class="table__column__wrapper">1<span class="sr-only">&nbsp;</span></div>
+    </td>
+    <td class="table__column table__column--numeric">
+      <div class="table__column__wrapper">2<span class="sr-only">&nbsp;</span></div>
+    </td>
   </tr>
   <!--v-if-->
   <tr class="table__row" tabindex="0">
     <!--v-if-->
     <!--v-if-->
-    <td class="table__column table__column--text">3<span class="sr-only">&nbsp;</span></td>
-    <td class="table__column table__column--numeric">4<span class="sr-only">&nbsp;</span></td>
+    <td class="table__column table__column--text">
+      <div class="table__column__wrapper">3<span class="sr-only">&nbsp;</span></div>
+    </td>
+    <td class="table__column table__column--numeric">
+      <div class="table__column__wrapper">4<span class="sr-only">&nbsp;</span></div>
+    </td>
   </tr>
   <!--v-if-->
   <!--v-if-->

--- a/packages/vue/src/components/FTableColumn/FTableColumn.spec.ts
+++ b/packages/vue/src/components/FTableColumn/FTableColumn.spec.ts
@@ -107,8 +107,8 @@ describe("when in `<thead>`", () => {
         jest.restoreAllMocks();
     });
 
-    it("should not render", async () => {
-        expect.assertions(1);
+    it("should only render element on mount", async () => {
+        expect.assertions(2);
         const TestComponent = {
             components: { FTableColumn },
             template: /* HTML */ `
@@ -129,12 +129,55 @@ describe("when in `<thead>`", () => {
             },
         };
         const wrapper = mount(TestComponent);
+        expect(wrapper.element.querySelector("td")).toMatchInlineSnapshot(`
+            <td
+              class="table__column table__column--text"
+            >
+              <div
+                class="table__column__wrapper"
+              >
+                <!--v-if-->
+              </div>
+            </td>
+        `);
+
         await wrapper.vm.$nextTick();
         expect(wrapper.element.querySelector("tr")).toMatchInlineSnapshot(`
             <tr>
               <!--v-if-->
             </tr>
         `);
+    });
+
+    it("should not throw on undefined object in content", async () => {
+        expect.assertions(1);
+        const TestComponent = {
+            components: { FTableColumn },
+            template: /* HTML */ `
+                <table>
+                    <thead>
+                        <tr>
+                            <f-table-column title="Mock column">
+                                {{ row.content.deep }}
+                            </f-table-column>
+                        </tr>
+                    </thead>
+                </table>
+            `,
+            setup() {
+                provide("addColumn", jest.fn());
+                provide("setVisibilityColumn", jest.fn());
+                provide("renderColumns", true);
+            },
+            data() {
+                return {
+                    row: {},
+                };
+            },
+        };
+        expect(async () => {
+            mount(TestComponent);
+        }).not.toThrow();
     });
 
     it("should register when mounted", async () => {

--- a/packages/vue/src/components/FTableColumn/FTableColumn.vue
+++ b/packages/vue/src/components/FTableColumn/FTableColumn.vue
@@ -129,6 +129,14 @@ const renderElement = computed(() => {
     return !hasMounted.value || shouldRender;
 });
 
+/**
+ * Only render content after it has finished mounted to avoid
+ * error on undefined object in content for headers.
+ */
+const renderContent = computed(() => {
+    return hasMounted.value && renderColumns.value;
+});
+
 watch(
     () => props.visible,
     () => {
@@ -172,13 +180,15 @@ function isTableHeader(): boolean {
 
 <template>
     <component :is="tagName" v-if="renderElement" ref="element" :class="classes" :scope="scope" v-bind="$attrs">
-        <template v-if="renderColumns">
-            <!-- @slot Content to be rendered in table cell. -->
-            <slot></slot>
-            <!-- Extra space between columns for screen reader. Otherwise it can sometimes read two numbers as one longer number.
-            For example a table with | 2 | 200 | can be read as 2200 in some languages.
-            -->
-            <span class="sr-only">&nbsp;</span>
-        </template>
+        <div class="table__column__wrapper">
+            <template v-if="renderContent">
+                <!-- @slot Content to be rendered in table cell. -->
+                <slot></slot>
+                <!-- Extra space between columns for screen reader. Otherwise it can sometimes read two numbers as one longer number.
+                For example a table with | 2 | 200 | can be read as 2200 in some languages.
+                -->
+                <span class="sr-only">&nbsp;</span>
+            </template>
+        </div>
     </component>
 </template>


### PR DESCRIPTION
När `FTableColumn` befinner sig i headern så finns inte någon `row`, utan bara ett tomt objekt skickas med. Och eftersom den renderas i ett tick för att avgöra om den är header eller inte, så blir det error om den har innehåll där man refererar till nåt som är tänkt att finnas på `row` objektet.

Potentiella lösningar jag sett...

1. Skicka med en dummy row för att inte få nån undefined referens, typ `<slot v-bind="{ row: rows[0] }" />`.
2. Rendera inte innehållet, bara elementet.

Försökte mig på nr 2, vilket ses i PR just nu, men blev problem då vue directives inte längre fungerade med kolumn med den ändringen (t.ex. `v-format:number`). Fungerar igen om jag lägger in en `div`. Gissningsvis är det för att det då inte finns nåt att lägga directive på när den mountas, liknande som att directives inte är funkis med `<teleport>` i root. Samt, nr 2 löser inte problemet om man refererar till det tomma objekt i nåt attribut på kolumnen så det känns som en återvändsgränd.

Nån som har andra idéer på lösningar? Annars lutar det väl åt att testa nr 1 istället.