### PR TITLE
fix: update editable style (refs SFKUI-6500)

### DIFF
--- a/packages/design/src/components/table-ng/_cell.scss
+++ b/packages/design/src/components/table-ng/_cell.scss
@@ -24,52 +24,63 @@ $horizontal-padding: size.$padding-050;
         }
     }
 
+    &--select,
     &--text {
         padding: 0 0.25rem;
 
         &:focus-visible {
-            outline: none !important;
-            box-shadow: none !important;
-
-            .table-ng__texticon {
+            .table-ng__editable__icon {
                 visibility: visible;
             }
         }
 
         &:hover {
-            .table-ng__textwrapper {
+            .table-ng__editable {
                 @extend %text-hover-state;
             }
         }
+    }
+
+    &--text {
+        &:focus-visible {
+            outline: none !important;
+            box-shadow: none !important;
+        }
 
         &.table-ng__cell--error:not(:focus-within) {
-            .table-ng__textwrapper {
+            .table-ng__editable {
                 @extend %text-error-state;
             }
-            .table-ng__texticon {
+            .table-ng__editable__icon {
                 visibility: visible;
             }
         }
 
         &.table-ng__cell--error:hover:not(:focus-within) {
-            .table-ng__textwrapper {
+            .table-ng__editable {
                 @extend %text-error-state;
             }
         }
 
         &.table-ng__cell--error:focus {
-            .table-ng__textwrapper {
+            .table-ng__editable {
                 @extend %text-error-state;
             }
         }
-    }
 
-    &--select {
-        padding: 0 0.25rem;
+        .table-ng__editable {
+            border-width: 2px;
+            border-style: solid;
+            border-color: transparent;
 
-        &:hover {
-            .table-ng__selectwrapper {
-                @extend %text-hover-state;
+            &:focus-within {
+                .table-ng__editable__text {
+                    display: none;
+                }
+
+                .table-ng__textedit {
+                    flex: 1 0 auto;
+                }
             }
         }
     }
@@ -98,43 +109,6 @@ $horizontal-padding: size.$padding-050;
     }
 }
 
-.table-ng__textwrapper {
-    padding: $vertical-padding $horizontal-padding;
-    display: flex;
-    border-width: 2px;
-    border-style: solid;
-    border-color: transparent;
-    align-items: center;
-
-    &:hover:not(:focus-within) .table-ng__texticon {
-        visibility: visible;
-    }
-
-    &:focus-within {
-        .table-ng__textview {
-            display: none;
-        }
-
-        .table-ng__textedit {
-            flex: 1 0 auto;
-        }
-    }
-}
-
-.table-ng__selectwrapper {
-    padding: $vertical-padding $horizontal-padding;
-    display: flex;
-    align-items: center;
-
-    &:hover:not(:focus-within) .table-ng__texticon {
-        visibility: visible;
-    }
-}
-
-.table-ng__textview {
-    flex: 1 1 auto;
-}
-
 .table-ng__textedit {
     flex: 0 1 0;
     width: 0;
@@ -148,9 +122,24 @@ $horizontal-padding: size.$padding-050;
     }
 }
 
-.table-ng__texticon {
-    visibility: hidden;
-    margin-left: 1rem;
+.table-ng__editable {
+    padding: $vertical-padding $horizontal-padding;
+    display: flex;
+    align-items: center;
+
+    &:hover:not(:focus-within) &__icon {
+        visibility: visible;
+    }
+
+    &__text {
+        flex: 1 1 auto;
+    }
+
+    &__icon {
+        visibility: hidden;
+        margin-left: 1rem;
+        flex: none;
+    }
 }
 
 %text-hover-state {

--- a/packages/vue-labs/src/components/FTable/ITableSelect.vue
+++ b/packages/vue-labs/src/components/FTable/ITableSelect.vue
@@ -223,9 +223,9 @@ function cancel(): void {
         @click.stop="onCellClick"
         @table-activate-cell="onActivateCell"
     >
-        <div v-show="!editing" class="table-ng__selectwrapper">
-            <span class="table-ng__textview">{{ viewValue }}</span>
-            <f-icon name="pen" class="table-ng__texticon"></f-icon>
+        <div v-show="!editing" class="table-ng__editable">
+            <span class="table-ng__editable__text">{{ viewValue }}</span>
+            <f-icon name="pen" class="table-ng__editable__icon"></f-icon>
         </div>
         <div
             v-show="editing"
@@ -235,7 +235,7 @@ function cancel(): void {
             aria-expanded
             :aria-controls="dropdownId"
             aria-autocomplete="list"
-            class="table-ng__selectwrapper"
+            class="table-ng__editable"
             @click.stop
             @dblclick.prevent
             @keydown.stop="onEditKeyDown"

--- a/packages/vue-labs/src/components/FTable/ITableText.vue
+++ b/packages/vue-labs/src/components/FTable/ITableText.vue
@@ -162,8 +162,8 @@ function onValidity(event: CustomEvent<ValidityEvent>): void {
         @keydown="onKeydown"
         @table-activate-cell="onActivateCell"
     >
-        <div class="table-ng__textwrapper">
-            <span ref="view" class="table-ng__textview">{{ column.value(row) }}</span>
+        <div class="table-ng__editable">
+            <span ref="view" class="table-ng__editable__text">{{ column.value(row) }}</span>
             <input
                 ref="input"
                 v-model="model"
@@ -174,8 +174,8 @@ function onValidity(event: CustomEvent<ValidityEvent>): void {
                 @blur="onBlur"
                 @validity="onValidity"
             />
-            <f-icon v-if="hasError" name="error" class="table-ng__texticon"></f-icon>
-            <f-icon v-else name="pen" class="table-ng__texticon"></f-icon>
+            <f-icon v-if="hasError" name="error" class="table-ng__editable__icon"></f-icon>
+            <f-icon v-else name="pen" class="table-ng__editable__icon"></f-icon>
         </div>
     </td>
     <td


### PR DESCRIPTION
Ändrar så att select och text använder samma style/klass för gemensamma edit grejer, samt fixar så att edit ikoner inte krymper och lägger till att edit ikon för select visas även vid fokus och inte bara hover.