### PR TITLE
refactor: `FTable` fix expandable nav (refs SFKUI-7329)

### DIFF
--- a/packages/design/src/components/table-ng/_cell.scss
+++ b/packages/design/src/components/table-ng/_cell.scss
@@ -96,16 +96,25 @@ $horizontal-padding: size.$padding-050;
         }
     }
 
+    &--expand,
     &--button {
         button {
-            background: inherit;
-            border: 0;
-            cursor: pointer;
-            margin: 0;
-            min-width: var(--f-icon-size-medium);
             padding: 0;
+            margin: 0;
+            border: 0;
+            min-width: var(--f-icon-size-medium);
             width: 100%;
+            background: inherit;
+            cursor: pointer;
+
+            svg {
+                vertical-align: middle;
+            }
         }
+    }
+
+    &--expand {
+        width: var(--f-icon-size-medium);
     }
 }
 
@@ -139,6 +148,16 @@ $horizontal-padding: size.$padding-050;
         visibility: hidden;
         margin-left: 1rem;
         flex: none;
+    }
+}
+
+.table-ng__custom-expandable {
+    padding: $vertical-padding $horizontal-padding;
+    border: 2px solid transparent;
+
+    &:focus {
+        box-shadow: none;
+        border: 2px solid var(--f-color-focus);
     }
 }
 

--- a/packages/vue-labs/src/components/FTable/FTable.vue
+++ b/packages/vue-labs/src/components/FTable/FTable.vue
@@ -27,6 +27,7 @@ import ITablePager from "./ITablePager.vue";
 import ITableHeader from "./ITableHeader.vue";
 import { stopEditKey } from "./start-stop-edit";
 import { type MetaRow } from "./MetaRow";
+import { type FTableActivateCellEvent } from "./events";
 
 type ExpandedContent = Required<T>[ExpandableAttribute] extends unknown[]
     ? Required<T>[ExpandableAttribute][number]
@@ -197,18 +198,34 @@ function onClick(e: MouseEvent): void {
     }
 }
 
+function isInExpandable(el: HTMLElement): boolean {
+    if (!el.parentElement) {
+        return false;
+    }
+    return Boolean(el.parentElement.closest(".table-ng__custom-expandable"));
+}
+
 function onTableFocusout(e: FocusEvent): void {
+    const { target, relatedTarget } = e;
+    const validFocus = target instanceof HTMLElement && relatedTarget instanceof HTMLElement;
+    if (!validFocus) {
+        return;
+    }
+    if (isInExpandable(target)) {
+        return;
+    }
+
     assertRef(tableRef);
-    const outsideTable = !e.relatedTarget || !tableRef.value.contains(e.relatedTarget as HTMLElement);
+    const outsideTable = !relatedTarget || !tableRef.value.contains(relatedTarget);
 
     if (outsideTable) {
-        const td = (e.target as HTMLElement).closest("td");
+        const td = target.closest("td");
 
         if (td) {
             dispatchActivateCellEvent(td, { focus: false });
         }
     } else {
-        (e.target as HTMLElement).tabIndex = -1;
+        target.tabIndex = -1;
     }
 }
 
@@ -256,6 +273,16 @@ function onToggleSortOrder(sortable: string): void {
         }
     } else {
         sort(sortable, true);
+    }
+}
+
+function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): void {
+    if (e.target instanceof HTMLElement) {
+        e.target.tabIndex = 0;
+
+        if (e.detail.focus) {
+            e.target.focus();
+        }
     }
 }
 
@@ -320,7 +347,12 @@ onMounted(() => {
                     @toggle="onToggleExpanded"
                 >
                     <template v-if="level! > 1 && hasExpandableSlot">
-                        <td :colspan="columns.length">
+                        <td
+                            class="table-ng__custom-expandable"
+                            :colspan="columns.length"
+                            tabindex="-1"
+                            @table-activate-cell="onActivateCell"
+                        >
                             <!-- @todo "typeof row" is a lie, row is not T but T | T[ExpandableAttribute] -->
                             <slot name="expandable" v-bind="{ row: row as ExpandedContent }" />
                         </td>

--- a/packages/vue-labs/src/components/FTable/ITableRow.vue
+++ b/packages/vue-labs/src/components/FTable/ITableRow.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts" generic="T extends Record<string, unknown>, K extends keyof T">
-import { computed, provide } from "vue";
+import { computed, provide, useTemplateRef } from "vue";
+import { assertRef } from "@fkui/logic";
 import { FIcon } from "@fkui/vue";
+import { type FTableActivateCellEvent } from "./events";
+
+const expandableRef = useTemplateRef("expandable");
 
 const {
     renderHeader = false,
@@ -25,6 +29,15 @@ const emit = defineEmits<{
 provide("renderHeader", renderHeader);
 
 const toggleIcon = computed(() => (isExpanded ? "arrow-down" : "arrow-right"));
+
+function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): void {
+    assertRef(expandableRef);
+    expandableRef.value.tabIndex = 0;
+
+    if (e.detail.focus) {
+        expandableRef.value.focus();
+    }
+}
 </script>
 
 <template>
@@ -37,18 +50,28 @@ const toggleIcon = computed(() => (isExpanded ? "arrow-down" : "arrow-right"));
     <template v-else>
         <tr class="table-ng__row" :aria-level>
             <template v-if="isTreegrid">
-                <td v-if="isExpandable" tabindex="-1">
+                <td
+                    v-if="isExpandable"
+                    class="table-ng__cell table-ng__cell--expand"
+                    @table-activate-cell="onActivateCell"
+                >
                     <button
+                        ref="expandable"
+                        tabindex="-1"
                         aria-label="toggle"
                         type="button"
-                        class="expander"
                         :class="`level-${ariaLevel}`"
                         @click="emit('toggle', rowKey)"
                     >
                         <f-icon class="button__icon" :name="toggleIcon"></f-icon>
                     </button>
                 </td>
-                <td v-else :class="`level-${ariaLevel}`"></td>
+                <td
+                    v-else
+                    ref="expandable"
+                    :class="`table-ng__cell level-${ariaLevel}`"
+                    @table-activate-cell="onActivateCell"
+                ></td>
             </template>
 
             <slot></slot>
@@ -57,14 +80,6 @@ const toggleIcon = computed(() => (isExpanded ? "arrow-down" : "arrow-right"));
 </template>
 
 <style>
-.expander {
-    margin: 0;
-    padding: 0;
-    background: inherit;
-    border: 0;
-    cursor: pointer;
-}
-
 .level-2 {
     margin-left: 0.5rem;
 }


### PR DESCRIPTION
Fixar till så man kan pila till kolumn för expanderingsknappen, samt till custom expanderad cell. Justerar också styling för att bland annat stämma överens med övriga celler.