### PR TITLE
refactor: dont import compiler macros (refs SFKUI-6500)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,6 +78,14 @@ export default [
     },
 
     {
+        name: "local/stricter-rules",
+        files: ["**/*.vue"],
+        rules: {
+            "vue/no-import-compiler-macros": "error",
+        },
+    },
+
+    {
         /* @todo technical debt */
         name: "local/technical-debt",
         rules: {

--- a/packages/vue/src/components/FButton/FButton.vue
+++ b/packages/vue/src/components/FButton/FButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineProps, useAttrs, type PropType } from "vue";
+import { computed, useAttrs, type PropType } from "vue";
 import { FIcon } from "../FIcon";
 import { useInflight } from "./use-inflight";
 


### PR DESCRIPTION
Löser varningen vi får:

> [@vue/compiler-sfc] `defineProps` is a compiler macro and no longer needs to be imported.

Lägger till eslint regel som klagar om vi försöker importera dem igen.