### PR TITLE
fix: fix redundant classes being added to FButton (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FButton/FButton.vue
+++ b/packages/vue/src/components/FButton/FButton.vue
@@ -139,8 +139,9 @@ const buttonClass = computed((): string[] => {
     if (props.mobileFullWidth && props.size !== "large") {
         classes.push(`button--full-width`);
     }
+
     if (inflight.value) {
-        classes.push(`${classes} button__inflight`);
+        classes.push(`button__inflight`);
     }
 
     return classes;


### PR DESCRIPTION
<img width="1145" height="82" alt="image" src="https://github.com/user-attachments/assets/0ac64b45-0044-4a39-a33c-b1d4399c0966" />

`${array}` blir implicit joined med `,` som delimiter men här vill vi överhuvudtaget inte lägga på dubbletterna ändå.

Hittade det när jag slog på `@typescript-eslint/restrict-template-expressions` som då klagar på implicit sträng-konvertering när man försöker skicka in en array till en template literal.

Det känns lite som att det saknas testfall någonstans här dock.