### PR TITLE
enable `@typescript-eslint/restrict-template-expressions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -147,7 +147,6 @@ export default [
             "@typescript-eslint/no-unsafe-assignment": "off",
             "@typescript-eslint/no-unsafe-call": "off",
             "@typescript-eslint/no-unsafe-return": "off",
-            "@typescript-eslint/restrict-template-expressions": "off",
             "@typescript-eslint/unbound-method": "off",
             "sonarjs/slow-regex": "off",
         },

--- a/packages/date/src/f-date.ts
+++ b/packages/date/src/f-date.ts
@@ -117,7 +117,7 @@ export class FDate implements IterableDate<FDate>, Clampable<FDate> {
     ): FDate {
         const paddedMonth = month.toString().padStart(2, "0");
         const paddedDay = day.toString().padStart(2, "0");
-        const iso = `${year}-${paddedMonth}-${paddedDay}`;
+        const iso = `${String(year)}-${paddedMonth}-${paddedDay}`;
 
         return FDate.fromIso(iso);
     }

--- a/packages/logic/src/dom/focus.ts
+++ b/packages/logic/src/dom/focus.ts
@@ -253,7 +253,7 @@ export function popFocus(handle: StackHandle): void {
     }
     const top = _focusElementStack.pop();
     if (top?.id !== handle[sym]) {
-        const outOfOrderErrorMsg = `push/pop called out-of-order. Expected stack handle id: ${top?.id} but got ${handle[sym]}`;
+        const outOfOrderErrorMsg = `push/pop called out-of-order. Expected stack handle id: ${String(top?.id)} but got ${String(handle[sym])}`;
         if (configLogic.production) {
             // eslint-disable-next-line no-console -- expected to log
             console.error(outOfOrderErrorMsg);

--- a/packages/logic/src/services/ValidationService/Validators/DecimalValidator.ts
+++ b/packages/logic/src/services/ValidationService/Validators/DecimalValidator.ts
@@ -13,7 +13,7 @@ export interface DecimalValidatorConfig extends ValidatorOptions {
 
 function createNumberRegexp(minDecimals = 0, maxDecimals = 2): RegExp {
     return new RegExp(
-        `^([-\u2212]?[0-9]+)([,.][0-9]{${minDecimals},${maxDecimals}})(?<![,.])$`,
+        `^([-\u2212]?[0-9]+)([,.][0-9]{${String(minDecimals)},${String(maxDecimals)}})(?<![,.])$`,
     );
 }
 

--- a/packages/logic/src/services/ValidationService/Validators/EmailValidator.ts
+++ b/packages/logic/src/services/ValidationService/Validators/EmailValidator.ts
@@ -14,7 +14,7 @@ export const emailValidator: Validator<EmailValidatorConfig> = {
     validation(value, _element, config) {
         const maxLength = config.maxLength ?? 254;
         const EMAIL_REGEXP = new RegExp(
-            `^(?=.{1,${maxLength}}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_\`a-z{|}~åäöÅÄÖ]+(\\.[-!#$%&'*+/0-9=?A-Z^_\`a-z{|}~åäöÅÄÖ]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$`,
+            `^(?=.{1,${String(maxLength)}}$)(?=.{1,64}@)[-!#$%&'*+/0-9=?A-Z^_\`a-z{|}~åäöÅÄÖ]+(\\.[-!#$%&'*+/0-9=?A-Z^_\`a-z{|}~åäöÅÄÖ]+)*@[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$`,
         );
 
         return isEmpty(value) || EMAIL_REGEXP.test(value);

--- a/packages/logic/src/utils/cookies.ts
+++ b/packages/logic/src/utils/cookies.ts
@@ -25,7 +25,7 @@ export function setCookie(options: CookieOptions): void {
     }
 
     const timeout = timeLimitSeconds ?? TWELVE_HOURS;
-    const cookieString = `${name}=${encodeURIComponent(value)}; path=/; max-age=${timeout};`;
+    const cookieString = `${name}=${encodeURIComponent(value)}; path=/; max-age=${String(timeout)};`;
 
     document.cookie = cookieString;
 }

--- a/packages/logic/src/utils/exceptions.ts
+++ b/packages/logic/src/utils/exceptions.ts
@@ -11,7 +11,7 @@ export class DecoratedError extends Error {
         super(message);
         Object.setPrototypeOf(this, DecoratedError.prototype);
         /* eslint-disable-next-line @typescript-eslint/restrict-plus-operands -- technical debt */
-        this.stack += `\nCaused by: ${cause.stack}`;
+        this.stack += `\nCaused by: ${String(cause.stack)}`;
         this.cause = cause;
     }
 

--- a/packages/vue-labs/src/components/FTable/ITableText.vue
+++ b/packages/vue-labs/src/components/FTable/ITableText.vue
@@ -59,7 +59,7 @@ function onStartEdit(modelValue: string): void {
 
     const { width } = tdElement.value.getBoundingClientRect();
     model.value = modelValue;
-    tdElement.value.style.setProperty("width", `${width}px`);
+    tdElement.value.style.setProperty("width", `${String(width)}px`);
 
     inputElement.value.focus();
 }

--- a/packages/vue-labs/src/components/XTimeTextField/XTimeTextField.vue
+++ b/packages/vue-labs/src/components/XTimeTextField/XTimeTextField.vue
@@ -30,7 +30,7 @@ export default defineComponent({
         const inputElement: HTMLInputElement = this.$el.querySelector("input");
 
         if (!isSet(inputElement)) {
-            throw new Error(`Could not find input element in XTimeTextField with id ${this.$el.id}`);
+            throw new Error(`Could not find input element in XTimeTextField with id ${String(this.$el.id)}`);
         }
 
         ValidationService.addValidatorsToElement(

--- a/packages/vue-labs/src/demo/Demo-2-FTable.vue
+++ b/packages/vue-labs/src/demo/Demo-2-FTable.vue
@@ -106,7 +106,9 @@ const columns = defineTableColumns<FruitOrder>([
         header: "Totalbelopp",
         type: "text",
         value(row) {
-            return `${formatNumber(String(erp.getOrderTotal(row)), 2)} kr`;
+            const total = erp.getOrderTotal(row);
+            const formatted = formatNumber(String(total), 2);
+            return `${String(formatted)} kr`;
         },
     },
     {

--- a/packages/vue/src/components/FCalendar/examples/FCalendarCustom.vue
+++ b/packages/vue/src/components/FCalendar/examples/FCalendarCustom.vue
@@ -60,7 +60,7 @@ export default defineComponent({
     },
     methods: {
         getEvents(date: FDate) {
-            const dayOfYear = `${date.month}-${date.day}`;
+            const dayOfYear = `${String(date.month)}-${String(date.day)}`;
 
             const match = holidays.find((it) => it.date === dayOfYear);
             if (match) {
@@ -72,7 +72,7 @@ export default defineComponent({
         },
         eventClasses(date: FDate) {
             const classes = ["event"];
-            const dayOfYear = `${date.month}-${date.day}`;
+            const dayOfYear = `${String(date.month)}-${String(date.day)}`;
 
             const match = holidays.find((it) => it.date === dayOfYear);
             if (match) {

--- a/packages/vue/src/components/FCalendar/use-calendar-height.ts
+++ b/packages/vue/src/components/FCalendar/use-calendar-height.ts
@@ -29,7 +29,10 @@ export function useCalendarHeight(options: UseCalendarHeightOptions): void {
 
     watchEffect(() => {
         if (cachedHeight.value) {
-            dst.value?.style.setProperty(property, `${cachedHeight.value}px`);
+            dst.value?.style.setProperty(
+                property,
+                `${String(cachedHeight.value)}px`,
+            );
         }
     });
 }

--- a/packages/vue/src/components/FCheckboxField/FCheckboxField.vue
+++ b/packages/vue/src/components/FCheckboxField/FCheckboxField.vue
@@ -166,11 +166,12 @@ export default defineComponent({
             let errorMessage = "";
 
             if (hasSlot(this, "default")) {
-                const labelText = this.injected.getFieldsetLabelText();
+                const labelText = this.injected.getFieldsetLabelText() as string | undefined;
+                const slotText = renderSlotText(this.$slots.default) ?? "";
                 if (labelText) {
-                    errorMessage = `${labelText} ${renderSlotText(this.$slots.default)}`;
+                    errorMessage = `${labelText} ${slotText}`;
                 } else {
-                    errorMessage = `${renderSlotText(this.$slots.default)}`;
+                    errorMessage = slotText;
                 }
             }
 

--- a/packages/vue/src/components/FDatepickerField/examples/FDatepickerFieldLiveExample.vue
+++ b/packages/vue/src/components/FDatepickerField/examples/FDatepickerFieldLiveExample.vue
@@ -131,7 +131,7 @@ export default defineComponent({
         },
         getMonthYearString(date: string): string {
             const fdate = FDate.fromIso(date);
-            return `${fdate.monthName} ${fdate.year}`;
+            return `${fdate.monthName} ${String(fdate.year)}`;
         },
         getInvalidDates(): string[] {
             return [FDate.now().addDays(-7).toString(), FDate.now().addDays(-3).toString()];

--- a/packages/vue/src/components/FErrorList/focus-error.ts
+++ b/packages/vue/src/components/FErrorList/focus-error.ts
@@ -2,12 +2,14 @@ import { focus, scrollTo } from "@fkui/logic";
 import { type ErrorItem } from "../../types";
 
 export function focusError(item: ErrorItem): void {
-    const element = document.querySelector(`#${item.id}`);
+    const element = document.querySelector(`#${String(item.id)}`);
     if (!element) {
-        throw new Error(`Can not find element with id "${item.id}"`);
+        throw new Error(`Can not find element with id "${String(item.id)}"`);
     }
 
-    const focusElement = document.querySelector(`#${item.focusElementId}`);
+    const focusElement = document.querySelector(
+        `#${String(item.focusElementId)}`,
+    );
 
     scrollTo(element, window.innerHeight * 0.25);
     focus(focusElement ?? element);

--- a/packages/vue/src/components/FIcon/examples/FIconAll.vue
+++ b/packages/vue/src/components/FIcon/examples/FIconAll.vue
@@ -18,7 +18,7 @@ async function importIcons(): Promise<IconPackage> {
 }
 
 function decamelize(value: string): string {
-    return value.replace(/([A-Z])/g, (_, ch) => `-${ch.toLowerCase()}`);
+    return value.replace(/([A-Z])/g, (_, ch: string) => `-${ch.toLowerCase()}`);
 }
 
 const iconsPromise = importIcons();

--- a/packages/vue/src/components/FLayoutLeftPanel/FLayoutLeftPanel.vue
+++ b/packages/vue/src/components/FLayoutLeftPanel/FLayoutLeftPanel.vue
@@ -41,21 +41,21 @@ export default defineComponent({
     computed: {
         navigationStyle(): Record<string, string> {
             if (this.isOpen) {
-                return { width: `${this.panelWidth}px`, top: `${this.offsetTop}px` };
+                return { width: `${String(this.panelWidth)}px`, top: `${String(this.offsetTop)}px` };
             } else {
-                return { top: `${this.offsetTop}px` };
+                return { top: `${String(this.offsetTop)}px` };
             }
         },
         primaryStyle(): Record<string, string> {
             if (this.isOpen) {
-                return { "margin-left": `${this.panelWidth}px` };
+                return { "margin-left": `${String(this.panelWidth)}px` };
             } else {
                 return { "margin-left": `3.5rem` };
             }
         },
         // This is to make word-wrap work in IE11
         contentStyle(): Record<string, string> {
-            return { "max-width": `${this.panelWidth - 35}px` };
+            return { "max-width": `${String(this.panelWidth - 35)}px` };
         },
     },
     mounted(): void {

--- a/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.vue
+++ b/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.vue
@@ -56,19 +56,19 @@ export default defineComponent({
     computed: {
         secondaryStyle(): Record<string, string> {
             if (this.isOpen) {
-                return { width: `${this.panelWidth}px`, top: `${this.offsetTop}px` };
+                return { width: `${String(this.panelWidth)}px`, top: `${String(this.offsetTop)}px` };
             }
-            return { top: `${this.offsetTop}px` };
+            return { top: `${String(this.offsetTop)}px` };
         },
         primaryStyle(): Record<string, string> {
             if (this.isOpen && !this.isAbsolutePositioned) {
-                return { "margin-right": `${this.panelWidth}px` };
+                return { "margin-right": `${String(this.panelWidth)}px` };
             }
             return {};
         },
         // This is to make word-wrap work in IE11
         contentStyle(): Record<string, string> {
-            return { "max-width": `${this.panelWidth - 35}px` };
+            return { "max-width": `${String(this.panelWidth - 35)}px` };
         },
     },
     mounted(): void {

--- a/packages/vue/src/components/FModal/FModal.vue
+++ b/packages/vue/src/components/FModal/FModal.vue
@@ -136,7 +136,7 @@ export default defineComponent({
         openModal(): void {
             const root = document.documentElement;
             const scroll = root.scrollTop;
-            root.style.top = `-${scroll}px`;
+            root.style.top = `-${String(scroll)}px`;
             root.style.left = "0";
             root.style.right = "0";
             // both of these properties is used to prevent scrolling in the background

--- a/packages/vue/src/components/FNavigationMenu/FNavigationMenu.vue
+++ b/packages/vue/src/components/FNavigationMenu/FNavigationMenu.vue
@@ -335,7 +335,7 @@ export default defineComponent({
             const firstHiddenItemRect = getAbsolutePosition(firstHiddenItem);
             const wrapperRect = getAbsolutePosition(wrapper);
             const offset = wrapperRect.x - firstHiddenItemRect.x;
-            wrapper.style.left = `-${offset}px`;
+            wrapper.style.left = `-${String(offset)}px`;
 
             this.popupOpen = popupWasOpen;
         },

--- a/packages/vue/src/components/FNavigationMenu/examples/router.ts
+++ b/packages/vue/src/components/FNavigationMenu/examples/router.ts
@@ -5,7 +5,10 @@ function generateExampleLabelsAndRoutes(
 ): NavigationMenuItem[] {
     const res = [];
     for (let i = 0; i < nbRoutes; i++) {
-        res.push({ label: `label${i + 1}`, route: `ROUTE_${i + 1}` });
+        res.push({
+            label: `label${String(i + 1)}`,
+            route: `ROUTE_${String(i + 1)}`,
+        });
     }
     return res;
 }

--- a/packages/vue/src/components/FProgressbar/FProgressbar.vue
+++ b/packages/vue/src/components/FProgressbar/FProgressbar.vue
@@ -47,7 +47,7 @@ function clamp(val: number): number {
 }
 
 const progressValueNow = computed(() => clamp(props.value));
-const cssWidth = computed(() => `width: ${progressValueNow.value}%`);
+const cssWidth = computed(() => `width: ${String(progressValueNow.value)}%`);
 const progressBarClass = computed(() => {
     if (progressValueNow.value === MIN_VALUE) {
         return "progress__meter--pending";

--- a/packages/vue/src/components/FRadioField/FRadioField.vue
+++ b/packages/vue/src/components/FRadioField/FRadioField.vue
@@ -119,10 +119,11 @@ export default defineComponent({
 
             if (hasSlot(this, "default")) {
                 const labelText = this.getFieldsetLabelText();
+                const slotText = renderSlotText(this.$slots.default) ?? "";
                 if (labelText) {
-                    errorMessage = `${labelText} ${renderSlotText(this.$slots.default)}`;
+                    errorMessage = `${labelText} ${slotText}`;
                 } else {
-                    errorMessage = `${renderSlotText(this.$slots.default)}`;
+                    errorMessage = slotText;
                 }
             }
 

--- a/packages/vue/src/components/FResizePane/FResizePane.ce.vue
+++ b/packages/vue/src/components/FResizePane/FResizePane.ce.vue
@@ -142,8 +142,8 @@ const orientation = computed((): Orientation => {
 
 const classes = computed(() => {
     return [
-        `resize--${attachment.value}`,
-        `resize--${direction.value}`,
+        `resize--${String(attachment.value)}`,
+        `resize--${String(direction.value)}`,
         props.overlay ? "resize--overlay" : undefined,
         props.disabled ? "resize--disabled" : undefined,
     ];
@@ -167,9 +167,9 @@ watchEffect(() => {
         const shadowRoot = root.value.getRootNode() as ShadowRoot;
         const host = shadowRoot.host as HTMLElement;
         host.style.setProperty("--size", `${String(value)}px`);
-        host.style.setProperty("--min", `${min}px`);
-        host.style.setProperty("--max", `${max}px`);
-        host.style.setProperty("--offset", `${props.offset}px`);
+        host.style.setProperty("--min", `${String(min)}px`);
+        host.style.setProperty("--max", `${String(max)}px`);
+        host.style.setProperty("--offset", `${String(props.offset)}px`);
     }
     if (separator.value) {
         separator.value.setAttribute("aria-valuemin", String(Math.floor(min)));

--- a/packages/vue/src/components/FTextField/examples/FTextFieldLiveExample.vue
+++ b/packages/vue/src/components/FTextField/examples/FTextFieldLiveExample.vue
@@ -98,7 +98,7 @@ export default defineComponent({
 
             if (this.maxLength > 0) {
                 validators += ".maxLength";
-                settings.push(` maxLength: { length: ${this.maxLength} }`);
+                settings.push(` maxLength: { length: ${String(this.maxLength)} }`);
             }
 
             if (settings.length > 0) {

--- a/packages/vue/src/components/FTooltip/FTooltip.vue
+++ b/packages/vue/src/components/FTooltip/FTooltip.vue
@@ -112,7 +112,7 @@ export default defineComponent({
             if (!wrapper.value) {
                 return;
             }
-            wrapper.value.style.setProperty("--f-tooltip-offset", `${offset.value}px`);
+            wrapper.value.style.setProperty("--f-tooltip-offset", `${String(offset.value)}px`);
             ready.value = true;
         });
         return { animate, iconTarget, ready };

--- a/packages/vue/src/components/FTooltip/use-animation.ts
+++ b/packages/vue/src/components/FTooltip/use-animation.ts
@@ -83,7 +83,7 @@ export function useAnimation(options: {
 
             if (state === "expand") {
                 animation = element.animate(
-                    [{ height: 0 }, { height: `${h}px` }],
+                    [{ height: 0 }, { height: `${String(h)}px` }],
                     {
                         duration,
                         easing,
@@ -91,7 +91,7 @@ export function useAnimation(options: {
                 );
             } else {
                 animation = element.animate(
-                    [{ height: `${h}px` }, { height: 0 }],
+                    [{ height: `${String(h)}px` }, { height: 0 }],
                     {
                         duration,
                         easing,

--- a/packages/vue/src/cypress/FCheckboxField.pageobject.ts
+++ b/packages/vue/src/cypress/FCheckboxField.pageobject.ts
@@ -13,7 +13,7 @@ export class FCheckboxFieldPageObject implements BasePageObject {
      */
     public constructor(selector: string, index?: number) {
         if (index) {
-            this.selector = `${selector}:nth(${index})`;
+            this.selector = `${selector}:nth(${String(index)})`;
         } else {
             this.selector = selector;
         }

--- a/packages/vue/src/cypress/FContextMenu.pageobject.ts
+++ b/packages/vue/src/cypress/FContextMenu.pageobject.ts
@@ -42,7 +42,7 @@ export class FContextMenuPageObject implements BasePageObject {
      */
     public getItemLink(index: number): DefaultCypressChainable {
         return cy.get(
-            `${this.selector} .contextmenu__list__item a:nth(${index})`,
+            `${this.selector} .contextmenu__list__item a:nth(${String(index)})`,
         );
     }
 }

--- a/packages/vue/src/cypress/FDialogueTree.pageobject.ts
+++ b/packages/vue/src/cypress/FDialogueTree.pageobject.ts
@@ -18,7 +18,7 @@ export class FDialogueTreePageObject implements BasePageObject {
 
     public option(index: number): FDialogueTreeItemPageObject {
         return new FDialogueTreeItemPageObject(
-            `${this.selector} li:nth(${index})`,
+            `${this.selector} li:nth(${String(index)})`,
         );
     }
 }

--- a/packages/vue/src/cypress/FErrorList.pageobject.ts
+++ b/packages/vue/src/cypress/FErrorList.pageobject.ts
@@ -33,7 +33,7 @@ export class FErrorListPageObject {
     }
 
     public getLink(index: number): DefaultCypressChainable {
-        return cy.get(`${this.selector} a:nth(${index})`);
+        return cy.get(`${this.selector} a:nth(${String(index)})`);
     }
 
     public getLinkByName(

--- a/packages/vue/src/cypress/FInteractiveTable.pageobject.ts
+++ b/packages/vue/src/cypress/FInteractiveTable.pageobject.ts
@@ -51,8 +51,8 @@ export class FInteractiveTablePageObject implements BasePageObject {
             [
                 this.selector,
                 `tbody`,
-                `tr:not(.table__expandable-row--collapsed):nth(${rowIndex})`,
-                `> .table__column:nth(${colIndex})`,
+                `tr:not(.table__expandable-row--collapsed):nth(${String(rowIndex)})`,
+                `> .table__column:nth(${String(colIndex)})`,
             ].join(" "),
         );
     }
@@ -79,7 +79,9 @@ export class FInteractiveTablePageObject implements BasePageObject {
         col: number,
     ): Cypress.Chainable<JQuery<HTMLTableCellElement>> {
         const index = col - 1;
-        return cy.get(`${this.selector} thead .table__column:nth(${index})`);
+        return cy.get(
+            `${this.selector} thead .table__column:nth(${String(index)})`,
+        );
     }
 
     /**
@@ -99,7 +101,7 @@ export class FInteractiveTablePageObject implements BasePageObject {
      * @param index - Row number (0-indexed).
      */
     public row(index: number): DefaultCypressChainable {
-        return cy.get(`${this.selector} tbody tr:nth(${index})`);
+        return cy.get(`${this.selector} tbody tr:nth(${String(index)})`);
     }
 
     /**
@@ -131,7 +133,7 @@ export class FInteractiveTablePageObject implements BasePageObject {
             [
                 this.selector,
                 `tbody`,
-                `tr:not(.table__expandable-row--collapsed):nth(${index})`,
+                `tr:not(.table__expandable-row--collapsed):nth(${String(index)})`,
                 `.checkbox`,
             ].join(" "),
         );
@@ -167,7 +169,7 @@ export class FInteractiveTablePageObject implements BasePageObject {
         }
 
         return cy.get(
-            `${this.selector} thead th:nth(${index}) svg.${iconName}`,
+            `${this.selector} thead th:nth(${String(index)}) svg.${iconName}`,
         );
     }
 

--- a/packages/vue/src/cypress/FListItem.pageobject.ts
+++ b/packages/vue/src/cypress/FListItem.pageobject.ts
@@ -14,7 +14,7 @@ export class FListItemPageObject implements BasePageObject {
      * @param index - the index of matched li:s.
      */
     public constructor(selector: string, index: number) {
-        this.selector = `${selector}:nth(${index})`;
+        this.selector = `${selector}:nth(${String(index)})`;
         this.index = index;
         this.el = () => cy.get(this.selector);
     }

--- a/packages/vue/src/cypress/FNavigationMenu/FNavigationMenu.pageobject.ts
+++ b/packages/vue/src/cypress/FNavigationMenu/FNavigationMenu.pageobject.ts
@@ -59,7 +59,7 @@ export class FNavigationMenuPageobject implements BasePageObject {
      */
     public itemLink(index: number): DefaultCypressChainable {
         return cy.get(
-            `${this.selector} .imenu__list__item:not(.imenu__list__item--hidden) a:nth(${index})`,
+            `${this.selector} .imenu__list__item:not(.imenu__list__item--hidden) a:nth(${String(index)})`,
         );
     }
 

--- a/packages/vue/src/cypress/FRadioField.pageobject.ts
+++ b/packages/vue/src/cypress/FRadioField.pageobject.ts
@@ -13,7 +13,7 @@ export class FRadioFieldPageObject implements BasePageObject {
      */
     public constructor(selector: string, index?: number) {
         if (index) {
-            this.selector = `${selector}:nth(${index})`;
+            this.selector = `${selector}:nth(${String(index)})`;
         } else {
             this.selector = selector;
         }

--- a/packages/vue/src/cypress/FTableColumn.pageobject.ts
+++ b/packages/vue/src/cypress/FTableColumn.pageobject.ts
@@ -10,7 +10,7 @@ export class FTableColumnPageObject implements BasePageObject {
     public el: () => DefaultCypressChainable;
     public index: number;
     public constructor(selector: string, index: number) {
-        this.selector = `${selector}:nth(${index})`;
+        this.selector = `${selector}:nth(${String(index)})`;
         this.index = index;
         this.el = () => cy.get(this.selector);
     }
@@ -19,7 +19,7 @@ export class FTableColumnPageObject implements BasePageObject {
      * @deprecated Use ´FInteractiveTablePageObject.cell()´ instead. Deprecated since v6.11.0.
      */
     public tableRowBodyContent(position: number): DefaultCypressChainable {
-        return cy.get(`${this.selector} td:nth(${position})`);
+        return cy.get(`${this.selector} td:nth(${String(position)})`);
     }
 
     /**

--- a/packages/vue/src/cypress/FWizard/FWizard.pageobject.ts
+++ b/packages/vue/src/cypress/FWizard/FWizard.pageobject.ts
@@ -30,7 +30,7 @@ export class FWizardPageobject implements BasePageObject {
      */
     public getStep(index: number): FWizardStepPageobject {
         return new FWizardStepPageobject(
-            `${this.selector} .wizard-step:nth(${index})`,
+            `${this.selector} .wizard-step:nth(${String(index)})`,
         );
     }
 

--- a/packages/vue/src/cypress/ICalendar/Calendar.pageobject.ts
+++ b/packages/vue/src/cypress/ICalendar/Calendar.pageobject.ts
@@ -66,15 +66,15 @@ export class CalendarPageObject implements BasePageObject {
      */
     public dayButton(day = 1): DefaultCypressChainable {
         return cy.get(
-            `${this.selector} .calendar-month__button:nth(${day - 1})`,
+            `${this.selector} .calendar-month__button:nth(${String(day - 1)})`,
         );
     }
 
     public day(day: number = 1): FCalendarDayPageObject {
         return new FCalendarDayPageObject(
-            `${this.selector} .calendar-month__button:nth(${
-                day - 1
-            }) .calendar-day`,
+            `${this.selector} .calendar-month__button:nth(${String(
+                day - 1,
+            )}) .calendar-day`,
         );
     }
 
@@ -85,14 +85,14 @@ export class CalendarPageObject implements BasePageObject {
      * @param targetMonth - Selected month 0-11, 0 = Jan 11 = dec
      */
     public navigateTo(targetYear: number, targetMonth: number): void {
-        cy.log(`Navigate to ${monthList[targetMonth]} ${targetYear}`);
+        cy.log(`Navigate to ${monthList[targetMonth]} ${String(targetYear)}`);
         this.navigationBar.text().then((el) => {
             let currYear = 2023;
             let currentMonth = 0;
             el.text().replace(/(\w+)\s+(\d+)/, (match, p1, p2) => {
                 currentMonth = monthList.findIndex((month) => month === p1);
                 currYear = parseInt(p2, 10);
-                return `${currYear}`;
+                return String(currYear);
             });
 
             const yearDiff = Math.abs(currYear - targetYear);

--- a/packages/vue/src/cypress/IPopupMenu.pageobject.ts
+++ b/packages/vue/src/cypress/IPopupMenu.pageobject.ts
@@ -44,7 +44,7 @@ export class IPopupMenuPageObject implements BasePageObject {
      */
     public getItemLink(index: number): DefaultCypressChainable {
         return cy.get(
-            `${this.selector} .ipopupmenu__list__item a:nth(${index})`,
+            `${this.selector} .ipopupmenu__list__item a:nth(${String(index)})`,
         );
     }
 

--- a/packages/vue/src/internal-components/IAnimateExpand/IAnimateExpand.vue
+++ b/packages/vue/src/internal-components/IAnimateExpand/IAnimateExpand.vue
@@ -105,7 +105,7 @@ export default defineComponent({
             return this.cssClasses;
         },
         heightStyle(): string {
-            return this.height === "" ? "" : `height: ${this.height}px`;
+            return this.height === "" ? "" : `height: ${String(this.height)}px`;
         },
         shouldVIf(): boolean {
             if (this.useVShow) {

--- a/packages/vue/src/internal-components/IPopup/IPopup.vue
+++ b/packages/vue/src/internal-components/IPopup/IPopup.vue
@@ -215,8 +215,8 @@ export default defineComponent({
                 this.placement = result.placement;
                 const useOverlay = this.forceOverlay || result.placement !== Placement.Fallback;
                 if (useOverlay) {
-                    wrapper.style.left = `${result.x}px`;
-                    wrapper.style.top = `${result.y}px`;
+                    wrapper.style.left = `${String(result.x)}px`;
+                    wrapper.style.top = `${String(result.y)}px`;
                     return;
                 }
             }

--- a/packages/vue/src/internal-components/IPopup/examples/IPopupPositioning.vue
+++ b/packages/vue/src/internal-components/IPopup/examples/IPopupPositioning.vue
@@ -85,8 +85,8 @@ export default defineComponent({
                 SPACING,
                 area.height - anchor.height - SPACING - 2,
             );
-            anchorElement.style.left = `${left}px`;
-            anchorElement.style.top = `${top}px`;
+            anchorElement.style.left = `${String(left)}px`;
+            anchorElement.style.top = `${String(top)}px`;
             this.updatePosition();
         },
         updatePosition() {
@@ -113,8 +113,8 @@ export default defineComponent({
                 target.style.removeProperty("top");
             } else {
                 target.classList.remove("pos-target--inline");
-                target.style.left = `${result.x}px`;
-                target.style.top = `${result.y}px`;
+                target.style.left = `${String(result.x)}px`;
+                target.style.top = `${String(result.y)}px`;
             }
 
             target.innerText = `Popup (${result.placement})`;

--- a/packages/vue/src/internal-components/IPopupError/IPopupError.vue
+++ b/packages/vue/src/internal-components/IPopupError/IPopupError.vue
@@ -56,7 +56,7 @@ export default defineComponent({
             return `popup-error popup-error--arrow popup-error--${this.arrowPosition}`;
         },
         errorStyle(): string {
-            return `--i-popup-error-offset: ${this.arrowOffset}px`;
+            return `--i-popup-error-offset: ${String(this.arrowOffset)}px`;
         },
         teleportTarget() {
             return config.teleportTarget;
@@ -138,8 +138,8 @@ export default defineComponent({
             this.placement = result.placement;
             if (result.placement !== Placement.Fallback) {
                 this.teleportDisabled = false;
-                wrapper.style.left = `${result.x}px`;
-                wrapper.style.top = `${result.y}px`;
+                wrapper.style.left = `${String(result.x)}px`;
+                wrapper.style.top = `${String(result.y)}px`;
                 this.setArrowOffset();
                 return;
             }

--- a/packages/vue/src/internal-components/IPopupListbox/IPopupListbox.vue
+++ b/packages/vue/src/internal-components/IPopupListbox/IPopupListbox.vue
@@ -152,11 +152,11 @@ async function calculatePosition(): Promise<void> {
         const offsetLeft = offsetRect?.x ?? 0;
         /* eslint-disable-next-line @typescript-eslint/restrict-plus-operands -- technical debt */
         const offSetTop = Math.floor((offsetRect?.top ?? 0) + window.scrollY);
-        wrapperElement.style.top = `${top - offSetTop}px`;
-        wrapperElement.style.left = `${left - offsetLeft}px`;
-        wrapperElement.style.width = `${width}px`;
-        contentWrapper.style.maxHeight = `${height}px`;
-        contentWrapper.style.width = `${width}px`;
+        wrapperElement.style.top = `${String(top - offSetTop)}px`;
+        wrapperElement.style.left = `${String(left - offsetLeft)}px`;
+        wrapperElement.style.width = `${String(width)}px`;
+        contentWrapper.style.maxHeight = `${String(height)}px`;
+        contentWrapper.style.width = `${String(width)}px`;
     }
 }
 </script>

--- a/packages/vue/src/internal-components/calendar/ICalendarMonthGrid.vue
+++ b/packages/vue/src/internal-components/calendar/ICalendarMonthGrid.vue
@@ -33,7 +33,7 @@ export default defineComponent({
     },
     computed: {
         ariaLabel(): string {
-            return `${this.value.monthName} ${this.value.year}`;
+            return `${this.value.monthName} ${String(this.value.year)}`;
         },
         totalCols(): number {
             return this.hideWeekNumbers ? 7 : 8;

--- a/packages/vue/src/internal-components/calendar/ICalendarNavbar.vue
+++ b/packages/vue/src/internal-components/calendar/ICalendarNavbar.vue
@@ -162,7 +162,7 @@ export default defineComponent({
             this.$emit("update:yearSelectorOpen", value);
         },
         getDateText(value: FDate): string {
-            return `${capitalize(value.monthName)} ${value.year}`;
+            return `${capitalize(value.monthName)} ${String(value.year)}`;
         },
         isFocused(ref: string): boolean {
             return document.activeElement === this.$refs[ref];

--- a/packages/vue/src/internal-components/calendar/examples/ICalendarMonthDefault.vue
+++ b/packages/vue/src/internal-components/calendar/examples/ICalendarMonthDefault.vue
@@ -15,7 +15,7 @@ export default defineComponent({
     },
     methods: {
         onClick(date: FDate) {
-            alert(`Du klickade på dag ${date.day}`);
+            alert(`Du klickade på dag ${String(date.day)}`);
         },
     },
 });

--- a/packages/vue/src/internal-components/calendar/examples/ICalendarMonthWithFCalendarDay.vue
+++ b/packages/vue/src/internal-components/calendar/examples/ICalendarMonthWithFCalendarDay.vue
@@ -18,7 +18,7 @@ export default defineComponent({
     },
     methods: {
         onClick(date: FDate) {
-            alert(`Du klickade på dag ${date.day}`);
+            alert(`Du klickade på dag ${String(date.day)}`);
         },
     },
 });

--- a/packages/vue/src/internal-components/combobox/useCombobox.ts
+++ b/packages/vue/src/internal-components/combobox/useCombobox.ts
@@ -84,7 +84,10 @@ export function useCombobox(
         if (!inputRef.value) {
             return;
         }
-        inputRef.value.setAttribute("aria-expanded", `${dropdownIsOpen.value}`);
+        inputRef.value.setAttribute(
+            "aria-expanded",
+            String(dropdownIsOpen.value),
+        );
 
         if (dropdownIsOpen.value) {
             inputRef.value.setAttribute("aria-controls", dropdownId);

--- a/packages/vue/src/plugins/validation/ValidationPlugin.ts
+++ b/packages/vue/src/plugins/validation/ValidationPlugin.ts
@@ -90,7 +90,7 @@ const ValidationPrefixDirective: Directive<HTMLElement, string> = {
     beforeMount(el: HTMLElement, binding: DirectiveBinding) {
         el.addEventListener("component-validity", (event) => {
             const e = event as CustomEvent<ComponentValidityEvent>;
-            e.detail.errorMessage = `${binding.value}${e.detail.errorMessage}`;
+            e.detail.errorMessage = `${String(binding.value)}${e.detail.errorMessage}`;
         });
     },
 };

--- a/packages/vue/src/utils/VueRefUtils.ts
+++ b/packages/vue/src/utils/VueRefUtils.ts
@@ -196,7 +196,7 @@ export function getElementFromVueRef(ref: unknown): Element | never {
     const element = findElementFromVueRef(ref);
 
     if (!isSet(element)) {
-        throw new Error(`Unable to find element from ${ref}.`);
+        throw new Error(`Unable to find element from ${String(ref)}.`);
     }
 
     return element;
@@ -214,12 +214,12 @@ export function getHTMLElementFromVueRef(ref: unknown): HTMLElement | never {
     const element = findElementFromVueRef(ref);
 
     if (!isSet(element)) {
-        throw new Error(`Unable to find element from ${ref}.`);
+        throw new Error(`Unable to find element from ${String(ref)}.`);
     }
 
     if (element instanceof HTMLElement) {
         return element;
     }
 
-    throw new Error(`Not instance of HTMLELement ${ref}.`);
+    throw new Error(`Not instance of HTMLELement ${String(ref)}.`);
 }

--- a/packages/vue/src/utils/internal-key.ts
+++ b/packages/vue/src/utils/internal-key.ts
@@ -53,13 +53,13 @@ export function setInternalKeys<T>(
 
         if (invalidValue) {
             throw new Error(
-                `Key [${keyString}] is missing or has invalid value in item index ${index}`,
+                `Key [${keyString}] is missing or has invalid value in item index ${String(index)}`,
             );
         }
         if (seenValues.has(value)) {
             throw new Error(
                 /* eslint-disable-next-line @typescript-eslint/no-base-to-string -- technical debt */
-                `Expected each item to have key [${keyString}] with unique value but encountered duplicate of "${value}" in item index ${index}.`,
+                `Expected each item to have key [${keyString}] with unique value but encountered duplicate of "${String(value)}" in item index ${String(index)}.`,
             );
         }
 


### PR DESCRIPTION
Den här regeln förbjuder template literals från att implicit konvertera till strängar, det finns många problem med det:

* arrayer blir joinade med `,` vilket inte är säkert det man vill (även om man vill ha med `,` så vill man säkert ha ett mellanslag också)
* nummer kan få väldigt odefinerad avrundning, klassiker är att `0.1 + 0.2` kommer bli `0.3000...0004`. Bättre att explicit konvertera till sträng istället.
* objekt blir `[Object object]` om de inte har `.toString()`
* lätt att glömma att hantera `null`, `undefined` osv.

Nu har vi väldigt många ställen där jag bara slängde in `String(number)` vilket fortfarande lider av avrundningsfel men det är ju isf redan ett problem vi har så det blir ju inte sämre.

Och det är väl upp för diskussion om vi vill tillåta `number` och/eller `boolean` med regeln (det är en inställning) också.