### PR TITLE
fix: `FLayoutRightPanelService` treeshakable (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FLayoutRightPanel/services/FLayoutRightPanelService.ts
+++ b/packages/vue/src/components/FLayoutRightPanel/services/FLayoutRightPanelService.ts
@@ -66,4 +66,5 @@ class FRightPanelServiceImpl implements FLayoutRightPanelInteface {
  * @public
  */
 export const FLayoutRightPanelService: FLayoutRightPanelInteface =
+    /* @__PURE__ */
     new FRightPanelServiceImpl();


### PR DESCRIPTION
Det här har vi redan gjort med services från `@fkui/logic` (exempelvis [`ElementIdService`](https://github.com/Forsakringskassan/designsystem/blob/main/packages/logic/src/services/ElementIdService/ElementIdService.ts#L41-L43)), vet ni om det finns fler singletons i `@fkui/vue`?

Utan detta så dras koden med i alla bundles oavsett om den används eller ej (därför att kompilatorn kan ju inte garantera att `new FRightPanelServiceImpl()` inte har side-effects som påverkar).