### PR TITLE
refactor: add `label` to `FTable` columns (refs SFKUI-6500)

### DIFF
--- a/packages/vue-labs/src/components/FTable/FTable.cy.ts
+++ b/packages/vue-labs/src/components/FTable/FTable.cy.ts
@@ -74,23 +74,27 @@ function mountDefaultTestbed(): {
             editable: true,
             header: "edit text header",
             key: "editText",
+            label: () => "edit text label",
         },
         {
             type: "select",
             header: "select header",
             options: ["awesome option", "catastrophic option"],
             key: "select",
+            label: () => "select label",
         },
         {
             type: "checkbox",
             header: "checkbox header",
             key: "checkbox",
             editable: true,
+            label: () => "checkbox label",
         },
         {
             type: "radio",
             header: "radio header",
             key: "radio",
+            label: () => "radio label",
         },
         {
             type: "button",

--- a/packages/vue-labs/src/components/FTable/FTable.vue
+++ b/packages/vue-labs/src/components/FTable/FTable.vue
@@ -16,7 +16,7 @@ import {
     watchEffect,
 } from "vue";
 import { assertRef, assertSet } from "@fkui/logic";
-import { FSortFilterDatasetInjected, setInternalKeys } from "@fkui/vue";
+import { FSortFilterDatasetInjected, setInternalKeys, useTranslate } from "@fkui/vue";
 import { activateCell, getMetaRows, maybeNavigateToCell, setDefaultCellTarget, stopEdit } from "./FTable.logic";
 import ITableCheckbox from "./ITableCheckbox.vue";
 import ITableExpandButton from "./ITableExpandButton.vue";
@@ -56,6 +56,7 @@ const {
     striped?: boolean;
     selectable?: "single" | "multi";
 }>();
+const $t = useTranslate();
 const tableRef = useTemplateRef("table");
 const selectAllRef = ref<HTMLInputElement | null>(null);
 const expandedKeys: Ref<string[]> = ref([]);
@@ -87,6 +88,10 @@ const multiSelectColumn: NormalizedTableColumnCheckbox<T, KeyAttribute> = {
     description: ref(null),
     sortable: null,
     component: ITableCheckbox,
+    label() {
+        /** Screen reader text for checkbox in multi select table row. */
+        return $t("fkui.table.selectable.checkbox", "Välj rad");
+    },
     value(row) {
         if (!keyAttribute) {
             return false;
@@ -118,6 +123,10 @@ const singleSelectColumn: NormalizedTableColumnRadio<T, KeyAttribute> = {
     description: ref(null),
     sortable: null,
     component: ITableRadio,
+    label() {
+        /** Screen reader text for radio button in single select table row. */
+        return $t("fkui.table.selectable.radio", "Välj rad");
+    },
     value(row) {
         if (!keyAttribute) {
             return false;

--- a/packages/vue-labs/src/components/FTable/ITableCheckbox.vue
+++ b/packages/vue-labs/src/components/FTable/ITableCheckbox.vue
@@ -9,7 +9,10 @@ const { column, row } = defineProps<{
 }>();
 
 const targetElement = useTemplateRef("target");
-const ariaLabel = computed(() => column.header.value);
+const ariaLabel = computed(() => {
+    const value = column.label(row);
+    return value.length > 0 ? value : undefined;
+});
 
 function onChange(e: Event): void {
     const checked = (e.target as HTMLInputElement).checked;

--- a/packages/vue-labs/src/components/FTable/ITableRadio.vue
+++ b/packages/vue-labs/src/components/FTable/ITableRadio.vue
@@ -10,7 +10,10 @@ const { column, row } = defineProps<{
 }>();
 
 const inputElement = useTemplateRef("input");
-const ariaLabel = computed(() => column.header.value);
+const ariaLabel = computed(() => {
+    const value = column.label(row);
+    return value.length > 0 ? value : undefined;
+});
 
 function onChange(_e: Event): void {
     assertRef(inputElement);

--- a/packages/vue-labs/src/components/FTable/ITableSelect.vue
+++ b/packages/vue-labs/src/components/FTable/ITableSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" generic="T, K extends keyof T">
-import { type Ref, nextTick, ref, useTemplateRef, watchEffect } from "vue";
+import { type Ref, computed, nextTick, ref, useTemplateRef, watchEffect } from "vue";
 import { ElementIdService, assertRef, assertSet } from "@fkui/logic";
 import { FIcon, IComboboxDropdown } from "@fkui/vue";
 import { useStartStopEdit } from "./start-stop-edit";
@@ -24,6 +24,11 @@ const editRef = useTemplateRef("edit");
 const { stopEdit } = useStartStopEdit();
 
 const viewValue = ref(column.value(row));
+
+const ariaLabel = computed(() => {
+    const value = column.label(row);
+    return value.length > 0 ? value : undefined;
+});
 
 /* eslint-disable-next-line @typescript-eslint/require-await -- technical debt */
 async function onCellKeyDown(e: KeyboardEvent): Promise<void> {
@@ -228,6 +233,7 @@ function cancel(): void {
             :aria-controls="dropdownId"
             aria-autocomplete="list"
             class="table-ng__editable"
+            :aria-label
             @click.stop
             @dblclick.prevent
             @keydown.stop="onEditKeyDown"

--- a/packages/vue-labs/src/components/FTable/ITableText.vue
+++ b/packages/vue-labs/src/components/FTable/ITableText.vue
@@ -32,6 +32,10 @@ const inputClasses = computed(() => {
         "table-ng__textedit": true,
     };
 });
+const ariaLabel = computed(() => {
+    const value = column.label(row);
+    return value.length > 0 ? value : undefined;
+});
 const tdElement = useTemplateRef("td");
 const viewElement = useTemplateRef("view");
 const inputElement = useTemplateRef("input");
@@ -160,7 +164,7 @@ function onValidity(event: CustomEvent<ValidityEvent>): void {
                 type="text"
                 maxlength="40"
                 tabindex="-1"
-                aria-label="temp"
+                :aria-label
                 @blur="onBlur"
                 @validity="onValidity"
             />

--- a/packages/vue-labs/src/components/FTable/examples/FTableExample.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableExample.vue
@@ -35,11 +35,13 @@ const columns = defineTableColumns<Row>([
         type: "checkbox",
         header: "Kryssruta",
         key: "aktiv",
+        label: (row) => `Välj rad ${row.id}`,
         editable: true,
     },
     {
         type: "text",
         header: "Formatterad text",
+        label: (row) => `Text för rad ${row.id}`,
         value(row) {
             return formatNumber(row.antal) ?? "";
         },
@@ -51,6 +53,7 @@ const columns = defineTableColumns<Row>([
         header: "Redigerbar text",
         editable: true,
         key: "level",
+        label: (row) => `Text för rad ${row.id}`,
         value(row) {
             return row.level;
         },
@@ -85,6 +88,7 @@ const columns = defineTableColumns<Row>([
         header: "Dropplista",
         type: "select",
         key: "animal",
+        label: (row) => `Djur för rad ${row.id}`,
         options: selectFieldOptions,
         editable: true,
     },

--- a/packages/vue-labs/src/components/FTable/examples/FTableExpandableCustom.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableExpandableCustom.vue
@@ -23,12 +23,6 @@ interface Row {
 
 const columns = defineTableColumns<Row>([
     {
-        type: "checkbox",
-        header: "Kryssruta",
-        key: "aktiv",
-    },
-
-    {
         type: "text",
         header: "Oformaterad text",
         value(row) {
@@ -36,19 +30,29 @@ const columns = defineTableColumns<Row>([
             return String(row.antal);
         },
     },
-
+    {
+        type: "checkbox",
+        header: "Kryssruta",
+        key: "aktiv",
+        label: (row) => `Välj rad ${row.id}`,
+        editable: true,
+    },
     {
         type: "text",
         header: "Formatterad text",
+        label: (row) => `Text för rad ${row.id}`,
         value(row) {
             return formatNumber(row.antal) ?? "";
         },
+        editable: true,
     },
 
     {
         type: "text",
         header: "Redigerbar text",
         editable: true,
+        key: "level",
+        label: (row) => `Text för rad ${row.id}`,
         value(row) {
             return row.level;
         },
@@ -60,7 +64,6 @@ const columns = defineTableColumns<Row>([
             maxLength: { length: 5 },
         },
     },
-
     {
         type: "button",
         header: "Knapp",
@@ -84,7 +87,9 @@ const columns = defineTableColumns<Row>([
         header: "Dropplista",
         type: "select",
         key: "animal",
+        label: (row) => `Djur för rad ${row.id}`,
         options: selectFieldOptions,
+        editable: true,
     },
     {
         header: "Render function",

--- a/packages/vue-labs/src/components/FTable/examples/FTableExpandableRows.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableExpandableRows.vue
@@ -19,12 +19,6 @@ interface Row {
 
 const columns = defineTableColumns<Row>([
     {
-        type: "checkbox",
-        header: "Kryssruta",
-        key: "aktiv",
-    },
-
-    {
         type: "text",
         header: "Oformaterad text",
         value(row) {
@@ -32,19 +26,28 @@ const columns = defineTableColumns<Row>([
             return String(row.antal);
         },
     },
-
+    {
+        type: "checkbox",
+        header: "Kryssruta",
+        key: "aktiv",
+        label: (row) => `Välj rad ${row.id}`,
+        editable: true,
+    },
     {
         type: "text",
         header: "Formatterad text",
+        label: (row) => `Text för rad ${row.id}`,
         value(row) {
             return formatNumber(row.antal) ?? "";
         },
+        editable: true,
     },
-
     {
         type: "text",
         header: "Redigerbar text",
         editable: true,
+        key: "level",
+        label: (row) => `Text för rad ${row.id}`,
         value(row) {
             return row.level;
         },
@@ -56,7 +59,6 @@ const columns = defineTableColumns<Row>([
             maxLength: { length: 5 },
         },
     },
-
     {
         type: "button",
         header: "Knapp",
@@ -80,7 +82,9 @@ const columns = defineTableColumns<Row>([
         header: "Dropplista",
         type: "select",
         key: "animal",
+        label: (row) => `Djur för rad ${row.id}`,
         options: selectFieldOptions,
+        editable: true,
     },
     {
         header: "Render function",

--- a/packages/vue-labs/src/components/FTable/examples/FTableRadioExample.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableRadioExample.vue
@@ -34,19 +34,21 @@ const columns = defineTableColumns<Row>([
         type: "checkbox",
         header: "Kryssruta",
         key: "aktiv",
+        label: (row) => `Välj rad ${row.id}`,
     },
     {
         type: "text",
         header: "Formatterad text",
+        label: (row) => `Text för rad ${row.id}`,
         value(row) {
             return formatNumber(row.antal) ?? "";
         },
     },
-
     {
         type: "text",
         header: "Redigerbar text",
         editable: true,
+        label: (row) => `Text för rad ${row.id}`,
         value(row) {
             return row.level;
         },
@@ -58,7 +60,6 @@ const columns = defineTableColumns<Row>([
             maxLength: { length: 5 },
         },
     },
-
     {
         type: "button",
         header: "Knapp",
@@ -82,6 +83,7 @@ const columns = defineTableColumns<Row>([
         header: "Dropplista",
         type: "select",
         key: "animal",
+        label: (row) => `Djur för rad ${row.id}`,
         options: selectFieldOptions,
     },
     {

--- a/packages/vue-labs/src/components/FTable/examples/FTableRowHeaderExample.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableRowHeaderExample.vue
@@ -40,24 +40,26 @@ const columns = defineTableColumns<Row>([
         type: "checkbox",
         header: "Kryssruta",
         key: "aktiv",
+        label: (row) => `Välj rad ${row.id}`,
         editable: true,
     },
     {
         type: "text",
         header: "Formatterad text",
         description: "Belopp",
+        label: (row) => `Text för rad ${row.id}`,
         value(row) {
             return formatNumber(row.antal) ?? "";
         },
         editable: true,
     },
-
     {
         type: "text",
         header: "Redigerbar text",
         description: "Förmån",
         editable: true,
         key: "level",
+        label: (row) => `Text för rad ${row.id}`,
         value(row) {
             return row.level;
         },

--- a/packages/vue-labs/src/components/FTable/table-column.ts
+++ b/packages/vue-labs/src/components/FTable/table-column.ts
@@ -19,6 +19,7 @@ export interface TableColumnSimple<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    label?(row: T): string;
     value?(row: T): string;
 }
 
@@ -57,6 +58,7 @@ export interface TableColumnCheckbox<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    label?(row: T): string;
     value?(row: T): boolean;
     update?(row: T, newValue: boolean, oldValue: boolean): void;
     editable?: boolean | ((row: T) => boolean);
@@ -75,6 +77,7 @@ export interface NormalizedTableColumnCheckbox<T, K> {
         row: T;
         column: NormalizedTableColumnCheckbox<T, K>;
     }>;
+    label(row: T): string;
     value(row: T): boolean;
     update(row: T, newValue: boolean, oldValue: boolean): void;
     editable(row: T): boolean;
@@ -88,6 +91,7 @@ export interface TableColumnRadio<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    label?(row: T): string;
     value?(row: T): boolean;
     update?(row: T, newValue: boolean, oldValue: boolean): void;
 }
@@ -105,6 +109,7 @@ export interface NormalizedTableColumnRadio<T, K> {
         row: T;
         column: NormalizedTableColumnRadio<T, K>;
     }>;
+    label(row: T): string;
     value(row: T): boolean;
     update(row: T, newValue: boolean, oldValue: boolean): void;
 }
@@ -117,6 +122,7 @@ export interface TableColumnText<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    label?(row: T): string;
     value?(row: T): string;
     update?(row: T, newValue: string, oldValue: string): void;
     editable?: boolean | ((row: T) => boolean);
@@ -137,6 +143,7 @@ export interface NormalizedTableColumnText<T, K> {
         row: T;
         column: NormalizedTableColumnText<T, K>;
     }>;
+    label(row: T): string;
     value(row: T): string;
     update(row: T, newValue: string, oldValue: string): void;
     editable(row: T): boolean;
@@ -214,6 +221,7 @@ export interface TableColumnSelect<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    label?(row: T): string;
     value?(row: T): string;
     update?(row: T, newValue: string, oldValue: string): void;
     editable?: boolean | ((row: T) => boolean);
@@ -234,6 +242,7 @@ export interface NormalizedTableColumnSelect<T, K> {
         row: T;
         column: NormalizedTableColumnSelect<T, K>;
     }>;
+    label(row: T): string;
     value(row: T): string;
     update(row: T, newValue: string, oldValue: string): void;
     editable(row: T): boolean;
@@ -287,6 +296,15 @@ export type NormalizedTableColumn<T, K> =
     | NormalizedTableColumnButton<T, K>
     | NormalizedTableColumnRender<T>
     | NormalizedTableColumnSelect<T, K>;
+
+function getLabelFn<TRow>(
+    fn: ((row: TRow) => string) | undefined,
+): (row: TRow) => string {
+    if (fn) {
+        return fn;
+    }
+    return () => "";
+}
 
 /* eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- technical debt */
 function getValueFn<TRow, TValue, K extends keyof TRow>(
@@ -381,6 +399,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                label: getLabelFn(column.label),
                 value: getValueFn(column.value, column.key, Boolean, false),
                 update: getUpdateFn(column.update, column.key),
                 editable:
@@ -396,6 +415,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                label: getLabelFn(column.label),
                 value: getValueFn(column.value, column.key, Boolean, false),
                 update: getUpdateFn(column.update, column.key),
                 sortable: column.key ?? null,
@@ -407,6 +427,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                label: getLabelFn(column.label),
                 value: getValueFn(column.value, column.key, String, ""),
                 update: getUpdateFn(column.update, column.key),
                 editable:
@@ -464,6 +485,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                label: getLabelFn(column.label),
                 value: getValueFn(column.value, column.key, String, ""),
                 update: getUpdateFn(column.update, column.key),
                 editable:
@@ -480,6 +502,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                label: () => "",
                 value: getValueFn(column.value, column.key, String, ""),
                 update() {
                     /* do nothing */


### PR DESCRIPTION
Lägger till så konsument kan hantera label för de kolumner som har innehåll som behöver en label.