### PR TITLE
feat: table cell api (refs SFKUI-6500)

### DIFF
--- a/packages/vue-labs/elements.js
+++ b/packages/vue-labs/elements.js
@@ -10,25 +10,29 @@ module.exports = defineMetadata({
     },
 
     tr: {
-        inherit: "tr",
         permittedContent: [
             "@script",
             "td",
             "th",
-            "i-table-header",
-            "i-table-text",
-            "i-table-select",
-            "i-table-checkbox",
-            "i-table-radio",
-            "i-table-button",
-            "i-table-expand-button",
             "i-table-anchor",
-            "i-table-rowheader",
+            "i-table-button",
+            "i-table-checkbox",
             "i-table-expandable",
+            "i-table-expand-button",
+            "i-table-header",
+            "i-table-header-selectable",
+            "i-table-radio",
+            "i-table-rowheader",
+            "i-table-select",
+            "i-table-text",
         ],
     },
 
     "i-table-header": {
+        flow: true,
+    },
+
+    "i-table-header-selectable": {
         flow: true,
     },
 

--- a/packages/vue-labs/src/components/FTable/FTable.cy.ts
+++ b/packages/vue-labs/src/components/FTable/FTable.cy.ts
@@ -1,0 +1,236 @@
+import { type VNode, ref } from "vue";
+import { h } from "vue";
+import FTable from "./FTable.vue";
+import { defineTableColumns } from "./table-column";
+
+interface AwesomeRow {
+    staticText: string;
+    editText: string;
+    select: string;
+    checkbox: boolean;
+    radio: boolean;
+    button: string;
+    anchor: string;
+    custom: string;
+    children?: AwesomeRow[];
+}
+
+function renderButton(
+    text: string,
+    dataTest: string,
+    onClick?: () => void,
+): VNode {
+    return h(
+        "button",
+        {
+            type: "button",
+            "data-test": dataTest,
+            onClick,
+        },
+        text,
+    );
+}
+
+function getTestSelector(value: string): string {
+    return `[data-test="${value}"]`;
+}
+
+function mountDefaultTestbed(): {
+    buttonBeforeTable: string;
+} {
+    const rows = ref([
+        {
+            staticText: "awesome static text",
+            editText: "awesome edit text",
+            select: "awesome option",
+            checkbox: true,
+            radio: true,
+            button: "awesome button",
+            anchor: "awesome anchor",
+            custom: "awesome custom",
+            children: [
+                {
+                    staticText: "child static text",
+                    editText: "child edit text",
+                    select: "another option",
+                    checkbox: false,
+                    radio: false,
+                    button: "child button",
+                    anchor: "child anchor",
+                    custom: "child custom",
+                },
+            ],
+        },
+    ]);
+
+    const columns = defineTableColumns<AwesomeRow>([
+        {
+            type: "text",
+            header: "static text header",
+            key: "staticText",
+        },
+        {
+            type: "text",
+            editable: true,
+            header: "edit text header",
+            key: "editText",
+        },
+        {
+            type: "select",
+            header: "select header",
+            options: ["awesome option", "catastrophic option"],
+            key: "select",
+        },
+        {
+            type: "checkbox",
+            header: "checkbox header",
+            key: "checkbox",
+            editable: true,
+        },
+        {
+            type: "radio",
+            header: "radio header",
+            key: "radio",
+        },
+        {
+            type: "button",
+            header: "button header",
+            value(row) {
+                return row.button;
+            },
+            icon: "bell",
+        },
+        {
+            type: "anchor",
+            header: "anchor header",
+            value(row) {
+                return row.anchor;
+            },
+            href: "awesome href",
+        },
+    ]);
+
+    const buttonBeforeTable = "button-before-table";
+
+    cy.mount(() =>
+        h("div", [
+            renderButton("Before table", buttonBeforeTable),
+            h(FTable<AwesomeRow>, {
+                rows: rows.value,
+                columns,
+                expandableAttribute: "children",
+                selectable: "multi",
+            }),
+        ]),
+    );
+
+    return {
+        buttonBeforeTable: getTestSelector(buttonBeforeTable),
+    };
+}
+
+describe("navigation", () => {
+    it("should activate correct cell elements", () => {
+        const { buttonBeforeTable } = mountDefaultTestbed();
+        cy.get(buttonBeforeTable).focus();
+        cy.focused().press(Cypress.Keyboard.Keys.TAB);
+        // {1, 1}: expand button
+        cy.focused().click();
+        cy.focused()
+            .should("have.prop", "tagName", "BUTTON")
+            .should("have.attr", "aria-expanded", "true");
+        cy.focused().press(Cypress.Keyboard.Keys.RIGHT);
+        // {1, 2}: selectable checkbox
+        cy.focused().click();
+        cy.focused()
+            .should("have.prop", "tagName", "INPUT")
+            .should("have.attr", "type", "checkbox");
+        cy.focused().press(Cypress.Keyboard.Keys.RIGHT);
+        // {1, 3}: static text
+        cy.focused()
+            .should("have.prop", "tagName", "TD")
+            .should("contain.text", "awesome static text");
+        cy.focused().press(Cypress.Keyboard.Keys.RIGHT);
+        // {1, 4}: edit text
+        cy.focused()
+            .should("have.prop", "tagName", "TD")
+            .should("contain.text", "awesome edit text");
+        cy.focused().press(Cypress.Keyboard.Keys.RIGHT);
+        // {1, 5}: select
+        cy.focused()
+            .should("have.prop", "tagName", "TD")
+            .should("contain.text", "awesome option");
+        cy.focused().press(Cypress.Keyboard.Keys.RIGHT);
+        // {1, 6}: checkbox
+        cy.focused()
+            .should("have.prop", "tagName", "INPUT")
+            .should("have.attr", "type", "checkbox");
+        cy.focused().press(Cypress.Keyboard.Keys.RIGHT);
+        // {1, 7}: radio
+        cy.focused()
+            .should("have.prop", "tagName", "INPUT")
+            .should("have.attr", "type", "radio");
+        cy.focused().press(Cypress.Keyboard.Keys.RIGHT);
+        // {1, 8}: button
+        cy.focused()
+            .should("have.prop", "tagName", "BUTTON")
+            .should("contain.text", "awesome button");
+        cy.focused().press(Cypress.Keyboard.Keys.RIGHT);
+        // {1, 9}: anchor
+        cy.focused()
+            .should("have.prop", "tagName", "A")
+            .should("contain.text", "awesome anchor");
+        cy.focused().press(Cypress.Keyboard.Keys.UP);
+        // {0, 9}: anchor header
+        cy.focused()
+            .should("have.prop", "tagName", "TH")
+            .should("contain.text", "anchor header", true);
+        cy.focused().press(Cypress.Keyboard.Keys.LEFT);
+        // {0, 8}: button header
+        cy.focused()
+            .should("have.prop", "tagName", "TH")
+            .should("contain.text", "button header", true);
+        cy.focused().press(Cypress.Keyboard.Keys.LEFT);
+        // {0, 7}: radio header
+        cy.focused()
+            .should("have.prop", "tagName", "TH")
+            .should("contain.text", "radio header", true);
+        cy.focused().press(Cypress.Keyboard.Keys.LEFT);
+        // {0, 6}: checkbox header
+        cy.focused()
+            .should("have.prop", "tagName", "TH")
+            .should("contain.text", "checkbox header", true);
+        cy.focused().press(Cypress.Keyboard.Keys.LEFT);
+        // {0, 5}: select header
+        cy.focused()
+            .should("have.prop", "tagName", "TH")
+            .should("contain.text", "select header", true);
+        cy.focused().press(Cypress.Keyboard.Keys.LEFT);
+        // {0, 4}: edit text header
+        cy.focused()
+            .should("have.prop", "tagName", "TH")
+            .should("contain.text", "edit text header", true);
+        cy.focused().press(Cypress.Keyboard.Keys.LEFT);
+        // {0, 3}: static text header
+        cy.focused()
+            .should("have.prop", "tagName", "TH")
+            .should("contain.text", "static text header", true);
+        cy.focused().press(Cypress.Keyboard.Keys.LEFT);
+        // {0, 2}: selectable header
+        cy.focused()
+            .should("have.prop", "tagName", "INPUT")
+            .should("have.attr", "type", "checkbox");
+        cy.focused().press(Cypress.Keyboard.Keys.LEFT);
+        // {0, 1}: expand header (empty)
+        cy.focused()
+            .should("have.prop", "tagName", "TH")
+            .should("not.have.text");
+        cy.focused().press(Cypress.Keyboard.Keys.DOWN);
+        // {1, 1}: expand
+        cy.focused().press(Cypress.Keyboard.Keys.DOWN);
+        // {1, 2}: expand for child (empty)
+        cy.focused()
+            .should("have.prop", "tagName", "TD")
+            .should("not.have.text");
+    });
+});

--- a/packages/vue-labs/src/components/FTable/ITableAnchor.vue
+++ b/packages/vue-labs/src/components/FTable/ITableAnchor.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts" generic="T, K extends keyof T">
 import { computed, useTemplateRef } from "vue";
-import { assertRef } from "@fkui/logic";
-import { type FTableActivateCellEvent } from "./events";
+import { type FTableCellApi } from "./f-table-api";
 import { type NormalizedTableColumnAnchor } from "./table-column";
 
 const { column, row } = defineProps<{
@@ -11,25 +10,19 @@ const { column, row } = defineProps<{
 
 const targetElement = useTemplateRef("target");
 
-function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): void {
-    assertRef(targetElement);
-    targetElement.value.tabIndex = 0;
-
-    if (e.detail.focus) {
-        targetElement.value.focus();
-    }
-}
-
 const renderAnchor = computed(() => {
     return column.enabled(row) && column.value(row) !== null;
 });
+
+const expose: FTableCellApi = { tabstopEl: targetElement };
+defineExpose(expose);
 </script>
 
 <template>
-    <td v-if="renderAnchor" class="table-ng__cell table-ng__cell--anchor" @table-activate-cell="onActivateCell">
+    <td v-if="renderAnchor" class="table-ng__cell table-ng__cell--anchor">
         <a ref="target" class="anchor anchor--block" target="_blank" :href="column.href" tabindex="-1">
             {{ column.value(row) }}
         </a>
     </td>
-    <td v-else ref="target" tabindex="-1" class="table-ng__cell" @table-activate-cell="onActivateCell"></td>
+    <td v-else ref="target" tabindex="-1" class="table-ng__cell"></td>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableButton.vue
+++ b/packages/vue-labs/src/components/FTable/ITableButton.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts" generic="T, K extends keyof T">
-import { computed, nextTick, useTemplateRef } from "vue";
-import { assertSet } from "@fkui/logic";
+import { computed, useTemplateRef } from "vue";
+import { assertRef } from "@fkui/logic";
 import { FIcon } from "@fkui/vue";
-import { type FTableActivateCellEvent } from "./events";
+import { type FTableCellApi } from "./f-table-api";
 import { type NormalizedTableColumnButton } from "./table-column";
 
 const { column, row } = defineProps<{
@@ -13,18 +13,10 @@ const { column, row } = defineProps<{
 const buttonElement = useTemplateRef("button");
 const tdElement = useTemplateRef("td");
 
-async function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): Promise<void> {
-    await nextTick();
-    const element = buttonElement.value ?? tdElement.value;
-    assertSet(element);
-    element.tabIndex = 0;
-
-    if (e.detail.focus) {
-        element.focus();
-    }
-}
-
 function onClickButton(): void {
+    assertRef(buttonElement);
+    buttonElement.value.tabIndex = 0;
+
     if (column.onClick) {
         column.onClick(row);
     }
@@ -33,14 +25,17 @@ function onClickButton(): void {
 const renderButton = computed(() => {
     return column.enabled(row) && column.value(row) !== null;
 });
+
+const expose: FTableCellApi = { tabstopEl: renderButton.value ? buttonElement : tdElement };
+defineExpose(expose);
 </script>
 
 <template>
-    <td v-if="renderButton" class="table-ng__cell table-ng__cell--button" @table-activate-cell="onActivateCell">
+    <td v-if="renderButton" class="table-ng__cell table-ng__cell--button">
         <button ref="button" class="icon-button" type="button" tabindex="-1" @click="onClickButton">
             <f-icon v-if="column.icon" :name="column.icon"></f-icon>
             <span class="sr-only">{{ column.value(row) }}</span>
         </button>
     </td>
-    <td v-else ref="td" tabindex="-1" class="table-ng__cell" @table-activate-cell="onActivateCell"></td>
+    <td v-else ref="td" tabindex="-1" class="table-ng__cell"></td>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableCheckbox.vue
+++ b/packages/vue-labs/src/components/FTable/ITableCheckbox.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts" generic="T, K extends keyof T">
 import { computed, useTemplateRef } from "vue";
-import { assertRef } from "@fkui/logic";
-import { type FTableActivateCellEvent } from "./events";
+import { type FTableCellApi } from "./f-table-api";
 import { type NormalizedTableColumnCheckbox } from "./table-column";
 
 const { column, row } = defineProps<{
@@ -12,36 +11,20 @@ const { column, row } = defineProps<{
 const targetElement = useTemplateRef("target");
 const ariaLabel = computed(() => column.header.value);
 
-function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): void {
-    assertRef(targetElement);
-    targetElement.value.tabIndex = 0;
-
-    if (e.detail.focus) {
-        targetElement.value.focus();
-    }
-}
-
 function onChange(e: Event): void {
     const checked = (e.target as HTMLInputElement).checked;
     column.update(row, checked, !checked);
 }
+
+const expose: FTableCellApi = { tabstopEl: targetElement };
+defineExpose(expose);
 </script>
 
 <template>
-    <td
-        v-if="column.editable(row)"
-        class="table-ng__cell table-ng__cell--checkbox"
-        @table-activate-cell="onActivateCell"
-    >
+    <td v-if="column.editable(row)" class="table-ng__cell table-ng__cell--checkbox">
         <input ref="target" :checked="column.value(row)" type="checkbox" :aria-label tabindex="-1" @change="onChange" />
     </td>
-    <td
-        v-else
-        ref="target"
-        tabindex="-1"
-        class="table-ng__cell table-ng__cell--checkbox"
-        @table-activate-cell="onActivateCell"
-    >
+    <td v-else ref="target" tabindex="-1" class="table-ng__cell table-ng__cell--checkbox">
         <input :checked="column.value(row)" type="checkbox" :aria-label />
     </td>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableExpandButton.vue
+++ b/packages/vue-labs/src/components/FTable/ITableExpandButton.vue
@@ -2,7 +2,7 @@
 import { computed, useTemplateRef } from "vue";
 import { assertRef } from "@fkui/logic";
 import { FIcon } from "@fkui/vue";
-import { type FTableActivateCellEvent } from "./events";
+import { type FTableCellApi } from "./f-table-api";
 
 const { isExpandable, isExpanded, rowKey } = defineProps<{
     isExpandable?: boolean;
@@ -18,28 +18,29 @@ const expandableRef = useTemplateRef("expandable");
 const toggleIcon = computed(() => (isExpanded ? "arrow-down" : "arrow-right"));
 const expandLabel = computed(() => (isExpanded ? "Stäng rad" : "Expandera rad"));
 
-function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): void {
+function onClick(): void {
     assertRef(expandableRef);
     expandableRef.value.tabIndex = 0;
 
-    if (e.detail.focus) {
-        expandableRef.value.focus();
-    }
+    emit("toggle", rowKey);
 }
+
+const expose: FTableCellApi = { tabstopEl: expandableRef };
+defineExpose(expose);
 </script>
 
 <template>
-    <td v-if="isExpandable" class="table-ng__cell table-ng__cell--expand" @table-activate-cell="onActivateCell">
+    <td v-if="isExpandable" class="table-ng__cell table-ng__cell--expand">
         <button
             ref="expandable"
             tabindex="-1"
             :aria-label="expandLabel"
             :aria-expanded="isExpanded"
             type="button"
-            @click="emit('toggle', rowKey)"
+            @click="onClick"
         >
             <f-icon class="button__icon" :name="toggleIcon"></f-icon>
         </button>
     </td>
-    <td v-else ref="expandable" tabindex="-1" class="table-ng__cell" @table-activate-cell="onActivateCell"></td>
+    <td v-else ref="expandable" tabindex="-1" class="table-ng__cell"></td>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableExpandable.vue
+++ b/packages/vue-labs/src/components/FTable/ITableExpandable.vue
@@ -1,26 +1,11 @@
 <script setup lang="ts">
-import { useTemplateRef } from "vue";
-import { assertRef } from "@fkui/logic";
-import { type FTableActivateCellEvent } from "./events";
-
 const { colspan } = defineProps<{
     colspan: number;
 }>();
-
-const rootRef = useTemplateRef("root");
-
-function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): void {
-    assertRef(rootRef);
-    rootRef.value.tabIndex = 0;
-
-    if (e.detail.focus) {
-        rootRef.value.focus();
-    }
-}
 </script>
 
 <template>
-    <td ref="root" class="table-ng__custom-expandable" :colspan tabindex="-1" @table-activate-cell="onActivateCell">
+    <td class="table-ng__custom-expandable" :colspan tabindex="-1">
         <slot></slot>
     </td>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableHeader.vue
+++ b/packages/vue-labs/src/components/FTable/ITableHeader.vue
@@ -2,7 +2,6 @@
 import { computed, useTemplateRef } from "vue";
 import { assertRef } from "@fkui/logic";
 import { FIcon, IFlex, IFlexItem } from "@fkui/vue";
-import { type FTableActivateCellEvent } from "./events";
 import { type NormalizedTableColumn } from "./table-column";
 
 const { column, sortEnabled, sortOrder } = defineProps<{
@@ -37,16 +36,10 @@ const sortIcon = computed(() => {
     }
 });
 
-function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): void {
+function onClickCell(): void {
     assertRef(thElement);
     thElement.value.tabIndex = 0;
 
-    if (e.detail.focus) {
-        thElement.value.focus();
-    }
-}
-
-function onClickCell(): void {
     if (!column.sortable || !sortEnabled) {
         return;
     }
@@ -63,14 +56,7 @@ function onKeydownCell(e: KeyboardEvent): void {
 </script>
 
 <template>
-    <th
-        ref="th"
-        class="table-ng__column"
-        tabindex="-1"
-        @keydown="onKeydownCell"
-        @click.stop="onClickCell"
-        @table-activate-cell="onActivateCell"
-    >
+    <th ref="th" class="table-ng__column" tabindex="-1" @keydown="onKeydownCell" @click.stop="onClickCell">
         <i-flex gap="1x">
             <i-flex-item shrink>
                 {{ column.header }}

--- a/packages/vue-labs/src/components/FTable/ITableHeaderSelectable.vue
+++ b/packages/vue-labs/src/components/FTable/ITableHeaderSelectable.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { useTemplateRef } from "vue";
+import { type FTableCellApi } from "./f-table-api";
+
+const emit = defineEmits<{
+    /**
+     * Emitted when checkbox value changes.
+     */
+    change: [];
+}>();
+
+const selectAllRef = useTemplateRef("selectAll");
+
+const expose: FTableCellApi = { tabstopEl: selectAllRef };
+defineExpose(expose);
+</script>
+
+<template>
+    <th scope="col" class="table-ng__column table-ng__column--checkbox">
+        <input
+            ref="selectAll"
+            type="checkbox"
+            aria-label="select all"
+            tabindex="-1"
+            indeterminate
+            @change="emit('change')"
+        />
+    </th>
+</template>

--- a/packages/vue-labs/src/components/FTable/ITableRadio.vue
+++ b/packages/vue-labs/src/components/FTable/ITableRadio.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts" generic="T, K extends keyof T">
 import { computed, useTemplateRef } from "vue";
 import { assertRef } from "@fkui/logic";
-import { type FTableActivateCellEvent } from "./events";
+import { type FTableCellApi } from "./f-table-api";
 import { type NormalizedTableColumnRadio } from "./table-column";
 
 const { column, row } = defineProps<{
@@ -12,23 +12,17 @@ const { column, row } = defineProps<{
 const inputElement = useTemplateRef("input");
 const ariaLabel = computed(() => column.header.value);
 
-function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): void {
-    assertRef(inputElement);
-    inputElement.value.tabIndex = 0;
-
-    if (e.detail.focus) {
-        inputElement.value.focus();
-    }
-}
-
 function onChange(_e: Event): void {
     assertRef(inputElement);
     column.update(row, inputElement.value.checked, !inputElement.value.checked);
 }
+
+const expose: FTableCellApi = { tabstopEl: inputElement };
+defineExpose(expose);
 </script>
 
 <template>
-    <td class="table-ng__cell table-ng__cell--radio" @table-activate-cell="onActivateCell">
+    <td class="table-ng__cell table-ng__cell--radio">
         <input ref="input" type="radio" :checked="column.value(row)" :aria-label tabindex="-1" @change="onChange" />
     </td>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableRowheader.vue
+++ b/packages/vue-labs/src/components/FTable/ITableRowheader.vue
@@ -1,28 +1,14 @@
 <script setup lang="ts" generic="T, K extends keyof T">
-import { useTemplateRef } from "vue";
-import { assertRef } from "@fkui/logic";
-import { type FTableActivateCellEvent } from "./events";
 import { type NormalizedTableColumnRowHeader } from "./table-column";
 
 const { row, column } = defineProps<{
     row: T;
     column: NormalizedTableColumnRowHeader<T, K>;
 }>();
-
-const thRef = useTemplateRef("th");
-
-function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): void {
-    assertRef(thRef);
-    thRef.value.tabIndex = 0;
-
-    if (e.detail.focus) {
-        thRef.value.focus();
-    }
-}
 </script>
 
 <template>
-    <th ref="th" class="table-ng__cell table-ng__cell--rowheader" scope="row" @table-activate-cell="onActivateCell">
+    <th ref="th" class="table-ng__cell table-ng__cell--rowheader" scope="row">
         {{ column.value(row) }}
     </th>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableSelect.vue
+++ b/packages/vue-labs/src/components/FTable/ITableSelect.vue
@@ -2,7 +2,6 @@
 import { type Ref, nextTick, ref, useTemplateRef, watchEffect } from "vue";
 import { ElementIdService, assertRef, assertSet } from "@fkui/logic";
 import { FIcon, IComboboxDropdown } from "@fkui/vue";
-import { type FTableActivateCellEvent } from "./events";
 import { useStartStopEdit } from "./start-stop-edit";
 import { type NormalizedTableColumnSelect } from "./table-column";
 
@@ -25,16 +24,6 @@ const editRef = useTemplateRef("edit");
 const { stopEdit } = useStartStopEdit();
 
 const viewValue = ref(column.value(row));
-const tdRef = useTemplateRef("td");
-
-function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): void {
-    assertRef(tdRef);
-    tdRef.value.tabIndex = 0;
-
-    if (e.detail.focus) {
-        tdRef.value.focus();
-    }
-}
 
 /* eslint-disable-next-line @typescript-eslint/require-await -- technical debt */
 async function onCellKeyDown(e: KeyboardEvent): Promise<void> {
@@ -221,12 +210,10 @@ function cancel(): void {
 <template>
     <td
         v-if="column.editable(row)"
-        ref="td"
         class="table-ng__cell table-ng__cell--select"
         tabindex="-1"
         @keydown="onCellKeyDown"
         @click.stop="onCellClick"
-        @table-activate-cell="onActivateCell"
     >
         <div v-show="!editing" class="table-ng__editable">
             <span class="table-ng__editable__text">{{ viewValue }}</span>
@@ -261,13 +248,7 @@ function cancel(): void {
             @close="onDropdownClose"
         ></i-combobox-dropdown>
     </td>
-    <td
-        v-else
-        ref="td"
-        tabindex="-1"
-        class="table-ng__cell table-ng__cell--static"
-        @table-activate-cell="onActivateCell"
-    >
+    <td v-else tabindex="-1" class="table-ng__cell table-ng__cell--static">
         {{ column.value(row) }}
     </td>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableText.vue
+++ b/packages/vue-labs/src/components/FTable/ITableText.vue
@@ -2,7 +2,6 @@
 import { computed, onMounted, ref, useTemplateRef } from "vue";
 import { type ValidityEvent, ValidationService, assertRef } from "@fkui/logic";
 import { FIcon } from "@fkui/vue";
-import { type FTableActivateCellEvent } from "./events";
 import { isAlphanumeric } from "./is-alphanumeric";
 import { useStartStopEdit } from "./start-stop-edit";
 import { type NormalizedTableColumnText } from "./table-column";
@@ -43,15 +42,6 @@ onMounted(() => {
         ValidationService.addValidatorsToElement(inputElement.value, column.validation);
     }
 });
-
-function onActivateCell(e: CustomEvent<FTableActivateCellEvent>): void {
-    assertRef(tdElement);
-    tdElement.value.tabIndex = 0;
-
-    if (e.detail.focus) {
-        tdElement.value.focus();
-    }
-}
 
 function onStartEdit(modelValue: string): void {
     assertRef(tdElement);
@@ -160,7 +150,6 @@ function onValidity(event: CustomEvent<ValidityEvent>): void {
         :class="wrapperClasses"
         @click.stop="onClickCell"
         @keydown="onKeydown"
-        @table-activate-cell="onActivateCell"
     >
         <div class="table-ng__editable">
             <span ref="view" class="table-ng__editable__text">{{ column.value(row) }}</span>
@@ -171,6 +160,7 @@ function onValidity(event: CustomEvent<ValidityEvent>): void {
                 type="text"
                 maxlength="40"
                 tabindex="-1"
+                aria-label="temp"
                 @blur="onBlur"
                 @validity="onValidity"
             />
@@ -178,13 +168,7 @@ function onValidity(event: CustomEvent<ValidityEvent>): void {
             <f-icon v-else name="pen" class="table-ng__editable__icon"></f-icon>
         </div>
     </td>
-    <td
-        v-else
-        ref="td"
-        tabindex="-1"
-        class="table-ng__cell table-ng__cell--static"
-        @table-activate-cell="onActivateCell"
-    >
+    <td v-else ref="td" tabindex="-1" class="table-ng__cell table-ng__cell--static">
         {{ column.value(row) }}
     </td>
 </template>

--- a/packages/vue-labs/src/components/FTable/events.ts
+++ b/packages/vue-labs/src/components/FTable/events.ts
@@ -1,3 +1,0 @@
-export interface FTableActivateCellEvent {
-    focus: boolean;
-}

--- a/packages/vue-labs/src/components/FTable/f-table-api.ts
+++ b/packages/vue-labs/src/components/FTable/f-table-api.ts
@@ -1,0 +1,31 @@
+import { type ShallowRef } from "vue";
+
+/**
+ * {@link FTable} optional cell api. Expose in cell component.
+ *
+ * @public
+ */
+export interface FTableCellApi {
+    /**
+     * Preferred tabstop element when other than default (`td`).
+     */
+    tabstopEl: Readonly<ShallowRef<HTMLElement | null>>;
+}
+
+/**
+ * @internal
+ */
+export function isFTableCellApi(value: unknown): value is FTableCellApi {
+    return (
+        value !== null &&
+        typeof value === "object" &&
+        Boolean((value as FTableCellApi).tabstopEl)
+    );
+}
+
+/**
+ * Key used on HTMLElement to store table cell api.
+ *
+ * @internal
+ */
+export const tableCellApiSymbol = Symbol("table:cell-api");

--- a/packages/vue-labs/src/components/FTable/index.ts
+++ b/packages/vue-labs/src/components/FTable/index.ts
@@ -1,2 +1,11 @@
+import { type FTableCellApi, type tableCellApiSymbol } from "./f-table-api";
+
 export { default as FTable } from "./FTable.vue";
+export { type FTableCellApi } from "./f-table-api";
 export { type TableColumn, defineTableColumns } from "./table-column";
+
+declare global {
+    interface HTMLElement {
+        [tableCellApiSymbol]?: FTableCellApi;
+    }
+}


### PR DESCRIPTION
Ersätter tidigare event-baserade lösning med api på cell-komponenter.

- cell-komponenter med `th`, `td` som default tabstop behöver inte göra något
- cell-komponenter med andra targets, t ex `input`, får exponera elementet via `FTableCellApi`

En av anledningarna till bytet är timing-issues som uppstår när vi använder events kombinerat med borttag av rader.
En annan anledning är att vi nu kan urskilja om custom cell-komponenter valt att exponera en referens och utifrån det besluta hur vi vill göra i default-fallet (då inget angetts). Kan vara fokus på `td` eller första element med `tabindex`.