### PR TITLE
fix: missing screenreader context for dialogue-tree questions (refs S…

### DIFF
--- a/docs/components/FDialogueTree.md
+++ b/docs/components/FDialogueTree.md
@@ -37,6 +37,7 @@ Låter användaren navigera genom X antal dialoger som leder till en slutvy base
 ## Användning
 
 ```html static
+<!-- [html-validate-disable-block aria-label-misuse -- well supported]-->
 <f-dialogue-tree v-model="current" dialogue-tree="tree">
     <template #default="{ userData }">
         <template v-if="userData.id === '1'"> 1 </template>
@@ -48,6 +49,7 @@ Låter användaren navigera genom X antal dialoger som leder till en slutvy base
 ## Exempel
 
 ```import
+<!-- [html-validate-disable-block aria-label-misuse -- well supported]-->
 ExampleFDialogueTree.vue
 ```
 
@@ -56,6 +58,7 @@ ExampleFDialogueTree.vue
 Exempel på en kombination av komponenterna FFormModal och FDialogueTree för att skapa en modal som inehåller flera steg.
 
 ```jsx
+<!-- [html-validate-disable-block aria-label-misuse -- well supported]-->
 const myAwesomeDialogTree: FDialogueTreeSubQuestion = {
   label: "Vad vill du lägga till?",
   options: [ /* ... */ ],
@@ -69,6 +72,7 @@ const myAwesomeDialogTree: FDialogueTreeSubQuestion = {
 ```
 
 ```import nomarkup
+<!-- [html-validate-disable-block aria-label-misuse -- well supported]-->
 FlerstegsModalExample.vue
 ```
 

--- a/packages/vue/htmlvalidate/cypress.js
+++ b/packages/vue/htmlvalidate/cypress.js
@@ -18,4 +18,7 @@ module.exports = [
 
     /* FWizardStep uses an anchor with role="button" for completed steps */
     ".wizard-step__header__title",
+
+    /* FDialogueTree uses aria-label on ul element */
+    ".dialogue-tree__list",
 ];

--- a/packages/vue/src/components/FDialogueTree/FDialogueTree.vue
+++ b/packages/vue/src/components/FDialogueTree/FDialogueTree.vue
@@ -103,7 +103,8 @@ export default defineComponent({
 <template>
     <div class="dialogue-tree">
         <template v-if="options.length > 0">
-            <ul class="dialogue-tree__list">
+            <!-- [html-validate-disable-next aria-label-misuse -- well supported] -->
+            <ul :key="currentStep.label" class="dialogue-tree__list" :aria-label="currentStep.label">
                 <li v-for="(option, index) in options" :key="option.label" class="dialogue-tree__list-item">
                     <button :ref="`dialogueButton-${index}`" type="button" @click="onClickedOption(option, index)">
                         <span>{{ option.label }}</span>


### PR DESCRIPTION
…FKUI-7416)

Solved by setting `aria-label` on `ul`-element.

Also added `key` in order for Vue to rerender element on next question (otherwise, only first question announced to screenreader).

Also relates to SFKUI-7415.

https://forsakringskassan.github.io/designsystem/pr-preview/pr-763/components/fdialoguetree.html