### PR TITLE
[POC] Show only icon inside buttons for navigation to previous/next page in `FPaginator`

### DIFF
--- a/packages/design/src/components/paginator/_paginator.scss
+++ b/packages/design/src/components/paginator/_paginator.scss
@@ -4,7 +4,8 @@
 
 $gap-size: size.$margin-050;
 $page-width: 2.5rem;
-$button-width: 8rem;
+$button-width: $page-width;
+$page-counter-width: 8rem;
 $number-of-pages: 9; // References `upperLimit` in FPaginator.logic
 
 //                      ____________                _________________________________________________________________                 ____________
@@ -23,6 +24,7 @@ $paginator-width-full: $button-width + $gap-size + $page-width * $number-of-page
     &__page,
     &__previous,
     &__next {
+        width: $page-width;
         border: none;
         color: black;
         background-color: white;
@@ -42,17 +44,11 @@ $paginator-width-full: $button-width + $gap-size + $page-width * $number-of-page
     }
 
     &__page {
-        width: $page-width;
         display: none;
     }
 
-    &__next,
-    &__page-counter,
-    &__previous {
-        width: $button-width;
-    }
-
     &__page-counter {
+        width: $page-counter-width;
         padding: size.$padding-025;
         text-align: center;
         color: $paginator-page-counter-color-text-default;

--- a/packages/vue/src/components/FPaginator/FPaginator.spec.ts
+++ b/packages/vue/src/components/FPaginator/FPaginator.spec.ts
@@ -57,12 +57,6 @@ describe("previous button", () => {
         previousButton = wrapper.find("[data-test='previous-button']");
     });
 
-    it("should have the correct label", () => {
-        expect(
-            previousButton.find("[data-test='label']").element.innerHTML,
-        ).toBe("Föregående");
-    });
-
     it("should have the correct value for 'aria-label'", () => {
         expect(previousButton.attributes("aria-label")).toBe("Föregående");
     });
@@ -79,12 +73,6 @@ describe("next button", () => {
             },
         });
         nextButton = wrapper.find("[data-test='next-button']");
-    });
-
-    it("should have the correct label", () => {
-        expect(nextButton.find("[data-test='label']").element.innerHTML).toBe(
-            "Nästa",
-        );
     });
 
     it("should have the correct value for 'aria-label'", () => {

--- a/packages/vue/src/components/FPaginator/FPaginator.vue
+++ b/packages/vue/src/components/FPaginator/FPaginator.vue
@@ -149,7 +149,6 @@ function showGap(page: number): boolean {
             @click="onClickPreviousButton()"
         >
             <f-icon name="chevrons-left" />
-            <span data-test="label">{{ previousButtonLabel }}</span>
         </button>
 
         <button
@@ -174,7 +173,6 @@ function showGap(page: number): boolean {
             :aria-label="nextButtonLabel"
             @click="onClickNextButton()"
         >
-            <span data-test="label">{{ nextButtonLabel }}</span>
             <f-icon name="arrow-right" class="paginator__icon" />
         </button>
     </nav>


### PR DESCRIPTION
Utbryten från #677 för att testa knappar för navigation till föregående/nästa sida med enbart ikon.

### Exempel
https://forsakringskassan.github.io/designsystem/pr-preview/pr-779/components/pagination.html