### PR TITLE
Shorter page counter label in `FPaginator`

### DIFF
--- a/docs/functions/cypress/pageobjects/FPaginatorPageObject/FPaginatorPageObject-page-counter.cy.ts
+++ b/docs/functions/cypress/pageobjects/FPaginatorPageObject/FPaginatorPageObject-page-counter.cy.ts
@@ -6,6 +6,6 @@ it("pageCounter() should contain correct text", () => {
 
     /* --- cut above --- */
     const paginator = new FPaginatorPageobject("[data-test='myPaginator']");
-    paginator.pageCounter().should("contain.text", "Sida 1 av 20");
+    paginator.pageCounter().should("contain.text", "1 av 20");
     /* --- cut below --- */
 });

--- a/packages/vue/src/components/FPaginator/FPaginator.spec.ts
+++ b/packages/vue/src/components/FPaginator/FPaginator.spec.ts
@@ -3,13 +3,13 @@ import FPaginator from "./FPaginator.vue";
 
 describe("page counter", () => {
     it.each`
-        currentPage | numberOfPages | expectedText
-        ${1}        | ${3}          | ${"Sida 1 av 3"}
-        ${2}        | ${3}          | ${"Sida 2 av 3"}
-        ${3}        | ${3}          | ${"Sida 3 av 3"}
+        currentPage | numberOfPages | expectedText | exceptedAriaText
+        ${1}        | ${3}          | ${"1 av 3"}  | ${"Sida 1 av 3"}
+        ${2}        | ${3}          | ${"2 av 3"}  | ${"Sida 2 av 3"}
+        ${3}        | ${3}          | ${"3 av 3"}  | ${"Sida 3 av 3"}
     `(
         "should display correct text",
-        ({ currentPage, numberOfPages, expectedText }) => {
+        ({ currentPage, numberOfPages, expectedText, exceptedAriaText }) => {
             const wrapper = mount(FPaginator, {
                 attrs: {
                     currentPage,
@@ -17,8 +17,13 @@ describe("page counter", () => {
                 },
             });
             expect(
-                wrapper.find("[data-test='page-counter']").element.innerHTML,
+                wrapper.find("[data-test='page-counter'] [aria-hidden]").element
+                    .innerHTML,
             ).toEqual(expectedText);
+            expect(
+                wrapper.find("[data-test='page-counter'] .sr-only").element
+                    .innerHTML,
+            ).toEqual(exceptedAriaText);
         },
     );
 });

--- a/packages/vue/src/components/FPaginator/FPaginator.vue
+++ b/packages/vue/src/components/FPaginator/FPaginator.vue
@@ -84,11 +84,27 @@ const previousButtonLabel = computed(() =>
     $t("fkui.paginator.previous", "Föregående"),
 );
 
+const pageCounterAriaLabel = computed(() =>
+    /**
+     * Page counter (shown for screen readers).
+     */
+    $t("fkui.paginator.page-counter-aria", "Sida {{ currentPage }} av {{ numberOfPages }}", {
+        /**
+         * The current page number.
+         */
+        currentPage: currentPage.value,
+        /**
+         * The total number of pages.
+         */
+        numberOfPages: numberOfPages.value,
+    }),
+);
+
 const pageCounterLabel = computed(() =>
     /**
      * Page counter.
      */
-    $t("fkui.paginator.page-counter", "Sida {{ currentPage }} av {{ numberOfPages }}", {
+    $t("fkui.paginator.page-counter", "{{ currentPage }} av {{ numberOfPages }}", {
         /**
          * The current page number.
          */
@@ -174,7 +190,10 @@ function showGap(page: number): boolean {
             {{ showGap(page) ? "..." : page }}
         </button>
 
-        <div data-test="page-counter" class="paginator__page-counter">{{ pageCounterLabel }}</div>
+        <div data-test="page-counter" class="paginator__page-counter">
+            <span class="sr-only">{{ pageCounterAriaLabel }}</span>
+            <span aria-hidden>{{ pageCounterLabel }}</span>
+        </div>
 
         <button
             data-test="next-button"


### PR DESCRIPTION
Utbryten från #677 för att testa en kortare etikett för sidräknaren utan prefixet _Sida_.

### Exempel
https://forsakringskassan.github.io/designsystem/pr-preview/pr-780/components/pagination.html