### PR TITLE
feat: add fraction digits optional option to `parseNumber` and `parsePercent` (refs SFKUI-6500)

### DIFF
--- a/etc/logic.api.md
+++ b/etc/logic.api.md
@@ -321,13 +321,13 @@ export function parseClearingNumber(value: string): ClearingnumberString | undef
 export function parseDate(value: string): DateString | undefined;
 
 // @public (undocumented)
-export function parseNumber(value: string): number | undefined;
+export function parseNumber(value: string, fractionDigits?: number): number | undefined;
 
 // @public (undocumented)
 export function parseOrganisationsnummer(value: string): OrganisationsnummerString | undefined;
 
 // @public (undocumented)
-export function parsePercent(viewValue: string): number;
+export function parsePercent(viewValue: string, fractionDigits?: number): number | undefined;
 
 // @public
 export function parsePersonnummer(value: string | null | undefined, now?: FDate): PersonnummerString | undefined;

--- a/packages/logic/src/converters/NumberConverter/numberConverter.spec.ts
+++ b/packages/logic/src/converters/NumberConverter/numberConverter.spec.ts
@@ -94,3 +94,42 @@ describe("parse", () => {
         },
     );
 });
+
+describe("parse with fractionDigits", () => {
+    it("should round parsed value to given precision", () => {
+        expect.assertions(23);
+
+        //Invalid values
+        expect(parseNumber("", 2)).toBeUndefined();
+        expect(parseNumber("foo", 2)).toBeUndefined();
+        expect(parseNumber("123a", 2)).toBeUndefined();
+        expect(parseNumber("123e-1", 2)).toBeUndefined();
+        expect(parseNumber("-Infinity", 2)).toBeUndefined();
+        expect(parseNumber("5.5", -2)).toBeUndefined();
+
+        //No fractions
+        expect(parseNumber("0.4", 0)).toBe(0);
+        expect(parseNumber("0.5", 0)).toBe(1);
+        expect(parseNumber("0.6", 0)).toBe(1);
+
+        //One fraction
+        expect(parseNumber("0.10", 1)).toBe(0.1);
+        expect(parseNumber("0.14", 1)).toBe(0.1);
+        expect(parseNumber("0.15", 1)).toBe(0.2);
+        expect(parseNumber("0.16", 1)).toBe(0.2);
+
+        //Two fractions
+        expect(parseNumber("0.001", 2)).toBe(0);
+        expect(parseNumber("0.004", 2)).toBe(0);
+        expect(parseNumber("0.005", 2)).toBe(0.01);
+        expect(parseNumber("0.006", 2)).toBe(0.01);
+        expect(parseNumber("9.999", 2)).toBe(10);
+
+        //Negative value and 3 fractions
+        expect(parseNumber("-9.9111", 3)).toBe(-9.911);
+        expect(parseNumber("-9.4444", 3)).toBe(-9.444);
+        expect(parseNumber("-9.5555", 3)).toBe(-9.556);
+        expect(parseNumber("-9.6666", 3)).toBe(-9.667);
+        expect(parseNumber("-9.9999", 3)).toBe(-10);
+    });
+});

--- a/packages/logic/src/converters/NumberConverter/numberConverter.ts
+++ b/packages/logic/src/converters/NumberConverter/numberConverter.ts
@@ -1,5 +1,5 @@
 import { stripWhitespace } from "../../text";
-import { isEmpty } from "../../utils";
+import { isEmpty, isSet } from "../../utils";
 
 const NUMBER_REGEXP = /^(-?\d+)([,.]\d+)?$/;
 
@@ -58,7 +58,10 @@ export function formatNumber(
 /**
  * @public
  */
-export function parseNumber(value: string): number | undefined {
+export function parseNumber(
+    value: string,
+    fractionDigits?: number,
+): number | undefined {
     if (isEmpty(value)) {
         return undefined;
     }
@@ -73,6 +76,20 @@ export function parseNumber(value: string): number | undefined {
     }
 
     const number = Number(numberString);
+    const parsedNumber = isSet(fractionDigits)
+        ? getNumberWithFraction(number, fractionDigits)
+        : number;
 
-    return isNaN(number) ? undefined : number;
+    return isNaN(parsedNumber) ? undefined : parsedNumber;
+}
+
+/**
+ * @internal
+ */
+function getNumberWithFraction(value: number, fractionDigits: number): number {
+    if (fractionDigits < 0) {
+        return NaN;
+    }
+    const exp = 10 ** fractionDigits;
+    return Math.sign(value) * (Math.round(Math.abs(value) * exp) / exp);
 }

--- a/packages/logic/src/converters/PercentConverter/percentConverter.ts
+++ b/packages/logic/src/converters/PercentConverter/percentConverter.ts
@@ -13,7 +13,9 @@ export function formatPercent(
 /**
  * @public
  */
-export function parsePercent(viewValue: string): number {
-    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- technical debt */
-    return parseNumber(viewValue)!;
+export function parsePercent(
+    viewValue: string,
+    fractionDigits?: number,
+): number | undefined {
+    return parseNumber(viewValue, fractionDigits);
 }


### PR DESCRIPTION
Gör det möjligt att begränsa antalet decimaler.
