### PR TITLE
docs: init dark mode for documentation pages (refs SB-4982)

### DIFF
--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -1,4 +1,4 @@
-@use "pkg:@fkui/theme-default";
+@use "pkg:@fkui/theme-default" as theme;
 @use "@fkui/theme-default/src/palette-variables" as palette;
 @use "@fkui/design/src/core/config-variables" with (
     $asset-path: ".",
@@ -7,10 +7,23 @@
 @use "@fkui/design/src/core/mixins/breakpoints";
 @use "@fkui/design" as fkui;
 @use "@forsakringskassan/docs-generator/style";
+@use "@forsakringskassan/docs-generator/theme/fkui" as theme-fkui;
 @use "@forsakringskassan/docs-live-example";
 
 $fk-logo-small: "fk-logo-primary-small.svg";
 $fk-logo-large: "fk-logo-primary-large.svg";
+
+@media (prefers-color-scheme: light) {
+    :root {
+        @include theme.light;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        @include theme.dark;
+    }
+}
 
 :root {
     --f-logo-image-small:

--- a/docs/src/fkui-theme.scss
+++ b/docs/src/fkui-theme.scss
@@ -1,7 +1,3 @@
-@use "@fkui/theme-default" as theme with (
-    $global: false
-);
-
 @use "@fkui/font-default" as font with (
     $global: false,
     $asset-path: "./assets/fonts"
@@ -15,22 +11,6 @@ $fk-logo-small-url: "#{config-variables.$asset-path-images}/fk-logo-primary-smal
 $fk-logo-large-url: "#{config-variables.$asset-path-images}/fk-logo-primary-large.svg";
 
 @include font.font-face;
-
-@media (prefers-color-scheme: light) {
-    .code-preview__preview,
-    .live-example__example,
-    .user-theme {
-        @include theme.light;
-    }
-}
-
-@media (prefers-color-scheme: dark) {
-    .code-preview__preview,
-    .live-example__example,
-    .user-theme {
-        @include theme.dark;
-    }
-}
 
 .code-preview__preview,
 .live-example__example,


### PR DESCRIPTION
Jag har påbörjat att skapa upp ett `fkui-tema` i docs-generatorn vars syfte är att mappa om variabler därifrån till våra egna.

Min lilla poc antyder att det finns en del att göra :-) 

Konceptuellt verkar allt lira, nu är det att fortsätta arbetet i docs-generator. Både att uttöka docs med fler variabler, men också mappa dem emot FKUI. Detta är ett arbete som skulle kunna göras tillsammans med en designer som har mer koll på alla semantiska färger än en annan ;)

* https://github.com/Forsakringskassan/docs-generator/blob/main/src/style/theme/fkui.scss

<img width="1310" height="604" alt="image" src="https://github.com/user-attachments/assets/0d230afb-0c10-4efd-be1c-55101d905223" />

Jag vill alltså att merga in detta och sedan fortsätta arbetet.
