### PR TITLE
refactor: extract selectable logic from table component

### DIFF
--- a/packages/vue-labs/elements.js
+++ b/packages/vue-labs/elements.js
@@ -1,4 +1,6 @@
-const { defineMetadata } = require("html-validate");
+const { defineMetadata, metadataHelper } = require("html-validate");
+
+const { allowedIfAttributeIsPresent } = metadataHelper;
 
 module.exports = defineMetadata({
     "x-file-dragdrop": {
@@ -11,6 +13,29 @@ module.exports = defineMetadata({
 
     "f-table": {
         flow: true,
+        attributes: {
+            columns: {
+                required: true,
+            },
+            rows: {
+                required: true,
+            },
+            "key-attribute": ["/.+/"],
+            "expandable-attribute": ["/.+/"],
+            striped: {
+                boolean: true,
+            },
+            selectable: ["/.+/"],
+            "selected-rows": {
+                allowed: allowedIfAttributeIsPresent("selectable"),
+                required: false,
+            },
+            "v-model:selected-rows": {
+                allowed: allowedIfAttributeIsPresent("selectable"),
+                required: false,
+            },
+        },
+        slots: ["empty", "expandable", "footer"],
     },
 
     tr: {
@@ -28,6 +53,7 @@ module.exports = defineMetadata({
             "i-table-radio",
             "i-table-rowheader",
             "i-table-select",
+            "i-table-selectable",
             "i-table-text",
         ],
     },
@@ -37,6 +63,10 @@ module.exports = defineMetadata({
     },
 
     "i-table-header-selectable": {
+        flow: true,
+    },
+
+    "i-table-selectable": {
         flow: true,
     },
 

--- a/packages/vue-labs/src/components/FTable/FTable.spec.ts
+++ b/packages/vue-labs/src/components/FTable/FTable.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import FTable from "./FTable.vue";
 import { defineTableColumns } from "./table-column";
 
@@ -265,5 +265,200 @@ describe("footer", () => {
             const footerCell = wrapper.get("tfoot td");
             expect(footerCell.attributes("colspan")).toBe("5");
         });
+    });
+});
+
+describe("7.1 Bulk checkbox in header when multiselect is enabled", () => {
+    it("should render bulk checkbox in first column header for regular table", () => {
+        const rows = [{ text: "Foo" }, { text: "Bar" }];
+        const columns = defineTableColumns<(typeof rows)[number]>([
+            {
+                type: "text",
+                header: "Header",
+                key: "text",
+            },
+        ]);
+        const wrapper = mount(FTable<(typeof rows)[number]>, {
+            props: {
+                selectable: "multi",
+                rows,
+                columns,
+            },
+            global: {
+                stubs: ["i-table-header-selectable"],
+            },
+        });
+        expect(
+            wrapper.get("thead tr:first-child :first-child"),
+        ).toMatchInlineSnapshot(
+            `<i-table-header-selectable-stub selectable="multi" state="false"></i-table-header-selectable-stub>`,
+        );
+    });
+
+    it("should render bulk checkbox in second column header for expandable table", () => {
+        const rows = [{ text: "Foo", children: [{ text: "Bar" }] }];
+        const columns = defineTableColumns<(typeof rows)[number]>([
+            {
+                type: "text",
+                header: "Header",
+                key: "text",
+            },
+        ]);
+        const wrapper = mount(FTable<(typeof rows)[number]>, {
+            props: {
+                selectable: "multi",
+                expandableAttribute: "children",
+                rows,
+                columns,
+            },
+            global: {
+                stubs: ["i-table-header-selectable"],
+            },
+        });
+        expect(
+            wrapper.get("thead tr:first-child :nth-child(2)"),
+        ).toMatchInlineSnapshot(
+            `<i-table-header-selectable-stub selectable="multi" state="false"></i-table-header-selectable-stub>`,
+        );
+    });
+});
+
+describe("7.4 Bulk selection in expandable", () => {
+    it("should render checkboxes only for top-level rows", async () => {
+        const rows = [{ text: "Foo", children: [{ text: "Bar" }] }];
+        const columns = defineTableColumns<(typeof rows)[number]>([
+            {
+                type: "text",
+                header: "Header",
+                key: "text",
+            },
+        ]);
+        const wrapper = mount(FTable<(typeof rows)[number]>, {
+            props: {
+                selectable: "multi",
+                expandableAttribute: "children",
+                rows,
+                columns,
+            },
+        });
+
+        wrapper.get("button").trigger("click"); // expand row
+        await flushPromises();
+
+        expect(
+            wrapper.find("tbody tr:nth-child(1) input").exists(),
+        ).toBeTruthy();
+        expect(
+            wrapper.find("tbody tr:nth-child(2) input").exists(),
+        ).toBeFalsy();
+    });
+
+    it("should place selection checkboxes in column 2 when expandable column exists", async () => {
+        const rows = [{ text: "Foo", children: [{ text: "Bar" }] }];
+        const columns = defineTableColumns<(typeof rows)[number]>([
+            {
+                type: "text",
+                header: "Header",
+                key: "text",
+            },
+        ]);
+        const wrapper = mount(FTable<(typeof rows)[number]>, {
+            props: {
+                selectable: "multi",
+                expandableAttribute: "children",
+                rows,
+                columns,
+            },
+            global: {
+                stubs: ["i-table-selectable"],
+            },
+        });
+
+        wrapper.get("button").trigger("click"); // expand row
+        await flushPromises();
+
+        expect(
+            wrapper.get("tbody tr:nth-child(1) :nth-child(2)"),
+        ).toMatchInlineSnapshot(
+            `<i-table-selectable-stub selectable="multi" row="[object Object]" state="false" level="1"></i-table-selectable-stub>`,
+        );
+        expect(
+            wrapper.get("tbody tr:nth-child(2) :nth-child(2)"),
+        ).toMatchInlineSnapshot(
+            `<i-table-selectable-stub selectable="multi" row="[object Object]" state="false" level="2"></i-table-selectable-stub>`,
+        );
+    });
+});
+
+describe("7.6 aria-selected", () => {
+    it("should set aria-selected=true when row is selected via checkbox", async () => {
+        const rows = [{ text: "Foo" }, { text: "Bar" }];
+        const columns = defineTableColumns<(typeof rows)[number]>([
+            {
+                type: "text",
+                header: "Header",
+                key: "text",
+            },
+        ]);
+        const wrapper = mount(FTable<(typeof rows)[number]>, {
+            props: {
+                columns,
+                rows,
+                selectable: "multi",
+                keyAttribute: "text",
+                selectedRows: [],
+            },
+        });
+
+        expect(
+            wrapper.get("tbody tr:first-child").attributes("aria-selected"),
+        ).toBe("false");
+
+        await wrapper.get("tbody tr:first-child input").setValue();
+
+        expect(
+            wrapper.get("tbody tr:first-child").attributes("aria-selected"),
+        ).toBe("true");
+    });
+
+    it("should set aria-selected=true only for top-level rows expandable table", async () => {
+        const rows = [
+            { text: "1", children: [{ text: "2" }] },
+            { text: "3", children: [{ text: "4" }] },
+        ];
+        const columns = defineTableColumns<(typeof rows)[number]>([
+            {
+                type: "text",
+                header: "Header",
+                key: "text",
+            },
+        ]);
+        const wrapper = mount(FTable<(typeof rows)[number]>, {
+            props: {
+                columns,
+                rows,
+                selectable: "multi",
+                keyAttribute: "text",
+                expandableAttribute: "children",
+                selectedRows: [],
+            },
+        });
+
+        await wrapper.get("tbody tr:last-child button").trigger("click");
+        await wrapper.get("tbody tr:first-child button").trigger("click");
+        await wrapper.get("thead tr input").setValue();
+
+        const trs = wrapper.findAll("tbody tr");
+        expect(
+            trs.map(
+                (tr, index) =>
+                    `Row ${index + 1} aria-selected: ${tr.attributes("aria-selected")}`,
+            ),
+        ).toMatchObject([
+            "Row 1 aria-selected: true",
+            "Row 2 aria-selected: false",
+            "Row 3 aria-selected: true",
+            "Row 4 aria-selected: false",
+        ]);
     });
 });

--- a/packages/vue-labs/src/components/FTable/ITableHeaderSelectable.vue
+++ b/packages/vue-labs/src/components/FTable/ITableHeaderSelectable.vue
@@ -1,29 +1,39 @@
 <script setup lang="ts">
-import { useTemplateRef } from "vue";
+import { computed, useTemplateRef } from "vue";
 import { type FTableCellApi } from "./f-table-api";
+
+const { selectable, state } = defineProps<{ selectable: "single" | "multi"; state: boolean | "indeterminate" }>();
 
 const emit = defineEmits<{
     /**
      * Emitted when checkbox value changes.
      */
-    change: [];
+    toggle: [];
 }>();
 
-const selectAllRef = useTemplateRef("selectAll");
+const indeterminate = computed(() => state === "indeterminate");
+const checked = computed(() => (state === "indeterminate" ? false : state));
+const expose: Partial<FTableCellApi> = {};
 
-const expose: FTableCellApi = { tabstopEl: selectAllRef };
+if (selectable === "multi") {
+    const inputRef = useTemplateRef("input");
+    expose.tabstopEl = inputRef;
+}
+
 defineExpose(expose);
 </script>
 
 <template>
     <th scope="col" class="table-ng__column table-ng__column--selectable">
         <input
-            ref="selectAll"
+            v-if="selectable === 'multi'"
+            ref="input"
+            :checked
+            :indeterminate
             type="checkbox"
             aria-label="select all"
             tabindex="-1"
-            indeterminate
-            @change="emit('change')"
+            @change="emit('toggle')"
         />
     </th>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableSelect.vue
+++ b/packages/vue-labs/src/components/FTable/ITableSelect.vue
@@ -215,7 +215,7 @@ function cancel(): void {
 <template>
     <td
         v-if="column.editable(row)"
-        class="table-ng__cell table-ng__cell--select"
+        class="table-ng__cell table-ng__cell--selectable"
         tabindex="-1"
         @keydown="onCellKeyDown"
         @click.stop="onCellClick"

--- a/packages/vue-labs/src/components/FTable/ITableSelectable.vue
+++ b/packages/vue-labs/src/components/FTable/ITableSelectable.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts" generic="T, K extends keyof T">
+import { computed, ref, useTemplateRef } from "vue";
+import { useTranslate } from "@fkui/vue";
+import ITableCheckbox from "./ITableCheckbox.vue";
+import ITableRadio from "./ITableRadio.vue";
+import { type FTableCellApi } from "./f-table-api";
+import { type NormalizedTableColumnCheckbox, type NormalizedTableColumnRadio } from "./table-column";
+
+const {
+    selectable,
+    row,
+    state,
+    level = 1,
+} = defineProps<{
+    selectable: "single" | "multi";
+    row: T;
+    state: boolean;
+    level?: number;
+}>();
+
+const emit = defineEmits<{ toggle: [row: T] }>();
+
+const expose: Partial<FTableCellApi> = {};
+if (level === 1) {
+    const childRef = useTemplateRef("child");
+    expose.tabstopEl = computed(() => childRef.value?.tabstopEl ?? null);
+}
+defineExpose(expose);
+
+const $t = useTranslate();
+
+const multiSelectColumn: NormalizedTableColumnCheckbox<T, K> = {
+    type: "checkbox",
+    id: Symbol("multi-select"),
+    header: ref("selectable"),
+    description: ref(null),
+    sortable: null,
+    component: ITableCheckbox,
+    label() {
+        /** Screen reader text for checkbox in multi select table row. */
+        return $t("fkui.table.selectable.checkbox", "Välj rad");
+    },
+    value() {
+        return state;
+    },
+    editable() {
+        return true;
+    },
+    update() {
+        emit("toggle", row);
+    },
+};
+
+const singleSelectColumn: NormalizedTableColumnRadio<T, K> = {
+    type: "radio",
+    id: Symbol("single-select"),
+    header: ref("Välj en rad"),
+    description: ref(null),
+    sortable: null,
+    component: ITableRadio,
+    label() {
+        /** Screen reader text for radio button in single select table row. */
+        return $t("fkui.table.selectable.radio", "Välj rad");
+    },
+    value() {
+        return state;
+    },
+    update() {
+        emit("toggle", row);
+    },
+};
+</script>
+
+<template>
+    <td v-if="level > 1" tabindex="-1" class="table-ng__cell"></td>
+    <i-table-checkbox
+        v-else-if="selectable === 'multi'"
+        ref="child"
+        :row
+        :column="multiSelectColumn"
+        class="table-ng__cell--selectable"
+    ></i-table-checkbox>
+    <i-table-radio
+        v-else-if="selectable === 'single'"
+        ref="child"
+        :row
+        :column="singleSelectColumn"
+        class="table-ng__cell--selectable"
+    ></i-table-radio>
+</template>

--- a/packages/vue-labs/src/components/FTable/use-selectable.spec.ts
+++ b/packages/vue-labs/src/components/FTable/use-selectable.spec.ts
@@ -1,0 +1,364 @@
+import { ref, toValue } from "vue";
+import { setInternalKeys } from "@fkui/vue";
+import { flushPromises } from "@vue/test-utils";
+import { useSelectable } from "./use-selectable";
+
+interface Row {
+    id: number;
+    value?: string;
+}
+
+describe("selectableRowState(row)", () => {
+    it("should return `true` when selected row", () => {
+        const rows: Row[] = [{ id: 1 }, { id: 2 }];
+        setInternalKeys(rows);
+        const selectedRows = ref([rows[1]]);
+
+        const { selectableRowState } = useSelectable({
+            selectable: "multi",
+            selectedRows,
+            rows,
+        });
+
+        expect(selectableRowState(rows[1])).toBeTruthy();
+    });
+
+    it("should return `false` when not selected row", () => {
+        const rows: Row[] = [{ id: 1 }, { id: 2 }];
+        setInternalKeys(rows);
+        const selectedRows = ref([rows[0]]);
+
+        const { selectableRowState } = useSelectable({
+            selectable: "multi",
+            selectedRows,
+            rows,
+        });
+
+        expect(selectableRowState(rows[1])).toBeFalsy();
+    });
+});
+
+describe("single select", () => {
+    describe("toggleSelectableRow(row", () => {
+        it("should select row when nothing selected", () => {
+            const rows: Row[] = [{ id: 1 }, { id: 2 }];
+            setInternalKeys(rows);
+            const selectedRows = ref([]);
+
+            const { toggleSelectableRow, selectableRowState } = useSelectable({
+                selectable: "single",
+                selectedRows,
+                rows,
+            });
+
+            expect(selectableRowState(rows[0])).toBeFalsy();
+            expect(selectableRowState(rows[1])).toBeFalsy();
+            toggleSelectableRow(rows[0]);
+            expect(selectableRowState(rows[0])).toBeTruthy();
+            expect(selectableRowState(rows[1])).toBeFalsy();
+        });
+
+        it("should select row and unselect previous selected row", () => {
+            const rows: Row[] = [{ id: 1 }, { id: 2 }];
+            setInternalKeys(rows);
+            const selectedRows = ref([rows[0]]);
+
+            const { toggleSelectableRow, selectableRowState } = useSelectable({
+                selectable: "single",
+                selectedRows,
+                rows,
+            });
+
+            expect(selectableRowState(rows[0])).toBeTruthy();
+            expect(selectableRowState(rows[1])).toBeFalsy();
+            toggleSelectableRow(rows[1]);
+            expect(selectableRowState(rows[0])).toBeFalsy();
+            expect(selectableRowState(rows[1])).toBeTruthy();
+        });
+    });
+});
+
+describe("multi select", () => {
+    describe("selectableHeaderState", () => {
+        it("should return `false` when no rows selected", () => {
+            const { selectableHeaderState } = useSelectable({
+                selectable: "multi",
+                selectedRows: ref([]),
+                rows: [],
+            });
+
+            expect(selectableHeaderState()).toBeFalsy();
+        });
+
+        it("should return `indeterminate` when some rows selected", () => {
+            const rows: Row[] = [{ id: 1 }, { id: 2 }];
+            setInternalKeys(rows);
+            const selectedRows = ref([rows[1]]);
+
+            const { selectableHeaderState } = useSelectable({
+                selectable: "multi",
+                selectedRows,
+                rows,
+            });
+
+            expect(selectableHeaderState()).toBe("indeterminate");
+        });
+
+        it("should return `true` when all rows selected", () => {
+            const rows: Row[] = [{ id: 1 }, { id: 2 }];
+            setInternalKeys(rows);
+            const selectedRows = ref([...rows]);
+
+            const { selectableHeaderState } = useSelectable({
+                selectable: "multi",
+                selectedRows,
+                rows,
+            });
+
+            expect(selectableHeaderState()).toBeTruthy();
+        });
+    });
+
+    describe("toggleSelectableHeader()", () => {
+        it("should trigger checked state and select all rows when unchecked state", () => {
+            const rows: Row[] = [{ id: 1 }, { id: 2 }];
+            setInternalKeys(rows);
+            const selectedRows = ref([]);
+
+            const { selectableHeaderState, toggleSelectableHeader } =
+                useSelectable({
+                    selectable: "multi",
+                    selectedRows,
+                    rows,
+                });
+
+            expect(selectableHeaderState()).toBeFalsy();
+            toggleSelectableHeader();
+            expect(selectableHeaderState()).toBeTruthy();
+            expect(selectedRows.value).toHaveLength(2);
+        });
+
+        it("should trigger checked state and select all rows when indeterminate state", () => {
+            const rows: Row[] = [{ id: 1 }, { id: 2 }];
+            setInternalKeys(rows);
+            const selectedRows = ref([rows[1]]);
+
+            const { selectableHeaderState, toggleSelectableHeader } =
+                useSelectable({
+                    selectable: "multi",
+                    selectedRows,
+                    rows,
+                });
+
+            expect(selectableHeaderState()).toBe("indeterminate");
+            toggleSelectableHeader();
+            expect(selectableHeaderState()).toBeTruthy();
+            expect(selectedRows.value).toHaveLength(2);
+        });
+
+        it("should trigger unchecked state and unselect all rows when checked state", () => {
+            const rows: Row[] = [{ id: 1 }, { id: 2 }];
+            setInternalKeys(rows);
+            const selectedRows = ref([...rows]);
+
+            const { selectableHeaderState, toggleSelectableHeader } =
+                useSelectable({
+                    selectable: "multi",
+                    selectedRows,
+                    rows,
+                });
+
+            expect(selectableHeaderState()).toBeTruthy();
+            toggleSelectableHeader();
+            expect(selectableHeaderState()).toBeFalsy();
+            expect(selectedRows.value).toHaveLength(0);
+        });
+    });
+
+    describe("toggleSelectableRow(row)", () => {
+        it("should get header state `indeterminate` and row state `checked` when nothing selected", () => {
+            const rows: Row[] = [{ id: 1 }, { id: 2 }];
+            setInternalKeys(rows);
+            const selectedRows = ref([]);
+
+            const {
+                selectableHeaderState,
+                toggleSelectableRow,
+                selectableRowState,
+            } = useSelectable({
+                selectable: "multi",
+                selectedRows,
+                rows,
+            });
+
+            toggleSelectableRow(rows[1]);
+            expect(selectableHeaderState()).toBe("indeterminate");
+            expect(selectableRowState(rows[1])).toBeTruthy();
+        });
+
+        it("should get header state checked and all rows checked when selecting row by row", () => {
+            const rows: Row[] = [{ id: 1 }, { id: 2 }];
+            setInternalKeys(rows);
+            const selectedRows = ref([]);
+
+            const {
+                selectableHeaderState,
+                toggleSelectableRow,
+                selectableRowState,
+            } = useSelectable({
+                selectable: "multi",
+                selectedRows,
+                rows,
+            });
+
+            toggleSelectableRow(rows[0]);
+            toggleSelectableRow(rows[1]);
+            expect(selectableHeaderState()).toBeTruthy();
+            expect(selectableRowState(rows[0])).toBeTruthy();
+            expect(selectableRowState(rows[1])).toBeTruthy();
+        });
+
+        it("should get header state `indeterminate` and row unchecked when all selected", () => {
+            const rows: Row[] = [{ id: 1 }, { id: 2 }];
+            setInternalKeys(rows);
+            const selectedRows = ref([...rows]);
+
+            const {
+                selectableHeaderState,
+                toggleSelectableRow,
+                selectableRowState,
+            } = useSelectable({
+                selectable: "multi",
+                selectedRows,
+                rows,
+            });
+
+            expect(selectableHeaderState()).toBeTruthy();
+            toggleSelectableRow(rows[1]);
+            expect(selectableHeaderState()).toBe("indeterminate");
+            expect(selectableRowState(rows[0])).toBeTruthy();
+            expect(selectableRowState(rows[1])).toBeFalsy();
+        });
+    });
+});
+
+describe("7.7 Dataset change resets selection", () => {
+    it("should clear all selected rows and bulk checkbox when a row is added", async () => {
+        const rows = ref<Row[]>([{ id: 1 }, { id: 2 }]);
+        setInternalKeys(rows.value);
+        const selectedRows = ref([toValue(rows)[0]]);
+
+        const { selectableRowState, selectableHeaderState } = useSelectable({
+            selectable: "multi",
+            selectedRows,
+            rows,
+        });
+
+        expect(selectableHeaderState()).toBe("indeterminate");
+        expect(selectableRowState(toValue(rows)[0])).toBeTruthy();
+
+        rows.value.push({ id: 3 });
+        setInternalKeys(rows.value);
+        await flushPromises();
+
+        expect(selectedRows.value).toEqual([]);
+        expect(selectableRowState(toValue(rows)[0])).toBeFalsy();
+        expect(selectableHeaderState()).toBeFalsy();
+    });
+
+    it("should clear all selected rows and bulk checkbox when a row is removed", async () => {
+        const rows = ref<Row[]>([{ id: 1 }, { id: 2 }]);
+        setInternalKeys(rows.value);
+        const selectedRows = ref([toValue(rows)[0]]);
+
+        const { selectableRowState, selectableHeaderState } = useSelectable({
+            selectable: "multi",
+            selectedRows,
+            rows,
+        });
+
+        expect(selectableHeaderState()).toBe("indeterminate");
+        expect(selectableRowState(toValue(rows)[0])).toBeTruthy();
+
+        rows.value.splice(1, 1);
+        await flushPromises();
+
+        expect(selectedRows.value).toEqual([]);
+        expect(selectableRowState(toValue(rows)[0])).toBeFalsy();
+        expect(selectableHeaderState()).toBeFalsy();
+    });
+
+    it("should clear all selected rows and bulk checkbox when rows are replaced", async () => {
+        const rows = ref<Row[]>([{ id: 1 }, { id: 2 }]);
+        setInternalKeys(rows.value);
+        const selectedRows = ref([toValue(rows)[0]]);
+
+        const { selectableRowState, selectableHeaderState } = useSelectable({
+            selectable: "multi",
+            selectedRows,
+            rows,
+        });
+
+        expect(selectableHeaderState()).toBe("indeterminate");
+        expect(selectableRowState(toValue(rows)[0])).toBeTruthy();
+
+        rows.value = [{ id: 2 }, { id: 3 }];
+        setInternalKeys(rows.value);
+        await flushPromises();
+
+        expect(selectedRows.value).toEqual([]);
+        expect(selectableRowState(toValue(rows)[0])).toBeFalsy();
+        expect(selectableHeaderState()).toBeFalsy();
+    });
+
+    it("should not clear selected rows when row details are updated", async () => {
+        const rows = ref<Row[]>([
+            { id: 1, value: "foo" },
+            { id: 2, value: "baz" },
+        ]);
+        setInternalKeys(rows.value);
+        const selectedRows = ref([toValue(rows)[0]]);
+        const { selectableRowState, selectableHeaderState } = useSelectable({
+            selectable: "multi",
+            selectedRows,
+            rows,
+        });
+
+        expect(selectableHeaderState()).toBe("indeterminate");
+        expect(selectableRowState(toValue(rows)[0])).toBeTruthy();
+
+        rows.value[0].value = "baz";
+        await flushPromises();
+
+        expect(selectableHeaderState()).toBe("indeterminate");
+        expect(selectableRowState(toValue(rows)[0])).toBeTruthy();
+    });
+
+    it("should not clear selected rows when rows are sorted", async () => {
+        const rows = ref<Row[]>([
+            { id: 1, value: "foo" },
+            { id: 2, value: "baz" },
+        ]);
+        setInternalKeys(rows.value);
+        const selectedRows = ref([toValue(rows)[0]]);
+
+        const { selectableRowState, selectableHeaderState } = useSelectable({
+            selectable: "multi",
+            selectedRows,
+            rows,
+        });
+
+        expect(selectableHeaderState()).toBe("indeterminate");
+        expect(selectableRowState(toValue(rows)[0])).toBeTruthy();
+        expect(selectableRowState(toValue(rows)[1])).toBeFalsy();
+
+        const newRows = [...rows.value].reverse();
+        setInternalKeys(newRows);
+        rows.value = newRows;
+        await flushPromises();
+
+        expect(selectableHeaderState()).toBe("indeterminate");
+        expect(selectableRowState(toValue(rows)[0])).toBeFalsy();
+        expect(selectableRowState(toValue(rows)[1])).toBeTruthy();
+    });
+});

--- a/packages/vue-labs/src/components/FTable/use-selectable.ts
+++ b/packages/vue-labs/src/components/FTable/use-selectable.ts
@@ -1,0 +1,118 @@
+import { type MaybeRefOrGetter, type Ref, computed, toValue, watch } from "vue";
+import { assertRef } from "@fkui/logic";
+import { getInternalKey } from "@fkui/vue";
+
+const internalKey = getInternalKey();
+
+/* eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- technical debt */
+function rowKey<T>(row: T): string {
+    return String(row[internalKey]);
+}
+
+export function useSelectable<T>(options: {
+    selectable?: "single" | "multi";
+    selectedRows: Ref<T[]>;
+    rows: MaybeRefOrGetter<T[]>;
+}): {
+    selectableHeaderState: () => boolean | "indeterminate";
+    toggleSelectableHeader: () => void;
+    selectableRowState: (row: T) => boolean;
+    toggleSelectableRow: (row: T) => void;
+} {
+    const { selectable, selectedRows, rows } = options;
+
+    if (!selectable) {
+        return {
+            selectableHeaderState: () => false,
+            toggleSelectableHeader: () => undefined,
+            selectableRowState: () => false,
+            toggleSelectableRow: () => undefined,
+        };
+    }
+
+    const isIndeterminate = computed(() => {
+        return (
+            selectedRows.value.length > 0 &&
+            selectedRows.value.length < toValue(rows).length
+        );
+    });
+
+    const isAllRowsSelected = computed((): boolean => {
+        return (
+            selectedRows.value.length > 0 &&
+            selectedRows.value.length === toValue(rows).length
+        );
+    });
+
+    function selectableHeaderState(): boolean | "indeterminate" {
+        return isIndeterminate.value
+            ? "indeterminate"
+            : isAllRowsSelected.value;
+    }
+
+    function toggleSelectableHeader(): void {
+        if (isAllRowsSelected.value) {
+            selectedRows.value = [];
+        } else {
+            selectedRows.value = [...toValue(rows)];
+        }
+    }
+
+    function toggleSelectableRow(row: T): void {
+        assertRef(selectedRows);
+
+        if (selectable === "single") {
+            selectedRows.value = [row];
+        } else {
+            const index = selectedRows.value.indexOf(row);
+
+            if (index < 0) {
+                selectedRows.value.push(row);
+            } else {
+                selectedRows.value.splice(index, 1);
+            }
+        }
+    }
+
+    function selectableRowState(row: T): boolean {
+        const key = rowKey(row);
+        return selectedRows.value.some(
+            (selectedRow) => rowKey(selectedRow) === key,
+        );
+    }
+
+    let oldKeys: string[] | undefined = undefined;
+
+    watch(
+        () => toValue(rows),
+        (newValue) => {
+            // eslint-disable-next-line sonarjs/no-alphabetical-sort -- only used to compare
+            const newKeys = newValue.map(rowKey).sort();
+            if (!oldKeys) {
+                oldKeys = newKeys;
+                return;
+            }
+
+            // not able to use `oldValue` directly since array
+            const compareKeys = oldKeys;
+            oldKeys = newKeys;
+
+            if (newKeys.length !== compareKeys.length) {
+                selectedRows.value = [];
+                return;
+            }
+
+            if (compareKeys.join(",") !== newKeys.join(",")) {
+                selectedRows.value = [];
+            }
+        },
+        { deep: 1, immediate: true },
+    );
+
+    return {
+        toggleSelectableHeader,
+        toggleSelectableRow,
+        selectableHeaderState,
+        selectableRowState,
+    };
+}


### PR DESCRIPTION
A composable (`use-selectable`), a header component (`i-table-header-selectable`) and a cell component (`i-table-selectable`) is used to supply the selectable feature.

```js
const { selectableHeaderState, toggleSelectableHeader, selectableRowState, toggleSelectableRow } = useSelectable({
    selectable,
    selectedRows,
    rows,
});
```

```html
<i-table-header-selectable :state="selectableHeaderState()" :selectable @toggle="toggleSelectableHeader" />
```

```html
<i-table-selectable :selectable :state="selectableRowState(row)" :row @toggle="toggleSelectableRow" />
```