### PR TITLE
docs: init dark mode for docs site (refs SB-4982)

### DIFF
--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -1,4 +1,4 @@
-@use "pkg:@fkui/theme-default";
+@use "pkg:@fkui/theme-default" as theme;
 @use "@fkui/theme-default/src/palette-variables" as palette;
 @use "@fkui/design/src/core/config-variables" with (
     $asset-path: ".",
@@ -8,6 +8,7 @@
 @use "@fkui/design" as fkui;
 @use "@forsakringskassan/docs-generator/style";
 @use "@forsakringskassan/docs-live-example";
+@use "@forsakringskassan/docs-generator/theme/fkui" as theme-fkui;
 
 $fk-logo-small: "fk-logo-primary-small.svg";
 $fk-logo-large: "fk-logo-primary-large.svg";
@@ -22,6 +23,18 @@ $fk-logo-large: "fk-logo-primary-large.svg";
         linear-gradient(var(--f-background-pageheader-primary), var(--f-background-pageheader-primary));
 
     color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        @include theme.light;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        @include theme.dark;
+    }
 }
 
 .sandbox-link {


### PR DESCRIPTION
@ext : Var detta nåt sånt här du menade... Nu skulle exempel och docs kunna köra olika lägen, även om exempel idag saknar en toggle....

Bör inte mergas före nedan PR finns byggd i `docs-generator`
* https://github.com/Forsakringskassan/docs-generator/pull/291

## Demo
<img width="1354" height="654" alt="image" src="https://github.com/user-attachments/assets/32086a6e-25b7-40c9-984f-11de3b9930f0" />

Denna pr ersätter
* https://github.com/Forsakringskassan/designsystem/pull/793
