### PR TITLE
refactor: update `FTable` select column styling (refs SFKUI-6500)

### DIFF
--- a/packages/design/src/components/table-ng/_cell.scss
+++ b/packages/design/src/components/table-ng/_cell.scss
@@ -93,6 +93,7 @@ $horizontal-padding: size.$padding-050;
         input {
             height: var(--f-icon-size-medium);
             width: var(--f-icon-size-medium);
+            vertical-align: middle;
         }
     }
 
@@ -114,6 +115,11 @@ $horizontal-padding: size.$padding-050;
     }
 
     &--expand {
+        width: var(--f-icon-size-medium);
+        padding: core.densify(size.$padding-025);
+    }
+
+    &--select {
         width: var(--f-icon-size-medium);
     }
 

--- a/packages/design/src/components/table-ng/_column.scss
+++ b/packages/design/src/components/table-ng/_column.scss
@@ -17,13 +17,14 @@ $horizontal-padding: size.$padding-050;
         border-right: 1px solid var(--f-color-focus);
     }
 
-    &--checkbox {
+    &--select {
         text-align: center;
         padding: core.densify(size.$padding-025);
 
         input {
             height: var(--f-icon-size-medium);
             width: var(--f-icon-size-medium);
+            vertical-align: middle;
         }
     }
 

--- a/packages/vue-labs/src/components/FTable/ITableHeaderSelectable.vue
+++ b/packages/vue-labs/src/components/FTable/ITableHeaderSelectable.vue
@@ -16,7 +16,7 @@ defineExpose(expose);
 </script>
 
 <template>
-    <th scope="col" class="table-ng__column table-ng__column--checkbox table-ng__column--select">
+    <th scope="col" class="table-ng__column table-ng__column--select">
         <input
             ref="selectAll"
             type="checkbox"


### PR DESCRIPTION
Uppdaterar styling för valbar tabell så att kolumnen för att välja rad stämmer mer överens med designskissen. Bland annat så att den inte växer i bredd med övriga kolumner.

https://forsakringskassan.github.io/designsystem/pr-preview/pr-813/vue-labs/components/ftable.html