### PR TITLE
fix: fix deprecation warning from `@fkui/design` stylelint plugin

### DIFF
--- a/packages/design/stylelint/rules/deprecated-variable.js
+++ b/packages/design/stylelint/rules/deprecated-variable.js
@@ -73,11 +73,11 @@ function rule(actual) {
                 for (const variable of extractVariables(node)) {
                     if (isDeprecated(variable)) {
                         stylelint.utils.report({
-                            index: 0,
+                            result,
+                            ruleName,
                             message: messages.deprecated(variable.name),
                             node,
-                            ruleName,
-                            result,
+                            word: variable.name,
                         });
                     }
                 }

--- a/packages/design/stylelint/rules/deprecated-variable.test.mjs
+++ b/packages/design/stylelint/rules/deprecated-variable.test.mjs
@@ -29,8 +29,8 @@ it("should warn when using deprecated variable", async (t) => {
     t.assert.deepStrictEqual(parseErrors, []);
     t.assert.partialDeepStrictEqual(warnings, [
         {
-            column: 13,
-            endColumn: 42,
+            column: 24,
+            endColumn: 40,
             endLine: 3,
             fix: undefined,
             line: 3,
@@ -54,8 +54,8 @@ it("should handle whitespace", async (t) => {
     t.assert.deepStrictEqual(parseErrors, []);
     t.assert.partialDeepStrictEqual(warnings, [
         {
-            column: 13,
-            endColumn: 39,
+            column: 21,
+            endColumn: 37,
             endLine: 3,
             fix: undefined,
             line: 3,
@@ -65,8 +65,8 @@ it("should handle whitespace", async (t) => {
             url: undefined,
         },
         {
-            column: 13,
-            endColumn: 39,
+            column: 20,
+            endColumn: 36,
             endLine: 4,
             fix: undefined,
             line: 4,
@@ -76,8 +76,8 @@ it("should handle whitespace", async (t) => {
             url: undefined,
         },
         {
-            column: 13,
-            endColumn: 40,
+            column: 21,
+            endColumn: 37,
             endLine: 5,
             fix: undefined,
             line: 5,
@@ -99,8 +99,8 @@ it("should handle fallback value", async (t) => {
     t.assert.deepStrictEqual(parseErrors, []);
     t.assert.partialDeepStrictEqual(warnings, [
         {
-            column: 13,
-            endColumn: 51,
+            column: 24,
+            endColumn: 40,
             endLine: 3,
             fix: undefined,
             line: 3,
@@ -122,8 +122,8 @@ it("should handle properties with multiple declarations", async (t) => {
     t.assert.deepStrictEqual(parseErrors, []);
     t.assert.partialDeepStrictEqual(warnings, [
         {
-            column: 13,
-            endColumn: 72,
+            column: 29,
+            endColumn: 45,
             endLine: 3,
             fix: undefined,
             line: 3,
@@ -133,8 +133,8 @@ it("should handle properties with multiple declarations", async (t) => {
             url: undefined,
         },
         {
-            column: 13,
-            endColumn: 72,
+            column: 52,
+            endColumn: 70,
             endLine: 3,
             fix: undefined,
             line: 3,
@@ -156,8 +156,8 @@ it("should handle malformed var", async (t) => {
     t.assert.deepStrictEqual(parseErrors, []);
     t.assert.partialDeepStrictEqual(warnings, [
         {
-            column: 13,
-            endColumn: 39,
+            column: 20,
+            endColumn: 36,
             endLine: 4,
             fix: undefined,
             line: 4,


### PR DESCRIPTION
Idag får man en varning om deprekerad användning:

> ```
> DeprecationWarning: Partial position information in the `utils.report()` function is deprecated ("fkui/deprecated-variable").
> Please pass both `index` and `endIndex` as arguments in the `utils.report()` function of "fkui/deprecated-variable".
> ```

Lyssnade inte på ovan utan ändrar istället till att använda `word` parametern för det är enklare än att beräkna index men det ger också mycket bättre precision i resultatet.

Före ändringen så får man ett fel på hela raden:

<img width="521" height="126" alt="stylelint-pre" src="https://github.com/user-attachments/assets/7244e392-e9d8-4a19-9e85-8d15944c70b8" />

Notera att inte bara `color` och `background` nyckelorden markeras som fel men även fallback och till och med användning av en giltig variabel är understycket. Två fel är dessutom överlappande.

Efter denna ändringen så blir det mer precist:

<img width="517" height="120" alt="image" src="https://github.com/user-attachments/assets/3a40cf25-29c8-415c-ac6d-a3deaa2e16d7" />

Bara själva variabeln blir felet.

