### PR TITLE
docs: fix `FCrudDataset.md` prop reference error (refs SFKUI-6500)

### DIFF
--- a/docs/components/table-and-list/FCrudDataset.md
+++ b/docs/components/table-and-list/FCrudDataset.md
@@ -134,7 +134,7 @@ FCrudDatasetCustomTextExample.vue
 
 ## Modalstorlek
 
-Storleken på modalerna för "Lägg till" och "Ändra" kan anpassas med propen `addAndModifyModalSize`.
+Storleken på modalerna för "Lägg till" och "Ändra" kan anpassas med propen `formModalSize`.
 
 Giltiga värden är:
 


### PR DESCRIPTION
Jag noterade i #825 att dokumentation för datamängdsredigeraren refererar till en prop som inte finns i stycket _Modalstorlek_.

Stycket skapades i #816.