### PR TITLE
fix: use untrimmed value for whitelist validation (fixes SFKUI-7421)

### DIFF
--- a/packages/logic/src/services/ValidationService/Validators/WhitelistValidator.spec.ts
+++ b/packages/logic/src/services/ValidationService/Validators/WhitelistValidator.spec.ts
@@ -29,9 +29,11 @@ describe("validation", () => {
         ${"\\"}                        | ${false} | ${"escape should be invalid"}
         ${"\u200F"}                    | ${false} | ${"right-to-left mark should be invalid"}
         ${"$&%#_<>{}[]/\\\"'"}         | ${false} | ${'"$&%#_<>{}[]/\\"\'" should be invalid'}
+        ${" test"}                     | ${false} | ${"non-breaking space should be invalid"}
     `(
         'should return "$expected" for "$value" because of $description',
         ({ value, expected, config }) => {
+            element.value = value;
             const result = whitelistValidator.validation(
                 value,
                 element,

--- a/packages/logic/src/services/ValidationService/Validators/WhitelistValidator.ts
+++ b/packages/logic/src/services/ValidationService/Validators/WhitelistValidator.ts
@@ -6,7 +6,8 @@ const WHITELIST_REGEXP = /^[a-zA-Z0-9 .,\-()\r\n?+=!:@*\xC0-\xFF]*$/;
 export const whitelistValidator: Validator = {
     name: "whitelist",
     instant: true,
-    validation(value) {
+    validation(_value, element) {
+        const value = "value" in element ? element.value : "";
         return isEmpty(value) || WHITELIST_REGEXP.test(value);
     },
 };


### PR DESCRIPTION
Skickar värden från inmatningsfälten som de är till whitelist-valideringen för att kunna fånga fel med non-breaking space i början och slutet av texten.