### PR TITLE
fix: `pageCounter` selector in `FPaginator.pageobject` includes `sr-only` element (refs SFKUI-6500)

### DIFF
--- a/docs/functions/cypress/pageobjects/FPaginatorPageObject/FPaginatorPageObject-page-counter.cy.ts
+++ b/docs/functions/cypress/pageobjects/FPaginatorPageObject/FPaginatorPageObject-page-counter.cy.ts
@@ -1,11 +1,11 @@
 import { FPaginatorPageObject } from "@fkui/vue/cypress";
 import Example from "./FPaginatorPageObject.vue";
 
-it("pageCounter() should contain correct text", () => {
+it("pageCounter() should return correct text", () => {
     cy.mount(Example);
 
     /* --- cut above --- */
     const paginator = new FPaginatorPageObject("[data-test='myPaginator']");
-    paginator.pageCounter().should("contain.text", "1 av 20");
+    paginator.pageCounter().should("have.text", "1 av 20");
     /* --- cut below --- */
 });

--- a/packages/vue/src/cypress/FPaginator.pageobject.ts
+++ b/packages/vue/src/cypress/FPaginator.pageobject.ts
@@ -67,7 +67,9 @@ export class FPaginatorPageObject implements BasePageObject {
      * @returns The page counter.
      */
     public pageCounter(): DefaultCypressChainable {
-        return cy.get(`${this.selector} .paginator__page-counter`);
+        return cy.get(
+            `${this.selector} .paginator__page-counter [aria-hidden]`,
+        );
     }
 
     /**


### PR DESCRIPTION
Jag noterade i #827 att selektorn `pageCounter` i `FPaginator.pageobject` även returnerade ett element med klass `sr-only`.

Jag föreslår därmed att justera selektorn så att det enbart returnerar elementet med attributet `aria-hidden`.