### PR TITLE
refactor: fix `FTable` select class overlap (refs SFKUI-6500)

### DIFF
--- a/packages/design/src/components/table-ng/_cell.scss
+++ b/packages/design/src/components/table-ng/_cell.scss
@@ -133,7 +133,7 @@ $horizontal-padding: size.$padding-050;
         padding: core.densify(size.$padding-025);
     }
 
-    &--select {
+    &--selectable {
         width: var(--f-icon-size-medium);
     }
 

--- a/packages/design/src/components/table-ng/_column.scss
+++ b/packages/design/src/components/table-ng/_column.scss
@@ -17,7 +17,7 @@ $horizontal-padding: size.$padding-050;
         border-right: 1px solid var(--f-color-focus);
     }
 
-    &--select {
+    &--selectable {
         text-align: center;
         padding: core.densify(size.$padding-025);
 

--- a/packages/vue-labs/src/components/FTable/FTable.vue
+++ b/packages/vue-labs/src/components/FTable/FTable.vue
@@ -416,14 +416,14 @@ onMounted(() => {
                         :ref="bindCellApiRef"
                         :row
                         :column="multiSelectColumn"
-                        class="table-ng__cell--select"
+                        class="table-ng__cell--selectable"
                     ></i-table-checkbox>
                     <i-table-radio
                         v-if="isSingleSelect"
                         :ref="bindCellApiRef"
                         :row
                         :column="singleSelectColumn"
-                        class="table-ng__cell--select"
+                        class="table-ng__cell--selectable"
                     ></i-table-radio>
                     <template v-for="column in columns" :key="column.id">
                         <component

--- a/packages/vue-labs/src/components/FTable/ITableHeaderSelectable.vue
+++ b/packages/vue-labs/src/components/FTable/ITableHeaderSelectable.vue
@@ -16,7 +16,7 @@ defineExpose(expose);
 </script>
 
 <template>
-    <th scope="col" class="table-ng__column table-ng__column--select">
+    <th scope="col" class="table-ng__column table-ng__column--selectable">
         <input
             ref="selectAll"
             type="checkbox"

--- a/packages/vue-labs/src/cypress/FTable.pageobject.cy.ts
+++ b/packages/vue-labs/src/cypress/FTable.pageobject.cy.ts
@@ -5,9 +5,9 @@ const table = new FTablePageObject();
 
 const TABLE_CLASS = {
     HEADER_EXPAND: "table-ng__column--expand",
-    HEADER_SELECT: "table-ng__column--select",
+    HEADER_SELECT: "table-ng__column--selectable",
     CELL_EXPAND: "table-ng__cell--expand",
-    CELL_SELECT: "table-ng__cell--select",
+    CELL_SELECT: "table-ng__cell--selectable",
 };
 
 const rows = [

--- a/packages/vue-labs/src/cypress/FTable.pageobject.ts
+++ b/packages/vue-labs/src/cypress/FTable.pageobject.ts
@@ -7,11 +7,11 @@ import { type BasePageObject, type DefaultCypressChainable } from "./common";
 export class FTablePageObject implements BasePageObject {
     public selector: string;
 
-    private readonly selectHeader = ".table-ng__column--select";
+    private readonly selectHeader = ".table-ng__column--selectable";
     private readonly columnTitle = ".table-ng__column__title";
     private readonly columnDescription = ".table-ng__column__description";
     private readonly expandCell = ".table-ng__cell--expand";
-    private readonly selectCell = ".table-ng__cell--select";
+    private readonly selectCell = ".table-ng__cell--selectable";
 
     /**
      * @param selector - root element selector for `FTable`, usually `.table-ng`.


### PR DESCRIPTION
Råkade vara samma klass på kolumnen för att välja rad och dropplista, vilket gjorde att även kolumnen för dropplista försökte ha samma bredd som den.