### PR TITLE
docs: use disable-initial-focus in documentation (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FWizard/examples/FWizardExampleDefault.vue
+++ b/packages/vue/src/components/FWizard/examples/FWizardExampleDefault.vue
@@ -24,7 +24,7 @@ export default defineComponent({
 
 <template>
     <div>
-        <f-wizard v-model="current" header-tag="h2" @completed="onCompleted">
+        <f-wizard v-model="current" header-tag="h2" disable-initial-focus @completed="onCompleted">
             <f-wizard-step key="foo" :use-error-list="false" title="Stegrubrik 1">
                 <f-text-field v-validation.required.maxLength="{ maxLength: { length: 100 } }">
                     Etikett-rubrik


### PR DESCRIPTION
Fixar så att man kan länka till propen `disable-initial-focus`, nu snor första exemplet fokus :)
https://designsystem.forsakringskassan.se/latest/components/fwizard.html#fwizard-prop-disableinitialfocus