### PR TITLE
refactor: add `FTable` column size (refs SFKUI-6500)

### DIFF
--- a/etc/vue-labs.api.md
+++ b/etc/vue-labs.api.md
@@ -96,6 +96,9 @@ export function splitHoursMinutes(valueString: string, extraForgiving?: boolean)
 // @public (undocumented)
 export type TableColumn<T, K extends keyof T = keyof T> = TableColumnSimple<T, K> | TableColumnCheckbox<T, K> | TableColumnRadio<T, K> | TableColumnRowHeader<T, K> | TableColumnText<T, K> | TableColumnNumber<T, K> | TableColumnAnchor<T, K> | TableColumnButton<T, K> | TableColumnRender<T, K> | TableColumnSelect<T, K>;
 
+// @public (undocumented)
+export type TableColumnSize = "grow" | "shrink";
+
 // Warning: (ae-forgotten-export) The symbol "__VLS_export_2" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)

--- a/packages/design/src/components/table-ng/_column.scss
+++ b/packages/design/src/components/table-ng/_column.scss
@@ -33,6 +33,11 @@ $horizontal-padding: size.$padding-050;
         padding: core.densify(size.$padding-025);
     }
 
+    &--shrink {
+        width: 1px;
+        white-space: nowrap;
+    }
+
     &__sort-icon {
         color: $table-ng-color-icon-sort-selected;
         height: var(--f-icon-size-x-small);

--- a/packages/vue-labs/src/components/FTable/FTable.spec.ts
+++ b/packages/vue-labs/src/components/FTable/FTable.spec.ts
@@ -1,6 +1,82 @@
+import { ref } from "vue";
 import { flushPromises, mount } from "@vue/test-utils";
 import FTable from "./FTable.vue";
 import { defineTableColumns } from "./table-column";
+
+describe("1.6 column size", () => {
+    const rows: never[] = [];
+
+    it("should have grow class if not set", () => {
+        const columns = defineTableColumns<(typeof rows)[number]>([
+            {
+                type: "text",
+                header: "A",
+            },
+        ]);
+        const wrapper = mount(FTable<(typeof rows)[number]>, {
+            props: {
+                rows,
+                columns,
+            },
+        });
+        const header = wrapper.get("thead th");
+        expect(header.classes()).toContain("table-ng__column--grow");
+    });
+
+    it("should have grow class if set to null", () => {
+        const columns = defineTableColumns<(typeof rows)[number]>([
+            {
+                type: "text",
+                header: "A",
+                size: ref(null),
+            },
+        ]);
+        const wrapper = mount(FTable<(typeof rows)[number]>, {
+            props: {
+                rows,
+                columns,
+            },
+        });
+        const header = wrapper.get("thead th");
+        expect(header.classes()).toContain("table-ng__column--grow");
+    });
+
+    it("should have grow class if set to grow", () => {
+        const columns = defineTableColumns<(typeof rows)[number]>([
+            {
+                type: "text",
+                header: "A",
+                size: "grow",
+            },
+        ]);
+        const wrapper = mount(FTable<(typeof rows)[number]>, {
+            props: {
+                rows,
+                columns,
+            },
+        });
+        const header = wrapper.get("thead th");
+        expect(header.classes()).toContain("table-ng__column--grow");
+    });
+
+    it("should have shrink class if set to shrink", () => {
+        const columns = defineTableColumns<(typeof rows)[number]>([
+            {
+                type: "text",
+                header: "A",
+                size: "shrink",
+            },
+        ]);
+        const wrapper = mount(FTable<(typeof rows)[number]>, {
+            props: {
+                rows,
+                columns,
+            },
+        });
+        const header = wrapper.get("thead th");
+        expect(header.classes()).toContain("table-ng__column--shrink");
+    });
+});
 
 describe("1.12 aria-rowcount", () => {
     it("should include body rows and header", () => {

--- a/packages/vue-labs/src/components/FTable/FTable.vue
+++ b/packages/vue-labs/src/components/FTable/FTable.vue
@@ -274,7 +274,6 @@ onMounted(() => {
                     :sort-enabled="isSortEnabled(column)"
                     :sort-order="getSortOrder(column)"
                     scope="col"
-                    class="table-ng__column"
                     @toggle-sort-order="onToggleSortOrder"
                 ></i-table-header>
             </tr>

--- a/packages/vue-labs/src/components/FTable/ITableHeader.vue
+++ b/packages/vue-labs/src/components/FTable/ITableHeader.vue
@@ -21,6 +21,11 @@ const emit = defineEmits<{
 
 const thElement = useTemplateRef("th");
 
+const columnClasses = computed(() => {
+    const size = column.size.value === "shrink" ? "table-ng__column--shrink" : "table-ng__column--grow";
+    return ["table-ng__column", size];
+});
+
 const sortIconClass = computed(() => {
     return {
         "table-ng__column__sort-icon": true,
@@ -75,7 +80,7 @@ function onKeydownCell(e: KeyboardEvent): void {
 </script>
 
 <template>
-    <th ref="th" class="table-ng__column" tabindex="-1" @keydown="onKeydownCell" @click.stop="onClickCell">
+    <th ref="th" :class="columnClasses" tabindex="-1" @keydown="onKeydownCell" @click.stop="onClickCell">
         <i-flex gap="1x" :float="alignment">
             <i-flex-item shrink class="table-ng__column__title">
                 {{ column.header }}

--- a/packages/vue-labs/src/components/FTable/ITableSelectable.vue
+++ b/packages/vue-labs/src/components/FTable/ITableSelectable.vue
@@ -35,6 +35,7 @@ const multiSelectColumn: NormalizedTableColumnCheckbox<T, K> = {
     header: ref("selectable"),
     description: ref(null),
     sortable: null,
+    size: ref(null),
     component: ITableCheckbox,
     label() {
         /** Screen reader text for checkbox in multi select table row. */
@@ -57,6 +58,7 @@ const singleSelectColumn: NormalizedTableColumnRadio<T, K> = {
     header: ref("Välj en rad"),
     description: ref(null),
     sortable: null,
+    size: ref(null),
     component: ITableRadio,
     label() {
         /** Screen reader text for radio button in single select table row. */

--- a/packages/vue-labs/src/components/FTable/examples/FTableExample.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableExample.vue
@@ -36,6 +36,7 @@ const columns = defineTableColumns<Row>([
         type: "checkbox",
         header: "Kryssruta",
         key: "aktiv",
+        size: "shrink",
         label: (row) => `Välj rad ${row.id}`,
         editable: true,
     },
@@ -48,7 +49,6 @@ const columns = defineTableColumns<Row>([
         },
         editable: true,
     },
-
     {
         type: "text",
         header: "Redigerbar text",
@@ -70,6 +70,7 @@ const columns = defineTableColumns<Row>([
         type: "button",
         header: "Knapp",
         icon: "trashcan",
+        size: "shrink",
         value(row) {
             return `Ta bort ${row.id}`;
         },

--- a/packages/vue-labs/src/components/FTable/index.ts
+++ b/packages/vue-labs/src/components/FTable/index.ts
@@ -2,7 +2,11 @@ import { type FTableCellApi, type tableCellApiSymbol } from "./f-table-api";
 
 export { default as FTable } from "./FTable.vue";
 export { type FTableApi, type FTableCellApi } from "./f-table-api";
-export { type TableColumn, defineTableColumns } from "./table-column";
+export {
+    type TableColumn,
+    type TableColumnSize,
+    defineTableColumns,
+} from "./table-column";
 
 declare global {
     interface HTMLElement {

--- a/packages/vue-labs/src/components/FTable/table-column.ts
+++ b/packages/vue-labs/src/components/FTable/table-column.ts
@@ -27,6 +27,11 @@ import {
 /**
  * @public
  */
+export type TableColumnSize = "grow" | "shrink";
+
+/**
+ * @public
+ */
 export interface TableColumnSimple<T, K extends keyof T> {
     /* eslint-disable-next-line sonarjs/no-redundant-optional -- this is used as
      * a discriminator in the union, for the simple column we are not expected
@@ -35,6 +40,7 @@ export interface TableColumnSimple<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    size?: TableColumnSize | Readonly<Ref<TableColumnSize | null>>;
     label?(row: T): string;
     value?(row: T): string;
 }
@@ -47,6 +53,7 @@ export interface TableColumnRowHeader<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    size?: TableColumnSize | Readonly<Ref<TableColumnSize | null>>;
     value?(row: T): string;
 }
 
@@ -63,6 +70,7 @@ export interface NormalizedTableColumnRowHeader<T, K> {
         row: T;
         column: NormalizedTableColumnRowHeader<T, K>;
     }>;
+    readonly size: Readonly<Ref<TableColumnSize | null>>;
     value(row: T): string;
 }
 
@@ -74,6 +82,7 @@ export interface TableColumnCheckbox<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    size?: TableColumnSize | Readonly<Ref<TableColumnSize | null>>;
     label?(row: T): string;
     value?(row: T): boolean;
     update?(row: T, newValue: boolean, oldValue: boolean): void;
@@ -93,6 +102,7 @@ export interface NormalizedTableColumnCheckbox<T, K> {
         row: T;
         column: NormalizedTableColumnCheckbox<T, K>;
     }>;
+    readonly size: Readonly<Ref<TableColumnSize | null>>;
     label(row: T): string;
     value(row: T): boolean;
     update(row: T, newValue: boolean, oldValue: boolean): void;
@@ -107,6 +117,7 @@ export interface TableColumnRadio<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    size?: TableColumnSize | Readonly<Ref<TableColumnSize | null>>;
     label?(row: T): string;
     value?(row: T): boolean;
     update?(row: T, newValue: boolean, oldValue: boolean): void;
@@ -125,6 +136,7 @@ export interface NormalizedTableColumnRadio<T, K> {
         row: T;
         column: NormalizedTableColumnRadio<T, K>;
     }>;
+    readonly size: Readonly<Ref<TableColumnSize | null>>;
     label(row: T): string;
     value(row: T): boolean;
     update(row: T, newValue: boolean, oldValue: boolean): void;
@@ -138,6 +150,7 @@ export interface TableColumnText<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    size?: TableColumnSize | Readonly<Ref<TableColumnSize | null>>;
     label?(row: T): string;
     tnum?: boolean;
     align?: "left" | "right";
@@ -165,6 +178,7 @@ export interface NormalizedTableColumnText<T, K> {
         row: T;
         column: NormalizedTableColumnText<T, K>;
     }>;
+    readonly size: Readonly<Ref<TableColumnSize | null>>;
     label(row: T): string;
     value(row: T): string;
     update(row: T, newValue: string, oldValue: string): void;
@@ -180,6 +194,7 @@ export interface TableColumnNumber<T, K extends keyof T> {
     description?: string | Readonly<Ref<string | null>>;
     decimals?: number;
     key?: K;
+    size?: TableColumnSize | Readonly<Ref<TableColumnSize | null>>;
     label?(row: T): string;
     tnum?: boolean;
     align?: "left" | "right";
@@ -208,6 +223,7 @@ export interface NormalizedTableColumnNumber<T, K> {
         row: T;
         column: NormalizedTableColumnText<T, K>;
     }>;
+    readonly size: Readonly<Ref<TableColumnSize | null>>;
     label(row: T): string;
     value(row: T): string | number;
     update(row: T, newValue: number | string, oldValue: number | string): void;
@@ -222,6 +238,7 @@ export interface TableColumnAnchor<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    size?: TableColumnSize | Readonly<Ref<TableColumnSize | null>>;
     value(row: T): string | null;
     enabled?: boolean | ((row: T) => boolean);
     href: string;
@@ -241,6 +258,7 @@ export interface NormalizedTableColumnAnchor<T, K> {
         row: T;
         column: NormalizedTableColumnAnchor<T, K>;
     }>;
+    readonly size: Readonly<Ref<TableColumnSize | null>>;
     value(row: T): string | null;
     enabled(row: T): boolean;
 }
@@ -253,6 +271,7 @@ export interface TableColumnButton<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    size?: TableColumnSize | Readonly<Ref<TableColumnSize | null>>;
     value(row: T): string | null;
     onClick?(row: T): void;
     enabled?: boolean | ((row: T) => boolean);
@@ -273,6 +292,7 @@ export interface NormalizedTableColumnButton<T, K> {
         row: T;
         column: NormalizedTableColumnButton<T, K>;
     }>;
+    readonly size: Readonly<Ref<TableColumnSize | null>>;
     value(row: T): string | null;
     onClick?(row: T): void;
     enabled(row: T): boolean;
@@ -286,6 +306,7 @@ export interface TableColumnSelect<T, K extends keyof T> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    size?: TableColumnSize | Readonly<Ref<TableColumnSize | null>>;
     label?(row: T): string;
     value?(row: T): string;
     update?(row: T, newValue: string, oldValue: string): void;
@@ -307,6 +328,7 @@ export interface NormalizedTableColumnSelect<T, K> {
         row: T;
         column: NormalizedTableColumnSelect<T, K>;
     }>;
+    readonly size: Readonly<Ref<TableColumnSize | null>>;
     label(row: T): string;
     value(row: T): string;
     update(row: T, newValue: string, oldValue: string): void;
@@ -320,6 +342,7 @@ export interface TableColumnRender<T, K> {
     header: string | Readonly<Ref<string>>;
     description?: string | Readonly<Ref<string | null>>;
     key?: K;
+    size?: TableColumnSize | Readonly<Ref<TableColumnSize | null>>;
     render(row: T): VNode | Component;
 }
 
@@ -332,6 +355,7 @@ export interface NormalizedTableColumnRender<T> {
     readonly header: Readonly<Ref<string>>;
     readonly description: Readonly<Ref<string | null>>;
     readonly sortable: boolean | null;
+    readonly size: Readonly<Ref<TableColumnSize | null>>;
     render(row: T): VNode | Component;
 }
 
@@ -433,12 +457,15 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
         typeof column.description !== "undefined"
             ? toRef(column.description)
             : ref("");
+    const size: Readonly<Ref<TableColumnSize | null>> =
+        typeof column.size !== "undefined" ? toRef(column.size) : ref("grow");
     if ("render" in column) {
         return {
             type: undefined,
             id: Symbol(),
             header: toRef(column.header),
             description,
+            size,
             render: column.render,
             sortable: null,
         } satisfies NormalizedTableColumnRender<T>;
@@ -450,6 +477,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                size,
                 label: getLabelFn(column.label),
                 value: getValueFn(column.value, column.key, Boolean, false),
                 update: getUpdateFn(column.update, column.key),
@@ -466,6 +494,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                size,
                 label: getLabelFn(column.label),
                 value: getValueFn(column.value, column.key, Boolean, false),
                 update: getUpdateFn(column.update, column.key),
@@ -485,6 +514,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                size,
                 label: getLabelFn(column.label),
                 decimals,
                 tnum: column.tnum ?? defaultTnumValue(type),
@@ -528,6 +558,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                size,
                 tnum: column.tnum ?? defaultTnumValue(type),
                 align: column.align ?? "left",
                 label: getLabelFn(column.label),
@@ -553,6 +584,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                size,
                 value: getValueFn(column.value, column.key, String, ""),
                 sortable: column.key ?? null,
                 component: ITableRowheader,
@@ -563,6 +595,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                size,
                 value: column.value,
                 href: column.href,
                 enabled:
@@ -578,6 +611,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                size,
                 value: column.value,
                 onClick: column.onClick,
                 enabled:
@@ -594,6 +628,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                size,
                 label: getLabelFn(column.label),
                 value: getValueFn(column.value, column.key, String, ""),
                 update: getUpdateFn(column.update, column.key),
@@ -611,6 +646,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 id: Symbol(),
                 header: toRef(column.header),
                 description,
+                size,
                 label: () => "",
                 tnum: false,
                 align: "left",

--- a/packages/vue-labs/src/components/index.ts
+++ b/packages/vue-labs/src/components/index.ts
@@ -1,6 +1,7 @@
 export {
     type FTableApi,
     type TableColumn,
+    type TableColumnSize,
     FTable,
     defineTableColumns,
 } from "./FTable";


### PR DESCRIPTION
Lägger till möjlighet att sätta ifall en kolumn i tabellen ska växa `"grow"` eller krympa `"shrink"`. Detaljstyrning av kolumnbredd är inte prioriterat för MVP, så har endast inkluderat grow/shrink beteende.