### PR TITLE
feat: `FContextMenu` no longer handles tab for interelement navigation

### DIFF
--- a/packages/vue/src/components/FContextMenu/FContextMenu.spec.ts
+++ b/packages/vue/src/components/FContextMenu/FContextMenu.spec.ts
@@ -187,7 +187,7 @@ describe("events", () => {
 });
 
 describe("keyboard navigation", () => {
-    it("should focus on first element after Tab is pressed", async () => {
+    it("should close popup after tab is pressed when popup is open", async () => {
         jest.spyOn(window, "scrollTo").mockReturnValue();
 
         // Given
@@ -200,27 +200,6 @@ describe("keyboard navigation", () => {
 
         // When sending Tab to the element
         await imenuList.trigger("keydown", { key: "Tab" });
-        await wrapper.vm.$nextTick();
-        await flushPromises();
-
-        // Then the first element will have focus
-        const firstItem = imenuList.findAll(".contextmenu__list__item")[0];
-        expect(firstItem.element).toHaveFocus();
-    });
-
-    it("should close popup after shift Tab is pressed directly after opening the popup", async () => {
-        jest.spyOn(window, "scrollTo").mockReturnValue();
-
-        // Given
-        await mountPopup(testItems1);
-        await openPopup();
-
-        // after opening the popup the list has focus
-        const imenuList = wrapper.get(".contextmenu__list");
-        expect(imenuList.element).toHaveFocus();
-
-        // When sending Shift+Tab to the element
-        await imenuList.trigger("keydown", { key: "Tab", shiftKey: true });
         await wrapper.vm.$nextTick();
         await flushPromises();
 


### PR DESCRIPTION
Det enda jag är osäker på nu är om det är knappen man kom från eller det interagerbara elementet före man ska landa på när man trycker shift-tab.

<img width="540" height="367" alt="image" src="https://github.com/user-attachments/assets/af593ad6-11e1-4d6b-b0a5-05efb11f84c9" />

Knappen "Öppna" öppnar kontextmenyn. Ska shift-tab flytta oss tillbaka till "Öppna" eller "före"?

https://forsakringskassan.github.io/designsystem/pr-preview/pr-879/components/fcontextmenu.html