### PR TITLE
docs: fix input error in `PaginationExample` (fixes SFKUI-7533)

### DIFF
--- a/packages/vue/src/design-component-tests/Pagination/examples/PaginationExample.vue
+++ b/packages/vue/src/design-component-tests/Pagination/examples/PaginationExample.vue
@@ -4,7 +4,6 @@ import {
     FCheckboxField,
     FFieldset,
     FList,
-    FNumericTextField,
     FPaginateDataset,
     FPaginator,
     FSelectField,
@@ -18,7 +17,6 @@ export default defineComponent({
     components: {
         FCheckboxField,
         FFieldset,
-        FNumericTextField,
         FSelectField,
         LiveExample,
     },
@@ -41,7 +39,6 @@ export default defineComponent({
                 FCheckboxField,
                 FFieldset,
                 FList,
-                FNumericTextField,
                 FPaginateDataset,
                 FPaginator,
                 FSelectField,
@@ -80,6 +77,9 @@ export default defineComponent({
             return /* HTML */ this.numberOfPagesToShowAtMost
                 ? `:number-of-pages-to-show="${this.numberOfPagesToShowAtMost.toString()}"`
                 : ``;
+        },
+        numberOfRows(): number {
+            return persons.length;
         },
         paginator(): string {
             return /* HTML */ `<f-paginator
@@ -127,12 +127,15 @@ export default defineComponent({
 
 <template>
     <live-example :components :template :livedata :livemethods>
-        <f-numeric-text-field v-model="numberOfItemsPerPage">
-            <template #default>Antal objekt per sida</template>
+        <f-select-field id="numberOfItemsPerPage" v-model="numberOfItemsPerPage">
+            <template #label>Antal objekt per sida</template>
             <template #description="{ descriptionClass }">
                 <span :class="descriptionClass">Maximalt antal objekt per sida</span>
             </template>
-        </f-numeric-text-field>
+            <option v-for="option in numberOfRows" :key="option" :value="option">
+                {{ option }}
+            </option>
+        </f-select-field>
         <f-fieldset name="alternatives" show-details="when-selected">
             <template #label>Alternativ</template>
             <f-checkbox-field v-model="showInteractiveListWithCheckboxes" :value="true">


### PR DESCRIPTION
Liveexemplet kraschade vid borttag av värde i numerisk inmatningsfält `Antal objekt per sida`.

Jag har åtgärdat problemet genom att ersätta det numeriska inmatningsfältet med en dropplista:
https://forsakringskassan.github.io/designsystem/pr-preview/pr-881/components/pagination.html