### PR TITLE
fix: always use full width for content in `FWizardStep` (fixes SFKUI-7532)

### DIFF
--- a/packages/design/src/components/wizard/_wizard-step.scss
+++ b/packages/design/src/components/wizard/_wizard-step.scss
@@ -46,6 +46,10 @@ $icon-size: 30px;
         }
     }
 
+    .button-group:last-of-type {
+        margin-top: calc(4rem * var(--f-density-factor));
+    }
+
     #{$title-selector} {
         font-size: 1.125rem;
         margin-top: 2px;
@@ -111,10 +115,6 @@ $icon-size: 30px;
         margin-top: $line-gap-to-circle;
     }
 
-    #{$line-down-selector} {
-        grid-area: wizard-step__line-down;
-    }
-
     .wizard-step__content {
         margin-left: 0.5rem;
         min-width: 0;
@@ -153,6 +153,10 @@ $icon-size: 30px;
 
         .wizard-step__content {
             margin-left: 0;
+        }
+
+        #{$line-down-selector} {
+            grid-area: wizard-step__line-down;
         }
     }
 
@@ -194,6 +198,10 @@ $icon-size: 30px;
         #{$number-selector} {
             display: none;
         }
+
+        #{$line-down-selector} {
+            display: none;
+        }
     }
 
     &--pending {
@@ -205,6 +213,10 @@ $icon-size: 30px;
             border: 2px solid $wizardstep-color-circle-border-pending;
             background-color: $wizardstep-color-circle-background-pending;
             color: $wizardstep-color-circle-content-pending;
+        }
+
+        #{$line-down-selector} {
+            display: none;
         }
     }
 


### PR DESCRIPTION
Fixar så att hela bredden i `FWizardStep` används även i mobilläge. Ökar även marginalen ovanför knapparna.

- [ ] Fixa screenshot

# **Före:**
<img width="495" height="516" alt="image" src="https://github.com/user-attachments/assets/dbb58709-9013-482f-9677-b6fe500441ee" />

# **Efter:**
<img width="495" height="556" alt="image" src="https://github.com/user-attachments/assets/5505378f-ad11-4c96-87b4-3b0e5474a7d0" />

https://forsakringskassan.github.io/designsystem/pr-preview/pr-886/components/fwizard.html