### PR TITLE
docs: fix broken logo styling (refs SFKUI-7534)

### DIFF
--- a/docs/src/fkui-theme.scss
+++ b/docs/src/fkui-theme.scss
@@ -39,8 +39,8 @@ $fk-logo-large-url: "#{config-variables.$asset-path-images}/fk-logo-primary-larg
 
     $solid-color: linear-gradient(var(--fkds-color-header-background-primary), var(--fkds-color-header-background-primary));
 
-    --f-logo-image-small: url("#{$fk-logo-small-url}"), $solid-color;
-    --f-logo-image-large: url("#{$fk-logo-large-url}"), $solid-color;
+    --f-logo-image-small: url("#{$fk-logo-small-url}"), #{$solid-color};
+    --f-logo-image-large: url("#{$fk-logo-large-url}"), #{$solid-color};
 
     font-family: var(--f-font-family);
 }


### PR DESCRIPTION
Fixar så att logo visas i dokumentationen för `FLogo` och `FPageHeader`.
https://forsakringskassan.github.io/designsystem/pr-preview/pr-894/components/flogo.html
https://forsakringskassan.github.io/designsystem/pr-preview/pr-894/components/page-layout/fpageheader.html