### PR TITLE
test: run screenshot tests and create pr with diff (refs SFKUI-7447)

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -1,0 +1,50 @@
+name: Screenshot check
+
+on:
+    workflow_dispatch:
+    pull_request:
+    schedule:
+        - cron: "0 0 * * *"
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    screenshots:
+        name: Cypress screenshots check
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+            - name: Use Node.js 22.x
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 22.x
+            - name: Install dependencies
+              run: npm ci
+            - name: Build (minimal)
+              run: npm exec lerna -- run --include-dependencies --scope=@fkui/vue --scope=@fkui/cypress-split build
+            - name: Cypress Component Testing
+              run: unset CI && npm run cypress run -- --env type=base --component
+            - name: Check for changes
+              id: changes
+              run: |
+                  git status
+                  if git status --porcelain | grep .; then
+                    echo "changed=true" >> $GITHUB_OUTPUT
+                  else
+                    echo "changed=false" >> $GITHUB_OUTPUT
+                  fi
+            - name: Create Pull Request
+              if: steps.changes.outputs.changed == 'true'
+              uses: peter-evans/create-pull-request@v8
+              with:
+                  commit-message: "test: update screenshots (refs SFKUI-6500)"
+                  branch: "screenshots-${{ github.head_ref || github.ref_name }}"
+                  title: "Update screenshots for branch `${{ github.head_ref || github.ref_name }}`"
+                  body: "Automatiskt uppdaterade screenshots"
+                  labels: screenshots
+                  base: "${{ github.head_ref || github.ref_name }}"


### PR DESCRIPTION
Jag har tagit fram ett nytt koncept för hur vi kan jobba med screenshot. Det löser problemet med att bilder skapade lokalt och på GitHub ibland diffar (trots att dom är lika), då alla bilder alltid kommer skapas på GitHub. Tänker att detta ska bidra med två nya features/scenarion, den nattliga biten är otestad men bör funka :)

Initialt så kommer massor av bilder behöva uppdateras (se exempel PR nedn), så förslagsvis så kör man först alla tester lokalt för att verifiera att vi inte har något som diffar redan. Om vi kör på denna lösning kan vi även aktivera våra screenshot-tester på GitHub igen om vi vill.

**Dagligt arbete**
* Skapar feature-branch (inget händer om man pushar branchen till GitHub)
* Lägger PR -> Screenshots-jobbet triggas igång av din PR och kör alla screenshot-tester, diffar det så uppdateras bilderna och en PR mot din feature-branch skapas. Har du lagt till nya `cy.toMatchScreenshot()` så kommer antingen bilderna att skapas (om de inte var med i din feature-branch) alternativt uppdateras med hur de ser ut på GitHub (d.v.s. alla bilder kommer att vara skapade på GitHub).
* Koda vidare och om något push:as till din branch så kommer det trigga omkörning och uppdatering av screenshot-pr, om nödvändigt.

Exempel på en sådan PR: https://github.com/Forsakringskassan/designsystem/pull/899

**Nattlig kontroll:**
Tänk att vi är heta på gröten och mergar något till main som påverkar våra screenshot utan att vi vet om det.
Vid varje nattlig körning (går också att trigga manuellt) så körs alla screenshot-tester, om det blir en diff så skapas en PR mot main med de bilder som har ändrats. Vi blir då varse om vad som har hänt och kan då avgöra hur vi går vidare. Är det en bugg? Förväntat? o.s.v.


