### PR TITLE
refactor: add type `TableColumnType` containing all available column types

### DIFF
--- a/etc/vue-labs.api.md
+++ b/etc/vue-labs.api.md
@@ -99,6 +99,11 @@ export type TableColumn<T, K extends keyof T = keyof T> = TableColumnSimple<T, K
 // @public (undocumented)
 export type TableColumnSize = "grow" | "shrink";
 
+// @internal
+export type TableColumnType = TableColumn<unknown, never> extends infer U ? U extends {
+    type: infer T;
+} ? T extends undefined ? never : T : never : never;
+
 // Warning: (ae-forgotten-export) The symbol "__VLS_export_2" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)

--- a/packages/vue-labs/src/components/FTable/index.ts
+++ b/packages/vue-labs/src/components/FTable/index.ts
@@ -5,6 +5,7 @@ export { type FTableApi, type FTableCellApi } from "./f-table-api";
 export {
     type TableColumn,
     type TableColumnSize,
+    type TableColumnType,
     defineTableColumns,
 } from "./table-column";
 

--- a/packages/vue-labs/src/components/FTable/table-column.ts
+++ b/packages/vue-labs/src/components/FTable/table-column.ts
@@ -30,6 +30,20 @@ import {
 export type TableColumnSize = "grow" | "shrink";
 
 /**
+ * Union of all possible table column types.
+ *
+ * @internal
+ */
+export type TableColumnType =
+    TableColumn<unknown, never> extends infer U
+        ? U extends { type: infer T }
+            ? T extends undefined
+                ? never
+                : T
+            : never
+        : never;
+
+/**
  * @public
  */
 export interface TableColumnSimple<T, K extends keyof T> {

--- a/packages/vue-labs/src/components/index.ts
+++ b/packages/vue-labs/src/components/index.ts
@@ -2,6 +2,7 @@ export {
     type FTableApi,
     type TableColumn,
     type TableColumnSize,
+    type TableColumnType,
     FTable,
     defineTableColumns,
 } from "./FTable";


### PR DESCRIPTION
<img width="1141" height="155" alt="image" src="https://github.com/user-attachments/assets/135e8ccb-0265-48b4-9986-8f38cd90ae08" />

Användbart om man vill skriva funktioner eller skapa objekt som bara får ha giltiga typer.

```ts
function doSomething(type: TableColumnType) {
    /* ... */
}

const obj = {
  /* ... */
} satisfies Record<TableColumnType, {}>;
```

osv