### PR TITLE
refactor(eslint): fix eslint `eslint-env` deprecation warning

### DIFF
--- a/packages/icon-lib-builder/templates/inject.js
+++ b/packages/icon-lib-builder/templates/inject.js
@@ -1,4 +1,3 @@
-/* eslint-env browser */
 /* eslint-disable no-undef -- injectSpritesheet */
 if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", () => {

--- a/packages/icon-lib-builder/templates/spritesheet.js
+++ b/packages/icon-lib-builder/templates/spritesheet.js
@@ -1,4 +1,3 @@
-/* eslint-env browser */
 /* eslint-disable no-undef -- IMPORT_SPRITESHEET, PACKAGE, LIBRARY */
 /* eslint-disable no-unused-vars -- injectSpritesheet function */
 function injectSpritesheet() {


### PR DESCRIPTION
```
(node:560075) ESLintEnvWarning: /* eslint-env */ comments are no longer recognized when linting with flat config and will be reported as errors as of v10.0.0. Replace them with /* global */ comments or define globals in your config file. See https://eslint.org/docs/latest/use/configure/migration-guide#eslint-env-configuration-comments for details. Found in /path/to/project/packages/icon-lib-builder/templates/inject.js at line 1.
(node:560075) ESLintEnvWarning: /* eslint-env */ comments are no longer recognized when linting with flat config and will be reported as errors as of v10.0.0. Replace them with /* global */ comments or define globals in your config file. See https://eslint.org/docs/latest/use/configure/migration-guide#eslint-env-configuration-comments for details. Found in /path/to/project/packages/icon-lib-builder/templates/spritesheet.js at line 1.
```