### PR TITLE
f-sort-filter-dataset: skip sort during inline edits

### DIFF
--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -51,6 +51,7 @@ import { PropType } from 'vue';
 import { PublicProps } from 'vue';
 import { Ref } from 'vue';
 import { ShallowRef } from 'vue';
+import { ShallowUnwrapRef } from 'vue';
 import { Slot } from 'vue';
 import { Slots } from 'vue';
 import { StackHandle } from '@fkui/logic';

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -1385,6 +1385,20 @@ export function setItemIdentifiers<T>(items: T[], attribute?: keyof T, expandabl
 // @public (undocumented)
 export function setRunningContext(app: App): void;
 
+// @public (undocumented)
+export type SortFilterDatasetEventCallback = () => void;
+
+// @public (undocumented)
+export interface SortFilterDatasetEvents {
+    // (undocumented)
+    onLazyRowsAdded(this: void, callback: SortFilterDatasetEventCallback): void;
+    // (undocumented)
+    onRefresh(this: void, callback: SortFilterDatasetEventCallback): void;
+}
+
+// @public (undocumented)
+export const sortFilterDatasetEventsKey: InjectionKey<SortFilterDatasetEvents>;
+
 // @public
 export interface SortOrder {
     // (undocumented)
@@ -1537,6 +1551,9 @@ export interface UseSlotUtils {
 
 // @public (undocumented)
 export function useSlotUtils(): UseSlotUtils;
+
+// @public (undocumented)
+export function useSortFilterDatasetEvents(): SortFilterDatasetEvents;
 
 // @public
 export function useTextFieldSetup(props: TextFieldSetupProps): {

--- a/packages/vue-labs/src/components/FTable/FTable.vue
+++ b/packages/vue-labs/src/components/FTable/FTable.vue
@@ -22,6 +22,7 @@ import {
     useSlotUtils,
     useTranslate,
 } from "@fkui/vue";
+import { useSortFilterDatasetEvents } from "@fkui/vue";
 import ITableExpandButton from "./ITableExpandButton.vue";
 import ITableExpandable from "./ITableExpandable.vue";
 import ITableHeader from "./ITableHeader.vue";
@@ -37,10 +38,6 @@ import { type NormalizedTableColumn, type TableColumn, normalizeTableColumns } f
 import { usePopupError } from "./use-popup-error";
 import { useSelectable } from "./use-selectable";
 import { useTabstop } from "./use-tabstop";
-
-type ExpandedContent = Required<T>[DatasetNestedKeyOf<T>] extends unknown[]
-    ? Required<T>[DatasetNestedKeyOf<T>][number]
-    : never;
 
 const selectedRows = defineModel<T[]>("selectedRows", { default: [] });
 
@@ -89,6 +86,12 @@ defineSlots<{
         row: ExpandedContent;
     }): void;
 }>();
+
+const sortFilterDatasetEvents = useSortFilterDatasetEvents();
+
+type ExpandedContent = Required<T>[DatasetNestedKeyOf<T>] extends unknown[]
+    ? Required<T>[DatasetNestedKeyOf<T>][number]
+    : never;
 
 const $t = useTranslate();
 const { hasSlot } = useSlotUtils();
@@ -329,6 +332,7 @@ onMounted(() => {
     assertRef(tableRef);
     registerCallbackOnMount(callbackSortableColumns);
     registerCallbackOnSort(callbackOnSort);
+    sortFilterDatasetEvents.onRefresh(() => (selectedRows.value = []));
     /* eslint-disable-next-line @typescript-eslint/no-floating-promises -- technical debt */
     setDefaultCellTarget(tableRef.value);
 });

--- a/packages/vue-labs/src/components/FTable/FTableSortFilter.cy.ts
+++ b/packages/vue-labs/src/components/FTable/FTableSortFilter.cy.ts
@@ -1,0 +1,91 @@
+import { FSortFilterDatasetPageObject } from "@fkui/vue/cypress";
+import { FTablePageObject } from "../../cypress";
+
+import FTableBulkTestExample from "./examples/FTableBulkTestExample.vue";
+
+const table = new FTablePageObject();
+
+describe("7.3 Row Selection Behavior with Filtering and Sorting", () => {
+    it("should retain row selections after applying a filter", () => {
+        const sorter = new FSortFilterDatasetPageObject(".sort-filter-dataset");
+        cy.mount(FTableBulkTestExample);
+        table.selectInput(1).focus().click();
+        table.selectInput(1).should("be.checked");
+
+        table
+            .selectHeaderInput()
+            .should("not.be.checked")
+            .and("have.prop", "indeterminate", true);
+
+        sorter.textField.input().type("Ape");
+
+        table.selectInput(1).should("be.checked");
+        table
+            .selectHeaderInput()
+            .should("be.checked")
+            .and("have.prop", "indeterminate", true);
+    });
+
+    it("should retain row selections when sorting is applied", () => {
+        const sorter = new FSortFilterDatasetPageObject('[data-test="filter"]');
+
+        cy.mount(FTableBulkTestExample);
+
+        table.selectInput(2).focus().click();
+        table.selectInput(2).should("be.checked");
+        table
+            .selectHeaderInput()
+            .should("not.be.checked")
+            .and("have.prop", "indeterminate", true);
+        //sort ascending
+        table.header(2).click();
+        table.selectInput(2).should("be.checked");
+        table
+            .selectHeaderInput()
+            .should("not.be.checked")
+            .and("have.prop", "indeterminate", true);
+        //sort descending
+        table.header(2).click();
+        table.selectInput(1).should("be.checked");
+        table
+            .selectHeaderInput()
+            .should("not.be.checked")
+            .and("have.prop", "indeterminate", true);
+        //sort ascending
+        sorter.selectField.dropdown().select("Text (stigande)");
+        table.selectInput(2).should("be.checked");
+        table
+            .selectHeaderInput()
+            .should("not.be.checked")
+            .and("have.prop", "indeterminate", true);
+        //sort descending
+        sorter.selectField.dropdown().select("Text (fallande)");
+        table.selectInput(1).should("be.checked");
+        table
+            .selectHeaderInput()
+            .should("not.be.checked")
+            .and("have.prop", "indeterminate", true);
+    });
+});
+
+describe("9 Sorted and filtered table with editable cell", () => {
+    it("9.5 should sort, filter, edit a cell and then verify the table is unsorted", () => {
+        const sorter = new FSortFilterDatasetPageObject(".sort-filter-dataset");
+        cy.mount(FTableBulkTestExample);
+        // Gå med pilarna till sorteringsbar rubrik och sortera krav 4.3
+        table.header(2).click();
+        // Verifiera dropdown-sorteringen ska reflektera rubriksorteringen
+        sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+        // Filtrera  och verifiera krav 9.2 Sortering sker på hela tabellen och inte bara de rader som visas.
+        // Redigera tex inmatningsfält som påverka sorteringen
+        table.cell({ row: 1, col: 2 }).click();
+        cy.focused().clear();
+        cy.focused().type("Citron{enter}");
+        // Verifiera att värdet i filtreringen är kvar
+        table.cell({ row: 1, col: 2 }).should("contain.text", "Citron");
+        // Verifiera att tabellen visas osorterad både på dropdown och kolumnrubrik
+        sorter.selectField.dropdown().should("contain.text", "Välj");
+        table.header(2).get("svg").should("have.class", "f-icon-sort");
+        // Verifiera att radordningen är oförändrad
+    });
+});

--- a/packages/vue-labs/src/components/FTable/FTableSortFilter.cy.ts
+++ b/packages/vue-labs/src/components/FTable/FTableSortFilter.cy.ts
@@ -6,7 +6,7 @@ import FTableBulkTestExample from "./examples/FTableBulkTestExample.vue";
 const table = new FTablePageObject();
 
 describe("7.3 Row Selection Behavior with Filtering and Sorting", () => {
-    it("should retain row selections after applying a filter", () => {
+    it("should _not_ retain row selections after applying a filter", () => {
         const sorter = new FSortFilterDatasetPageObject(".sort-filter-dataset");
         cy.mount(FTableBulkTestExample);
         table.selectInput(1).focus().click();
@@ -19,11 +19,11 @@ describe("7.3 Row Selection Behavior with Filtering and Sorting", () => {
 
         sorter.textField.input().type("Ape");
 
-        table.selectInput(1).should("be.checked");
+        table.selectInput(1).should("not.be.checked");
         table
             .selectHeaderInput()
-            .should("be.checked")
-            .and("have.prop", "indeterminate", true);
+            .should("not.be.checked")
+            .and("have.prop", "indeterminate", false);
     });
 
     it("should retain row selections when sorting is applied", () => {

--- a/packages/vue-labs/src/components/FTable/examples/FTableBulkTestExample.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableBulkTestExample.vue
@@ -17,9 +17,7 @@ const columns = defineTableColumns<Row>([
         type: "text",
         header: "Text",
         key: "text",
-        value(row) {
-            return row.text;
-        },
+        editable: true,
     },
 ]);
 

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterDefaultModeExample.cy.ts
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterDefaultModeExample.cy.ts
@@ -9,12 +9,13 @@ describe("FTableSortFilterDefaultModeExample", () => {
     it("re-sorts rows after inline edit in standard mode", () => {
         cy.mount(Example);
 
-        table.header(2).click();
+        table.header(1).click();
         sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
 
-        table.cell({ row: 2, col: 2 }).click();
-        cy.focused().clear().type("Aardvark{enter}");
+        table.cell({ row: 1, col: 1 }).click();
+        cy.focused().clear();
+        cy.focused().type("Aardvark{enter}");
 
-        table.cell({ row: 1, col: 2 }).should("contain.text", "Aardvark");
+        table.cell({ row: 3, col: 1 }).should("contain.text", "Aardvark");
     });
 });

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterDefaultModeExample.cy.ts
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterDefaultModeExample.cy.ts
@@ -1,0 +1,20 @@
+import { FSortFilterDatasetPageObject } from "@fkui/vue/cypress";
+import { FTablePageObject } from "../../../../cypress";
+import Example from "./FTableSortFilterDefaultModeExample.vue";
+
+const table = new FTablePageObject();
+const sorter = new FSortFilterDatasetPageObject('[data-test="filter"]');
+
+describe("FTableSortFilterDefaultModeExample", () => {
+    it("re-sorts rows after inline edit in standard mode", () => {
+        cy.mount(Example);
+
+        table.header(2).click();
+        sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+
+        table.cell({ row: 2, col: 2 }).click();
+        cy.focused().clear().type("Aardvark{enter}");
+
+        table.cell({ row: 1, col: 2 }).should("contain.text", "Aardvark");
+    });
+});

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterDefaultModeExample.vue
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterDefaultModeExample.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { FSortFilterDataset, useDatasetRef } from "@fkui/vue";
+import { FTable, defineTableColumns } from "@fkui/vue-labs";
+
+interface Row {
+    id: string;
+    text: string;
+}
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Text",
+        key: "text",
+        editable: true,
+    },
+]);
+
+const rows = useDatasetRef<Row>([
+    { id: "1", text: "Apelsin" },
+    { id: "2", text: "Banan" },
+    { id: "3", text: "Citron" },
+]);
+
+const sortableAttributes = { text: "Text" };
+</script>
+
+<template>
+    <h2>Sort-filter i standardläge</h2>
+    <p>
+        Standardläget (<code>mode="none"</code>) kör full sortering/filtrering om när data
+        uppdateras.
+    </p>
+
+    <f-sort-filter-dataset
+        v-test="'filter'"
+        :data="rows"
+        :sortable-attributes
+        default-sort-attribute="text"
+    >
+        <template #default="{ sortFilterResult }">
+            <f-table :rows="sortFilterResult" :columns key-attribute="id" />
+        </template>
+    </f-sort-filter-dataset>
+</template>

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyModeExample.cy.ts
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyModeExample.cy.ts
@@ -9,25 +9,27 @@ describe("FTableSortFilterLazyModeExample", () => {
     it("keeps row position after inline edit in lazy mode", () => {
         cy.mount(Example);
 
-        table.header(2).click();
+        table.header(1).click();
         sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
 
-        table.cell({ row: 2, col: 2 }).click();
-        cy.focused().clear().type("Aardvark{enter}");
+        table.cell({ row: 1, col: 1 }).click();
+        cy.focused().clear();
+        cy.focused().type("Aardvark{enter}");
 
-        table.cell({ row: 2, col: 2 }).should("contain.text", "Aardvark");
+        table.cell({ row: 1, col: 1 }).should("contain.text", "Aardvark");
     });
 
     it("recomputes ordering when user explicitly sorts again", () => {
         cy.mount(Example);
 
-        table.header(2).click();
-        table.cell({ row: 2, col: 2 }).click();
-        cy.focused().clear().type("Aardvark{enter}");
+        table.header(1).click();
+        table.cell({ row: 1, col: 1 }).click();
+        cy.focused().clear();
+        cy.focused().type("Aardvark{enter}");
 
         sorter.selectField.dropdown().select("Text (fallande)");
         sorter.selectField.dropdown().select("Text (stigande)");
 
-        table.cell({ row: 1, col: 2 }).should("contain.text", "Aardvark");
+        table.cell({ row: 1, col: 1 }).should("contain.text", "Aardvark");
     });
 });

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyModeExample.cy.ts
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyModeExample.cy.ts
@@ -1,0 +1,33 @@
+import { FSortFilterDatasetPageObject } from "@fkui/vue/cypress";
+import { FTablePageObject } from "../../../../cypress";
+import Example from "./FTableSortFilterLazyModeExample.vue";
+
+const table = new FTablePageObject();
+const sorter = new FSortFilterDatasetPageObject('[data-test="filter"]');
+
+describe("FTableSortFilterLazyModeExample", () => {
+    it("keeps row position after inline edit in lazy mode", () => {
+        cy.mount(Example);
+
+        table.header(2).click();
+        sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+
+        table.cell({ row: 2, col: 2 }).click();
+        cy.focused().clear().type("Aardvark{enter}");
+
+        table.cell({ row: 2, col: 2 }).should("contain.text", "Aardvark");
+    });
+
+    it("recomputes ordering when user explicitly sorts again", () => {
+        cy.mount(Example);
+
+        table.header(2).click();
+        table.cell({ row: 2, col: 2 }).click();
+        cy.focused().clear().type("Aardvark{enter}");
+
+        sorter.selectField.dropdown().select("Text (fallande)");
+        sorter.selectField.dropdown().select("Text (stigande)");
+
+        table.cell({ row: 1, col: 2 }).should("contain.text", "Aardvark");
+    });
+});

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyModeExample.cy.ts
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyModeExample.cy.ts
@@ -6,30 +6,314 @@ const table = new FTablePageObject();
 const sorter = new FSortFilterDatasetPageObject('[data-test="filter"]');
 
 describe("FTableSortFilterLazyModeExample", () => {
-    it("keeps row position after inline edit in lazy mode", () => {
-        cy.mount(Example);
+    describe("Editing rows", () => {
+        it("keeps row position after inline edit when sort is active", () => {
+            cy.mount(Example);
 
-        table.header(1).click();
-        sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+            // Apply sort
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
 
-        table.cell({ row: 1, col: 1 }).click();
-        cy.focused().clear();
-        cy.focused().type("Aardvark{enter}");
+            // Edit first row - change "Apelsin" to "Aardvark"
+            table.cell({ row: 1, col: 1 }).click();
+            cy.focused().clear();
+            cy.focused().type("Aardvark{enter}");
 
-        table.cell({ row: 1, col: 1 }).should("contain.text", "Aardvark");
+            // Row should stay in same position (not re-sorted)
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Aardvark");
+        });
+
+        it("resets sort attribute when row is edited with active sort", () => {
+            cy.mount(Example);
+
+            // Apply sort
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+
+            // Edit first row
+            table.cell({ row: 1, col: 1 }).click();
+            cy.focused().clear();
+            cy.focused().type("Aardvark{enter}");
+
+            // Sort should be reset to "Välj"
+            sorter.selectField.dropdown().should("contain.text", "Välj");
+        });
+
+        it("keeps row visible even if filter no longer matches after edit", () => {
+            cy.mount(Example);
+
+            // Apply filter for "Ap"
+            sorter.textField.input().type("Ap");
+
+            // Should show only Apelsin
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Apelsin");
+
+            // Edit Apelsin to "Citronella" (no longer matches "Ap")
+            table.cell({ row: 1, col: 1 }).click();
+            cy.focused().clear();
+            cy.focused().type("Citronella{enter}");
+
+            // Row should still be visible (filter not reapplied on edit)
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Citronella");
+        });
+
+        it("preserves selections when editing rows without active sort", () => {
+            cy.mount(Example);
+
+            // Select first row
+            table.selectInput(1).click();
+            table.selectInput(1).should("be.checked");
+
+            // Edit without sorting
+            table.cell({ row: 1, col: 1 }).click();
+            cy.focused().clear();
+            cy.focused().type("Aardvark{enter}");
+
+            // Selection should be preserved (first row stays selected)
+            table.selectInput(1).should("be.checked");
+        });
+
+        it("preserves selections when editing rows with active sort", () => {
+            cy.mount(Example);
+
+            // Select first row (Apelsin)
+            table.selectInput(1).click();
+            table.selectInput(1).should("be.checked");
+
+            // Apply sort and edit
+            table.header(1).click();
+            table.cell({ row: 1, col: 1 }).click();
+            cy.focused().clear();
+            cy.focused().type("Aardvark{enter}");
+
+            // Selection should still be on first row
+            table.selectInput(1).should("be.checked");
+        });
     });
 
-    it("recomputes ordering when user explicitly sorts again", () => {
-        cy.mount(Example);
+    describe("Filtering", () => {
+        it("resets selections when filter is applied", () => {
+            cy.mount(Example);
 
-        table.header(1).click();
-        table.cell({ row: 1, col: 1 }).click();
-        cy.focused().clear();
-        cy.focused().type("Aardvark{enter}");
+            // Select all rows
+            table.selectHeaderInput().click();
+            table.selectInput(1).should("be.checked");
+            table.selectInput(2).should("be.checked");
+            table.selectInput(3).should("be.checked");
 
-        sorter.selectField.dropdown().select("Text (fallande)");
-        sorter.selectField.dropdown().select("Text (stigande)");
+            // Apply filter
+            sorter.textField.input().type("Ap");
 
-        table.cell({ row: 1, col: 1 }).should("contain.text", "Aardvark");
+            // Selections should be reset (no rows checked)
+            table.selectHeaderInput().should("not.be.checked");
+        });
+
+        it("recomputes filter when filter is changed", () => {
+            cy.mount(Example);
+
+            // Apply filter for "Ap"
+            sorter.textField.input().type("Ap");
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Apelsin");
+            table.el().contains("Banan").should("not.exist");
+
+            // Clear and apply new filter
+            sorter.textField.input().clear();
+            sorter.textField.input().type("B");
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Banan");
+            table.el().contains("Apelsin").should("not.exist");
+        });
+
+        it("displays rows starting with filtered letter", () => {
+            cy.mount(Example);
+
+            // Filter for "C"
+            sorter.textField.input().type("C");
+
+            // Only Citron should be visible
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Citron");
+            table.el().contains("Apelsin").should("not.exist");
+            table.el().contains("Banan").should("not.exist");
+        });
+    });
+
+    describe("Sorting", () => {
+        it("recomputes ordering when user explicitly sorts ascending", () => {
+            cy.mount(Example);
+
+            // Apply sort ascending
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+            
+            // Should be in ascending order
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Apelsin");
+            table.cell({ row: 2, col: 1 }).should("contain.text", "Banan");
+            table.cell({ row: 3, col: 1 }).should("contain.text", "Citron");
+        });
+
+        it("recomputes ordering when user sorts descending", () => {
+            cy.mount(Example);
+
+            // Apply sort descending
+            table.header(1).click();
+            sorter.selectField.dropdown().select("Text (fallande)");
+            
+            // Should be in descending order
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Citron");
+            table.cell({ row: 2, col: 1 }).should("contain.text", "Banan");
+            table.cell({ row: 3, col: 1 }).should("contain.text", "Apelsin");
+        });
+
+        it("preserves selections when sort is changed", () => {
+            cy.mount(Example);
+
+            // Select first row (Apelsin)
+            table.selectInput(1).click();
+            table.selectInput(1).should("be.checked");
+
+            // Apply sort ascending - Apelsin stays first
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+            
+            // First row (Apelsin) should still be checked
+            table.selectInput(1).should("be.checked");
+
+            // Change to sort descending - Citron moves to first
+            sorter.selectField.dropdown().select("Text (fallande)");
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Citron");
+            
+            // Apelsin should now be at position 3 and still checked
+            table.selectInput(3).should("be.checked");
+        });
+    });
+
+    describe("Multiple selections with sort", () => {
+        it("preserves multiple selections when sort is changed", () => {
+            cy.mount(Example);
+
+            // Bulk select all
+            table.selectHeaderInput().click();
+            table.selectInput(1).should("be.checked");
+            table.selectInput(2).should("be.checked");
+            table.selectInput(3).should("be.checked");
+
+            // Apply sort ascending
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+            
+            // All should still be checked
+            table.selectInput(1).should("be.checked");
+            table.selectInput(2).should("be.checked");
+            table.selectInput(3).should("be.checked");
+
+            // Change to descending - bulk checkbox should still show checked status
+            sorter.selectField.dropdown().select("Text (fallande)");
+            table.selectHeaderInput().should("be.checked");
+        });
+    });
+
+    describe("Combined sort and filter", () => {
+        it("preserves selections when sorting with active filter", () => {
+            cy.mount(Example);
+
+            // Apply filter for "B" (only Banan matches)
+            sorter.textField.input().type("B");
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Banan");
+
+            // Select Banan
+            table.selectInput(1).click();
+            table.selectInput(1).should("be.checked");
+
+            // Sort ascending
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+
+            // Banan should still be checked
+            table.selectInput(1).should("be.checked");
+        });
+
+        it("resets selections when filter is applied but preserves on sort", () => {
+            cy.mount(Example);
+
+            // Select Apelsin
+            table.selectInput(1).click();
+            table.selectInput(1).should("be.checked");
+
+            // Apply filter - selections reset
+            sorter.textField.input().type("Ap");
+            table.selectHeaderInput().should("not.be.checked");
+
+            // Apply sort - selections still preserved (empty)
+            table.header(1).click();
+            table.selectHeaderInput().should("not.be.checked");
+        });
+    });
+
+    describe("Recomputing ordering when explicitly sorted again", () => {
+        it("recomputes ordering after edit and re-sort", () => {
+            cy.mount(Example);
+
+            // Apply sort
+            table.header(1).click();
+            table.cell({ row: 1, col: 1 }).click();
+            cy.focused().clear();
+            cy.focused().type("Aardvark{enter}");
+
+            // Row should stay in position (lazy - no recompute yet)
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Aardvark");
+
+            // Re-sort to trigger recompute
+            sorter.selectField.dropdown().select("Text (fallande)");
+            sorter.selectField.dropdown().select("Text (stigande)");
+
+            // Aardvark should now be first (alphabetically after recompute)
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Aardvark");
+        });
+
+        it("shows correct order after sort toggle", () => {
+            cy.mount(Example);
+
+            // Sort ascending
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Apelsin");
+
+            // Change to descending
+            sorter.selectField.dropdown().select("Text (fallande)");
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Citron");
+
+            // Back to ascending
+            sorter.selectField.dropdown().select("Text (stigande)");
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Apelsin");
+        });
+    });
+
+    describe("UI state after operations", () => {
+        it("shows sort dropdown reset to Välj after row edit", () => {
+            cy.mount(Example);
+
+            // Sort ascending
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+
+            // Edit a cell
+            table.cell({ row: 2, col: 1 }).click();
+            cy.focused().clear();
+            cy.focused().type("Beta{enter}");
+
+            // Sort should reset to Välj
+            sorter.selectField.dropdown().should("contain.text", "Välj");
+        });
+
+        it("maintains sort after explicit user sort without edit", () => {
+            cy.mount(Example);
+
+            // Sort ascending
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+
+            // Change to descending (user-initiated sort)
+            sorter.selectField.dropdown().select("Text (fallande)");
+            sorter.selectField.dropdown().should("contain.text", "Text (fallande)");
+        });
     });
 });

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyModeExample.vue
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyModeExample.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { FSortFilterDataset, useDatasetRef } from "@fkui/vue";
+import { FTable, defineTableColumns } from "@fkui/vue-labs";
+
+interface Row {
+    id: string;
+    text: string;
+}
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Text",
+        key: "text",
+        editable: true,
+    },
+]);
+
+const rows = useDatasetRef<Row>([
+    { id: "1", text: "Apelsin" },
+    { id: "2", text: "Banan" },
+    { id: "3", text: "Citron" },
+]);
+
+const sortableAttributes = { text: "Text" };
+</script>
+
+<template>
+    <h2>Sort-filter i lazy-läge</h2>
+    <p>
+        Lazy-läge kör inte om sortering vid inline-editering. Sortering/filtrering körs först när
+        användaren sorterar eller filtrerar.
+    </p>
+
+    <f-sort-filter-dataset
+        v-test="'filter'"
+        mode="lazy"
+        :data="rows"
+        :sortable-attributes
+        default-sort-attribute="text"
+    >
+        <template #default="{ sortFilterResult }">
+            <f-table :rows="sortFilterResult" :columns key-attribute="id" />
+        </template>
+    </f-sort-filter-dataset>
+</template>

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyModeExample.vue
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyModeExample.vue
@@ -26,21 +26,87 @@ const sortableAttributes = { text: "Text" };
 </script>
 
 <template>
-    <h2>Sort-filter i lazy-läge</h2>
-    <p>
-        Lazy-läge kör inte om sortering vid inline-editering. Sortering/filtrering körs först när
-        användaren sorterar eller filtrerar.
-    </p>
+    <div class="row">
+        <div class="col col--sm-4">
+            <f-sort-filter-dataset
+                v-test="'filter'"
+                mode="lazy"
+                :data="rows"
+                :sortable-attributes
+                default-sort-attribute="text"
+            >
+                <template #default="{ sortFilterResult }">
+                    <f-table
+                        :rows="sortFilterResult"
+                        :columns
+                        key-attribute="id"
+                        selectable="multi"
+                    />
+                </template>
+            </f-sort-filter-dataset>
+        </div>
 
-    <f-sort-filter-dataset
-        v-test="'filter'"
-        mode="lazy"
-        :data="rows"
-        :sortable-attributes
-        default-sort-attribute="text"
-    >
-        <template #default="{ sortFilterResult }">
-            <f-table :rows="sortFilterResult" :columns key-attribute="id" />
-        </template>
-    </f-sort-filter-dataset>
+        <div class="col col--sm-8">
+            <h2>Redigerbar tabell med sortering och filtrering (lazy), flerval</h2>
+            <p>
+                Lazy-läge kör inte om sortering vid inline-editering och lägger till nya rader sist.
+                Ny sortering/filtrering körs först när användaren sorterar eller filtrerar.
+            </p>
+            <h3>Om man lägger till en eller flera rader</h3>
+            <pre>
+        - när ingen sortering eller filtrering är aktiv, så visas rad så som den blivit placerad i dataset
+        - när sortering eller filtrering är aktiv, så visas rad sist
+        - val behålls. bulkruta status kan påverkas (från ikryssad till indeterminate).
+    </pre
+            >
+
+            <h3>Om man tar bort en eller flera rader</h3>
+            <pre>
+        - val behålls. bulkruta status kan påverkas (från indeterminate till ikryssad).
+    </pre
+            >
+
+            <h3>Om man redigerar rader</h3>
+            <pre>
+        - när ingen sortering eller filtrering är aktiv: inget speciell hantering
+        - när filtrering eller sortering är aktiva:
+          - rad ska finnas kvar även om filtret ej längre matchar raden
+          - rad ska ligga kvar på samma position även om ändringen påverkar sorteringsordning.
+          - sortering ska sättas till ovald ("Välj")
+    </pre
+            >
+
+            <h3>
+                Om man helt ersätter all data, inga rader kvar från föregående data (instansbaserat)
+            </h3>
+            <pre>
+        - när ingen sortering eller filtrering är aktiv: allt visas
+        - när filter eller sortering är aktiva:
+          - filter och sortering körs om
+        - val nollställs
+    </pre
+            >
+
+            <h3>Om man filtrerar</h3>
+            <pre>
+        - filtrering och sortering körs om
+        - val nollställs
+    </pre
+            >
+
+            <h3>Om man sorterar</h3>
+            <pre>
+        - filtrering och sortering körs om
+        - val behålls
+    </pre
+            >
+
+            <h3>Om man kör refresh (`fSortFilterDataset.refresh()`)</h3>
+            <pre>
+        - filtrering och sortering körs om
+        - val behålls
+    </pre
+            >
+        </div>
+    </div>
 </template>

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyPaginationExample.cy.ts
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyPaginationExample.cy.ts
@@ -10,6 +10,497 @@ const paginator = new FPaginatorPageObject();
 const sorter = new FSortFilterDatasetPageObject('[data-test="filter"]');
 
 describe("FTableSortFilterLazyPaginationExample", () => {
+    describe("Pagination Navigation", () => {
+        it("displays correct items per page", () => {
+            cy.mount(Example);
+
+            // Should show 3 items on page 1
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Apelsin");
+            table.cell({ row: 2, col: 1 }).should("contain.text", "Banan");
+            table.cell({ row: 3, col: 1 }).should("contain.text", "Citron");
+            
+            // Only 3 rows visible
+            table.rows().should("have.length", 3);
+        });
+
+        it("navigates to next page", () => {
+            cy.mount(Example);
+
+            paginator.currentPageButton().should("contain.text", "1");
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            // Page 2 should show Druva, Fikon, Granatapple
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Druva");
+            table.cell({ row: 2, col: 1 }).should("contain.text", "Fikon");
+            table.cell({ row: 3, col: 1 }).should("contain.text", "Granatapple");
+        });
+
+        it("navigates to previous page", () => {
+            cy.mount(Example);
+
+            // Go to page 2
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            // Go back to page 1
+            paginator.previousButton().click();
+            paginator.currentPageButton().should("contain.text", "1");
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Apelsin");
+        });
+
+        it("shows page numbers in paginator", () => {
+            cy.mount(Example);
+
+            // Should show page 1 and 2 buttons (6 items, 3 per page = 2 pages)
+            paginator.pageButton().should("have.length.at.least", 2);
+        });
+    });
+
+    describe("Adding Rows - Pagination Behavior", () => {
+        it("jumps to last page when a new row is added with no sort/filter", () => {
+            cy.mount(Example);
+
+            paginator.currentPageButton().should("contain.text", "1");
+
+            cy.get('[data-test="add-row"]').click();
+
+            // New row added to end makes 7 items total (3 pages with 3 items per page)
+            // Should jump to page 3
+            paginator.currentPageButton().should("contain.text", "3");
+            
+            // Last page should have the new row
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Äpple");
+        });
+
+        it("jumps to last page when adding row with sort active", () => {
+            cy.mount(Example);
+
+            // Apply sort
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+
+            paginator.currentPageButton().should("contain.text", "1");
+
+            cy.get('[data-test="add-row"]').click();
+
+            // Should navigate to last page
+            paginator.currentPageButton().should("contain.text", "3");
+        });
+
+        it("jumps to last page when adding row with filter active", () => {
+            cy.mount(Example);
+
+            // Apply filter
+            sorter.textField.input().type("a");
+
+            paginator.currentPageButton().should("contain.text", "1");
+
+            cy.get('[data-test="add-row"]').click();
+
+            // Should jump to last page when rows added with filter active
+            // 4 matching items (Banan, Citron, Druva, Fikon, Granatapple, Äpple) on page with 3/page  
+            paginator.currentPageButton().should("contain.text", "2");
+        });
+
+        it("preserves selections when adding rows", () => {
+            cy.mount(Example);
+
+            // Select first row
+            table.selectInput(1).click();
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 1");
+
+            // Add row
+            cy.get('[data-test="add-row"]').click();
+
+            // Selection should be preserved
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 1");
+        });
+    });
+
+    describe("Adding Rows - Selection State", () => {
+        it("changes bulk checkbox from checked to indeterminate when row added to partial selection", () => {
+            cy.mount(Example);
+
+            // Select first 2 rows only
+            table.selectInput(1).click();
+            table.selectInput(2).click();
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 2");
+
+            // Bulk checkbox should show indeterminate
+            table.selectHeaderInput().should("have.prop", "indeterminate", true);
+
+            // Add row - selection preserved but now it's 2/7 so still indeterminate
+            cy.get('[data-test="add-row"]').click();
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 2");
+        });
+    });
+
+    describe("Editing Rows - Pagination Behavior", () => {
+        it("does not navigate pages when editing row on current page", () => {
+            cy.mount(Example);
+
+            // Apply sort
+            table.header(1).click();
+
+            paginator.currentPageButton().should("contain.text", "1");
+
+            // Edit first row
+            table.cell({ row: 1, col: 1 }).click();
+            cy.focused().clear();
+            cy.focused().type("Aardvark{enter}");
+
+            // Should stay on page 1 (no navigation on edit)
+            paginator.currentPageButton().should("contain.text", "1");
+        });
+
+        it("preserves page position when editing rows with sort active", () => {
+            cy.mount(Example);
+
+            // Go to page 2
+            table.header(1).click();
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            // Edit a row on page 2
+            table.cell({ row: 1, col: 1 }).click();
+            cy.focused().clear();
+            cy.focused().type("Beta{enter}");
+
+            // Should stay on page 2
+            paginator.currentPageButton().should("contain.text", "2");
+        });
+
+        it("preserves page position when editing row with filter active", () => {
+            cy.mount(Example);
+
+            // Apply filter that shows multiple pages
+            sorter.textField.input().type("a");
+
+            // Go to page 2 if available
+            paginator.nextButton().then((button) => {
+                if (!button.prop("disabled")) {
+                    cy.wrap(button).click();
+                    paginator.currentPageButton().should("contain.text", "2");
+
+                    // Edit a row
+                    table.cell({ row: 1, col: 1 }).click();
+                    cy.focused().clear();
+                    cy.focused().type("Beta{enter}");
+
+                    // Should stay on page 2
+                    paginator.currentPageButton().should("contain.text", "2");
+                }
+            });
+        });
+    });
+
+    describe("Filtering - Pagination Behavior", () => {
+        it("goes to first page when user applies filter", () => {
+            cy.mount(Example);
+
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            sorter.textField.input().type("Ban");
+
+            paginator.currentPageButton().should("contain.text", "1");
+        });
+
+        it("resets selections when filter is applied", () => {
+            cy.mount(Example);
+
+            // Select all rows on page 1
+            table.selectHeaderInput().click();
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 3");
+
+            // Apply filter
+            sorter.textField.input().type("D");
+
+            // Selections reset and page goes to 1
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 0");
+            paginator.currentPageButton().should("contain.text", "1");
+        });
+
+        it("shows filtered results on first page", () => {
+            cy.mount(Example);
+
+            // Go to page 2
+            paginator.nextButton().click();
+
+            // Apply filter
+            sorter.textField.input().type("Grana");
+
+            // Go to page 1 with filtered result
+            paginator.currentPageButton().should("contain.text", "1");
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Granatapple");
+        });
+
+        it("updates pagination when filter reduces item count below current page", () => {
+            cy.mount(Example);
+
+            // Go to page 2
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            // Apply filter that matches only 1 item (fit on page 1)
+            sorter.textField.input().type("Fikon");
+
+            // Should navigate to first page
+            paginator.currentPageButton().should("contain.text", "1");
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Fikon");
+        });
+
+        it("clears filter and preserves pagination", () => {
+            cy.mount(Example);
+
+            // Go to page 2
+            paginator.nextButton().click();
+
+            // Apply filter
+            sorter.textField.input().type("a");
+
+            // Clear filter
+            sorter.textField.input().clear();
+
+            // Should stay on page 1 (filter reset goes to first page)
+            paginator.currentPageButton().should("contain.text", "1");
+        });
+    });
+
+    describe("Sorting - Pagination Behavior", () => {
+        it("goes to first page when user applies sort", () => {
+            cy.mount(Example);
+
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+
+            paginator.currentPageButton().should("contain.text", "1");
+        });
+
+        it("preserves selections when sort applied and navigates to first page", () => {
+            cy.mount(Example);
+
+            // Select rows on page 1
+            table.selectInput(1).click();
+            table.selectInput(2).click();
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 2");
+
+            // Go to page 2
+            paginator.nextButton().click();
+
+            // Apply sort
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+
+            // Should navigate to page 1 but preserve selections
+            paginator.currentPageButton().should("contain.text", "1");
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 2");
+        });
+
+        it("changes sort order and navigates to first page", () => {
+            cy.mount(Example);
+
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            // Apply sort ascending
+            table.header(1).click();
+            sorter.selectField.dropdown().should("contain.text", "Text (stigande)");
+            paginator.currentPageButton().should("contain.text", "1");
+
+            // Go back to page 2
+            paginator.nextButton().click();
+
+            // Change to descending
+            sorter.selectField.dropdown().select("Text (fallande)");
+
+            // Should go back to page 1
+            paginator.currentPageButton().should("contain.text", "1");
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Granatapple");
+        });
+    });
+
+    describe("Refresh - Pagination Behavior", () => {
+        it("goes to first page when refresh is called", () => {
+            cy.mount(Example);
+
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            cy.get('[data-test="refresh"]').click();
+
+            paginator.currentPageButton().should("contain.text", "1");
+        });
+
+        it("preserves selections when refresh is called and navigates to first page", () => {
+            cy.mount(Example);
+
+            // Select a row
+            table.selectInput(1).click();
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 1");
+
+            // Go to page 2
+            paginator.nextButton().click();
+
+            // Refresh
+            cy.get('[data-test="refresh"]').click();
+
+            // Should go to page 1 but preserve selections
+            paginator.currentPageButton().should("contain.text", "1");
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 1");
+        });
+
+        it("clears selected rows when refresh is called", () => {
+            cy.mount(Example);
+
+            table.selectInput(1).click();
+            cy.get('[data-test="selected-count"]').should(
+                "contain.text",
+                "Valda rader: 1",
+            );
+
+            cy.get('[data-test="refresh"]').click();
+
+            cy.get('[data-test="selected-count"]').should(
+                "contain.text",
+                "Valda rader: 0",
+            );
+            table.selectInput(1).should("not.be.checked");
+        });
+    });
+
+    describe("Complex Pagination Scenarios", () => {
+        it("maintains pagination state through sort then filter", () => {
+            cy.mount(Example);
+
+            // Apply sort ascending
+            table.header(1).click();
+            paginator.currentPageButton().should("contain.text", "1");
+
+            // Go to page 2
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            // Apply filter - should go to page 1
+            sorter.textField.input().type("a");
+            paginator.currentPageButton().should("contain.text", "1");
+        });
+
+        it("handles pagination during add row with multiple pages", () => {
+            cy.mount(Example);
+
+            // Verify we have 2 pages (6 items, 3 per page)
+            paginator.nextButton().should("not.be.disabled");
+
+            // Go to page 2
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            // Add row - should create 3 pages and jump to page 3
+            cy.get('[data-test="add-row"]').click();
+            paginator.currentPageButton().should("contain.text", "3");
+
+            // Add another row - should stay on page 3 (new rows keep going to last)
+            cy.get('[data-test="add-row"]').click();
+            paginator.currentPageButton().should("contain.text", "3");
+        });
+
+        it("navigates correctly with sort and pagination together", () => {
+            cy.mount(Example);
+
+            // Apply sort descending
+            table.header(1).click();
+            sorter.selectField.dropdown().select("Text (fallande)");
+            
+            // First item should be Granatapple (descending)
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Granatapple");
+            paginator.currentPageButton().should("contain.text", "1");
+
+            // Navigate to page 2
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            // First item on page 2 should be Druva
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Druva");
+        });
+
+        it("shows correct selection count across pages", () => {
+            cy.mount(Example);
+
+            // Select on page 1
+            table.selectInput(1).click();
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 1");
+
+            // Go to page 2
+            paginator.nextButton().click();
+
+            // Select on page 2
+            table.selectInput(1).click();
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 2");
+
+            // Go back to page 1
+            paginator.previousButton().click();
+
+            // Selection count should reflect selections from both pages
+            cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 2");
+        });
+    });
+
+    describe("Removing Rows - Pagination Behavior", () => {
+        it("navigates to last page when last page becomes empty after removal", () => {
+            cy.mount(Example);
+
+            // We have 6 items, 3 per page = 2 pages
+            // Go to page 2
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            // Page 2 currently shows Druva, Fikon, Granatapple
+            table.cell({ row: 1, col: 1 }).should("contain.text", "Druva");
+
+            // Verify we can see page 2
+            cy.get('[data-test="selected-count"]').should("exist");
+        });
+    });
+
+    describe("Pagination UI State", () => {
+        it("disables previous button on first page", () => {
+            cy.mount(Example);
+
+            paginator.previousButton().should("be.disabled");
+            paginator.currentPageButton().should("contain.text", "1");
+        });
+
+        it("disables next button on last page", () => {
+            cy.mount(Example);
+
+            // Navigate to last page
+            paginator.nextButton().click();
+            paginator.nextButton().should("be.disabled");
+            paginator.currentPageButton().should("contain.text", "2");
+        });
+
+        it("enables both navigation buttons on middle pages", () => {
+            cy.mount(Example);
+
+            // Add rows to create 3+ pages
+            cy.get('[data-test="add-row"]').click();
+            cy.get('[data-test="add-row"]').click();
+
+            // Go to page 2 (middle page)
+            paginator.nextButton().click();
+            paginator.currentPageButton().should("contain.text", "2");
+
+            paginator.previousButton().should("not.be.disabled");
+            paginator.nextButton().should("not.be.disabled");
+        });
+    });
+
+    // Legacy tests from original implementation
     it("jumps to last page when a new row is added", () => {
         cy.mount(Example);
 

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyPaginationExample.cy.ts
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyPaginationExample.cy.ts
@@ -35,11 +35,17 @@ describe("FTableSortFilterLazyPaginationExample", () => {
         cy.mount(Example);
 
         table.selectInput(1).click();
-        cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 1");
+        cy.get('[data-test="selected-count"]').should(
+            "contain.text",
+            "Valda rader: 1",
+        );
 
         cy.get('[data-test="refresh"]').click();
 
-        cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 0");
+        cy.get('[data-test="selected-count"]').should(
+            "contain.text",
+            "Valda rader: 0",
+        );
         table.selectInput(1).should("not.be.checked");
     });
 

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyPaginationExample.cy.ts
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyPaginationExample.cy.ts
@@ -1,0 +1,56 @@
+import {
+    FPaginatorPageObject,
+    FSortFilterDatasetPageObject,
+} from "@fkui/vue/cypress";
+import { FTablePageObject } from "../../../../cypress";
+import Example from "./FTableSortFilterLazyPaginationExample.vue";
+
+const table = new FTablePageObject();
+const paginator = new FPaginatorPageObject();
+const sorter = new FSortFilterDatasetPageObject('[data-test="filter"]');
+
+describe("FTableSortFilterLazyPaginationExample", () => {
+    it("jumps to last page when a new row is added", () => {
+        cy.mount(Example);
+
+        paginator.currentPageButton().should("contain.text", "1");
+
+        cy.get('[data-test="add-row"]').click();
+
+        paginator.currentPageButton().should("contain.text", "3");
+    });
+
+    it("jumps to first page when refresh is called", () => {
+        cy.mount(Example);
+
+        paginator.nextButton().click();
+        paginator.currentPageButton().should("contain.text", "2");
+
+        cy.get('[data-test="refresh"]').click();
+
+        paginator.currentPageButton().should("contain.text", "1");
+    });
+
+    it("clears selected rows when refresh is called", () => {
+        cy.mount(Example);
+
+        table.selectInput(1).click();
+        cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 1");
+
+        cy.get('[data-test="refresh"]').click();
+
+        cy.get('[data-test="selected-count"]').should("contain.text", "Valda rader: 0");
+        table.selectInput(1).should("not.be.checked");
+    });
+
+    it("goes to first page when user applies filter", () => {
+        cy.mount(Example);
+
+        paginator.nextButton().click();
+        paginator.currentPageButton().should("contain.text", "2");
+
+        sorter.textField.input().type("Ban");
+
+        paginator.currentPageButton().should("contain.text", "1");
+    });
+});

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyPaginationExample.vue
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyPaginationExample.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from "vue";
+import {
+    FButton,
+    FPaginateDataset,
+    FPaginator,
+    FSortFilterDataset,
+    useDatasetRef,
+} from "@fkui/vue";
+import { FTable, defineTableColumns } from "@fkui/vue-labs";
+
+interface Row {
+    id: string;
+    text: string;
+}
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Text",
+        key: "text",
+        editable: true,
+    },
+]);
+
+const rows = useDatasetRef<Row>([
+    { id: "1", text: "Apelsin" },
+    { id: "2", text: "Banan" },
+    { id: "3", text: "Citron" },
+    { id: "4", text: "Druva" },
+    { id: "5", text: "Fikon" },
+    { id: "6", text: "Granatapple" },
+]);
+
+const selectedRows = ref<Row[]>([]);
+const sortableAttributes = { text: "Text" };
+const itemsPerPage = ref(3);
+const sortFilter = useTemplateRef("sortFilter");
+
+function onAddRow(): void {
+    rows.value.push({
+        id: String(rows.value.length + 1),
+        text: "Äpple",
+    });
+}
+
+function onRefresh(): void {
+    sortFilter.value?.refresh();
+}
+</script>
+
+<template>
+    <h2>Sort-filter lazy med paginering</h2>
+    <p>
+        Exemplet visar lazy-beteende med paginering: nya rader hoppar till sista sidan och
+        <code>refresh()</code> hoppar till första sidan samt tömmer markerade rader.
+    </p>
+
+    <p data-test="selected-count">Valda rader: {{ selectedRows.length }}</p>
+
+    <f-button data-test="add-row" variant="secondary" @click="onAddRow">Lägg till rad</f-button>
+    <f-button data-test="refresh" variant="secondary" @click="onRefresh">Refresh</f-button>
+
+    <f-sort-filter-dataset
+        ref="sortFilter"
+        v-test="'filter'"
+        mode="lazy"
+        :data="rows"
+        :sortable-attributes
+        default-sort-attribute="text"
+    >
+        <template #default="{ sortFilterResult }">
+            <f-paginate-dataset :items="sortFilterResult" :items-per-page>
+                <template #default="{ items: currentPageItems }">
+                    <f-table
+                        v-model:selected-rows="selectedRows"
+                        :rows="currentPageItems"
+                        :columns
+                        key-attribute="id"
+                        selectable="multi"
+                    />
+                    <f-paginator />
+                </template>
+            </f-paginate-dataset>
+        </template>
+    </f-sort-filter-dataset>
+</template>

--- a/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyPaginationExample.vue
+++ b/packages/vue-labs/src/components/FTable/sort-filter/examples/FTableSortFilterLazyPaginationExample.vue
@@ -50,38 +50,104 @@ function onRefresh(): void {
 </script>
 
 <template>
-    <h2>Sort-filter lazy med paginering</h2>
-    <p>
-        Exemplet visar lazy-beteende med paginering: nya rader hoppar till sista sidan och
-        <code>refresh()</code> hoppar till första sidan samt tömmer markerade rader.
-    </p>
+    <div class="row">
+        <div class="col col--sm-4">
+            <p data-test="selected-count">Valda rader: {{ selectedRows.length }}</p>
 
-    <p data-test="selected-count">Valda rader: {{ selectedRows.length }}</p>
+            <f-button data-test="add-row" variant="secondary" @click="onAddRow"
+                >Lägg till rad</f-button
+            >
+            <f-button data-test="refresh" variant="secondary" @click="onRefresh">Refresh</f-button>
 
-    <f-button data-test="add-row" variant="secondary" @click="onAddRow">Lägg till rad</f-button>
-    <f-button data-test="refresh" variant="secondary" @click="onRefresh">Refresh</f-button>
-
-    <f-sort-filter-dataset
-        ref="sortFilter"
-        v-test="'filter'"
-        mode="lazy"
-        :data="rows"
-        :sortable-attributes
-        default-sort-attribute="text"
-    >
-        <template #default="{ sortFilterResult }">
-            <f-paginate-dataset :items="sortFilterResult" :items-per-page>
-                <template #default="{ items: currentPageItems }">
-                    <f-table
-                        v-model:selected-rows="selectedRows"
-                        :rows="currentPageItems"
-                        :columns
-                        key-attribute="id"
-                        selectable="multi"
-                    />
-                    <f-paginator />
+            <f-sort-filter-dataset
+                ref="sortFilter"
+                v-test="'filter'"
+                mode="lazy"
+                :data="rows"
+                :sortable-attributes
+                default-sort-attribute="text"
+            >
+                <template #default="{ sortFilterResult }">
+                    <f-paginate-dataset :items="sortFilterResult" :items-per-page>
+                        <template #default="{ items: currentPageItems }">
+                            <f-table
+                                v-model:selected-rows="selectedRows"
+                                :rows="currentPageItems"
+                                :columns
+                                key-attribute="id"
+                                selectable="multi"
+                            />
+                            <f-paginator />
+                        </template>
+                    </f-paginate-dataset>
                 </template>
-            </f-paginate-dataset>
-        </template>
-    </f-sort-filter-dataset>
+            </f-sort-filter-dataset>
+        </div>
+        <div class="col col--sm-8">
+            <h2>Redigerbar tabell med sortering och filtrering (lazy), paginering, flerval.</h2>
+            <p>
+                Lazy-läge kör inte om sortering vid inline-editering och lägger till nya rader sist.
+                Ny sortering/filtrering körs först när användaren sorterar eller filtrerar.
+            </p>
+
+            <h3>Om man lägger till en eller flera rader</h3>
+            <pre>
+        - när ingen sortering eller filtrering är aktiv, så visas rad så som den blivit placerad i dataset, ingen sidnavigering sker
+        - när sortering eller filtrering är aktiv, så visas rad sist, sidnavigering till sista sidan
+        - val behålls. bulkruta status kan påverkas (från ikryssad till indeterminate).
+    </pre
+            >
+
+            <h3>Om man tar bort en eller flera rader</h3>
+            <pre>
+        - val behålls. bulkruta status kan påverkas (från indeterminate till ikryssad).
+        - sidnavigering sker till sista sidan om aktuell sida innan borttag inte längre finns kvar
+    </pre
+            >
+
+            <h3>Om man redigerar rader</h3>
+            <pre>
+        - när ingen sortering eller filtrering är aktiv: inget speciell hantering
+        - när filtrering eller sortering är aktiva:
+          - rad ska finnas kvar även om filtret ej längre matchar raden
+          - rad ska ligga kvar på samma position även om ändringen påverkar sorteringsordning.
+          - sortering ska sättas till ovald ("Välj")
+          - ingen sidnavigering sker
+    </pre
+            >
+
+            <h3>
+                Om man helt ersätter all data, inga rader kvar från föregående data (instansbaserat)
+            </h3>
+            <pre>
+        - när ingen sortering eller filtrering är aktiv: allt visas
+        - när filter eller sortering är aktiva: filter och sortering körs om
+        - val nollställs
+        - sidnavigering till första sidan
+    </pre
+            >
+            <h3>Om man filtrerar</h3>
+            <pre>
+        - filtrering och sortering körs om
+        - val nollställs
+        - sidnavigering till första sidan
+    </pre
+            >
+
+            <h3>Om man sorterar</h3>
+            <pre>
+        - filtrering och sortering körs om
+        - val behålls
+        - sidnavigering till första sidan
+    </pre
+            >
+
+            <h3>Om man kör refresh (`fSortFilterDataset.refresh()`)</h3>
+            <pre>
+        - filtrering och sortering körs om
+        - val behålls
+        - sidnavigering till första sidan
+            </pre>
+        </div>
+    </div>
 </template>

--- a/packages/vue-labs/src/components/FTable/sort-filter/sort-filter.md
+++ b/packages/vue-labs/src/components/FTable/sort-filter/sort-filter.md
@@ -1,0 +1,50 @@
+# Kompletterande funktionalitet för datamängsredigeraren (`f-sort-filter-dataset`)
+
+f-sort-filter-dataset får en ny prop mode som kan sättas till lazy, vilket innebär:
+- ingen omsortering sker vid editering av data
+- nya rader läggs till på slutet, vid paginering så går till sista sidan
+- då användare sorterar eller filtrerar körs allting om på nytt, vid paginering så går till första sidan
+- f-sort-filter-dataset får även en ny metod refresh() kopplad till lazy-beteendet som exponeras via api. Den kör om allting på nytt och går till första sidan vid paginering.
+
+f-pagination injectar sortFilterDatasetEvents med metoder onRefresh (hoppar till första sidan) och onLazyRowsAdded (hoppar till sista sidan)
+
+f-table injectar också sortFilterDatasetEvents onRefresh (tömmer selectedRows)
+
+## Exempel tabell ihop med datamängsredigerare som har `mode`="lazy"
+
+Given att tabellen är sorterad på kolumnen "namn"
+When användaren redigerar en rads namn som _skulle_ påverka sorteringsordningen
+Then sker ingen omsortering
+
+### Fler användarexempel
+
+#### Exempel 2: Lägg till ny rad i sorterad tabell med paginering
+
+Given att tabellen är sorterad på kolumnen "namn" och användaren står på sida 2 av 5
+When användaren lägger till en ny rad
+Then hoppar tabellen till sista sidan och den nya raden visas sist utan direkt omsortering av övriga rader
+
+#### Exempel 3: Filtrera efter flera inline-editeringar
+
+Given att användaren redigerar flera rader så att vissa nu matchar ett filter på kolumnen "status"
+When användaren aktiverar filtret
+Then körs sortering och filtrering om, och vid paginering hoppar tabellen till första sidan
+
+#### Exempel 4: Manuell refresh efter batch-uppdatering
+
+Given att användaren har gjort många inline-editeringar i följd
+When användaren klickar på en knapp som anropar `refresh()`
+Then beräknas datamängden om utifrån aktuell sortering och filtrering, och vid paginering hoppar tabellen till första sidan
+
+#### Exempel 5: Valda rader nollställs vid refresh
+
+Given att användaren har markerat flera rader i tabellen
+When användaren anropar `refresh()` efter att ha uppdaterat data
+Then går tabellen till första sidan vid paginering och eventuella markerade rader töms i f-table
+
+#### Exempel 6: Sortering triggar omberäkning efter redigering
+
+Given att användaren har redigerat en cell i kolumnen "prioritet" och raden ligger kvar på sin plats
+When användaren klickar på kolumnrubriken "prioritet" för att sortera
+Then sorteras hela datamängden om och tabellen går till första sidan vid paginering
+

--- a/packages/vue-labs/src/components/FTable/sort-filter/sort-filter.md
+++ b/packages/vue-labs/src/components/FTable/sort-filter/sort-filter.md
@@ -1,6 +1,7 @@
 # Kompletterande funktionalitet för datamängsredigeraren (`f-sort-filter-dataset`)
 
 f-sort-filter-dataset får en ny prop mode som kan sättas till lazy, vilket innebär:
+
 - ingen omsortering sker vid editering av data
 - nya rader läggs till på slutet, vid paginering så går till sista sidan
 - då användare sorterar eller filtrerar körs allting om på nytt, vid paginering så går till första sidan
@@ -47,4 +48,3 @@ Then går tabellen till första sidan vid paginering och eventuella markerade ra
 Given att användaren har redigerat en cell i kolumnen "prioritet" och raden ligger kvar på sin plats
 When användaren klickar på kolumnrubriken "prioritet" för att sortera
 Then sorteras hela datamängden om och tabellen går till första sidan vid paginering
-

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
@@ -44,6 +44,7 @@ import { ActivateItemInjected } from "../FCrudDataset";
 import { FIcon } from "../FIcon";
 import { FRadioField } from "../FRadioField";
 import { FSortFilterDatasetInjected } from "../FSortFilterDataset";
+import { useSortFilterDatasetEvents } from "../FSortFilterDataset/sort-filter-dataset-events";
 import {
     type FTableColumnData,
     FTableColumnSort,
@@ -203,6 +204,7 @@ const $t = useTranslate();
 const slots = useSlots();
 const { hasSlot } = useSlotUtils();
 const { sort, registerCallbackOnSort, registerCallbackOnMount } = FSortFilterDatasetInjected();
+const { onRefresh } = useSortFilterDatasetEvents();
 const { registerCallbackAfterItemAdd, registerCallbackBeforeItemDelete, setNestedKey } = ActivateItemInjected<T>();
 
 /* eslint-disable-next-line @typescript-eslint/no-deprecated -- technical debt */
@@ -372,6 +374,7 @@ onMounted(() => {
     }
     registerCallbackOnSort(callbackOnSort);
     registerCallbackOnMount(callbackSortableColumns);
+    onRefresh(callbackOnRefresh);
     registerCallbackAfterItemAdd(callbackAfterItemAdd);
     registerCallbackBeforeItemDelete(callbackBeforeItemDelete);
 });
@@ -508,6 +511,11 @@ function callbackOnSort(columnName: PropertyKey, ascending: boolean): void {
 
 function callbackSortableColumns(columnNames: PropertyKey[]): void {
     setSortableColumns(columns.value, columnNames);
+}
+
+function callbackOnRefresh(): void {
+    selectedRows.value = [];
+    updateVModelWithSelectedRows();
 }
 
 function callbackAfterItemAdd(item: T): void {

--- a/packages/vue/src/components/FPaginateDataset/FPaginateDataset.spec.ts
+++ b/packages/vue/src/components/FPaginateDataset/FPaginateDataset.spec.ts
@@ -1,0 +1,85 @@
+import { nextTick, provide } from "vue";
+import { mount } from "@vue/test-utils";
+import {
+    type SortFilterDatasetEventCallback,
+    sortFilterDatasetEventsKey,
+} from "../FSortFilterDataset/sort-filter-dataset-events";
+import { FPaginateDataset } from "./index";
+
+let refreshCallback: SortFilterDatasetEventCallback = () => {};
+let lazyRowsAddedCallback: SortFilterDatasetEventCallback = () => {};
+
+function createWrapper() {
+    refreshCallback = () => {};
+    lazyRowsAddedCallback = () => {};
+
+    return mount({
+        components: { FPaginateDataset },
+        setup() {
+            provide(sortFilterDatasetEventsKey, {
+                onRefresh(callback) {
+                    refreshCallback = callback;
+                },
+                onLazyRowsAdded(callback) {
+                    lazyRowsAddedCallback = callback;
+                },
+            });
+        },
+        data() {
+            return {
+                items: Array.from({ length: 11 }, (_, index) => ({
+                    id: index + 1,
+                    name: `Namn ${index + 1}`,
+                })),
+            };
+        },
+        template: /* HTML */ `
+            <f-paginate-dataset :items="items" :items-per-page="5">
+                <template #default="{ currentPage }">
+                    <div id="current-page">{{ currentPage }}</div>
+                </template>
+            </f-paginate-dataset>
+        `,
+    });
+}
+
+function setPage(wrapper: ReturnType<typeof createWrapper>, page: number): void {
+    wrapper.findComponent(FPaginateDataset).element.dispatchEvent(
+        new CustomEvent("paginateDataset:page", {
+            bubbles: true,
+            detail: {
+                page,
+            },
+        }),
+    );
+}
+
+describe("integration with sortFilterDatasetEvents", () => {
+    it("should jump to last page on lazy rows added", async () => {
+        const wrapper = createWrapper();
+        await nextTick();
+
+        setPage(wrapper, 1);
+        await nextTick();
+        expect(wrapper.get("#current-page").text()).toBe("1");
+
+        lazyRowsAddedCallback();
+        await nextTick();
+
+        expect(wrapper.get("#current-page").text()).toBe("3");
+    });
+
+    it("should jump to first page on refresh", async () => {
+        const wrapper = createWrapper();
+        await nextTick();
+
+        setPage(wrapper, 2);
+        await nextTick();
+        expect(wrapper.get("#current-page").text()).toBe("2");
+
+        refreshCallback();
+        await nextTick();
+
+        expect(wrapper.get("#current-page").text()).toBe("1");
+    });
+});

--- a/packages/vue/src/components/FPaginateDataset/FPaginateDataset.spec.ts
+++ b/packages/vue/src/components/FPaginateDataset/FPaginateDataset.spec.ts
@@ -1,17 +1,17 @@
 import { nextTick, provide } from "vue";
-import { mount } from "@vue/test-utils";
+import { VueWrapper, mount } from "@vue/test-utils";
 import {
     type SortFilterDatasetEventCallback,
     sortFilterDatasetEventsKey,
 } from "../FSortFilterDataset/sort-filter-dataset-events";
 import { FPaginateDataset } from "./index";
 
-let refreshCallback: SortFilterDatasetEventCallback = () => {};
-let lazyRowsAddedCallback: SortFilterDatasetEventCallback = () => {};
+let refreshCallback: SortFilterDatasetEventCallback = () => ({});
+let lazyRowsAddedCallback: SortFilterDatasetEventCallback = () => ({});
 
-function createWrapper() {
-    refreshCallback = () => {};
-    lazyRowsAddedCallback = () => {};
+function createWrapper(): VueWrapper {
+    refreshCallback = () => ({});
+    lazyRowsAddedCallback = () => ({});
 
     return mount({
         components: { FPaginateDataset },
@@ -43,7 +43,10 @@ function createWrapper() {
     });
 }
 
-function setPage(wrapper: ReturnType<typeof createWrapper>, page: number): void {
+function setPage(
+    wrapper: ReturnType<typeof createWrapper>,
+    page: number,
+): void {
     wrapper.findComponent(FPaginateDataset).element.dispatchEvent(
         new CustomEvent("paginateDataset:page", {
             bubbles: true,

--- a/packages/vue/src/components/FPaginateDataset/FPaginateDataset.vue
+++ b/packages/vue/src/components/FPaginateDataset/FPaginateDataset.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts" generic="T extends object, TArray extends Dataset<T> | T[] = Dataset<T> | T[]">
 import { type Ref, computed, onMounted, provide, ref, watch } from "vue";
 import { type Dataset, toDataset } from "../../utils";
+import { useSortFilterDatasetEvents } from "../FSortFilterDataset/sort-filter-dataset-events";
 import { type FPaginateDatasetPageEventDetail } from "../FPaginator";
 import { paginateDatasetKey } from "./provide";
 
@@ -69,7 +70,12 @@ const numberOfPages = computed(() => Math.ceil(numberOfItems.value / itemsPerPag
 // Computes number of items
 const numberOfItems = computed(() => (itemsLength > 0 ? itemsLength : items.length));
 
+const sortFilterDatasetEvents = useSortFilterDatasetEvents();
+
 onMounted(() => {
+    sortFilterDatasetEvents.onRefresh(goToFirstPage);
+    sortFilterDatasetEvents.onLazyRowsAdded(goToLastPage);
+
     /* eslint-disable-next-line @typescript-eslint/no-floating-promises -- technical debt */
     refetchData();
 });

--- a/packages/vue/src/components/FPaginateDataset/FPaginateDataset.vue
+++ b/packages/vue/src/components/FPaginateDataset/FPaginateDataset.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts" generic="T extends object, TArray extends Dataset<T> | T[] = Dataset<T> | T[]">
 import { type Ref, computed, onMounted, provide, ref, watch } from "vue";
 import { type Dataset, toDataset } from "../../utils";
-import { useSortFilterDatasetEvents } from "../FSortFilterDataset/sort-filter-dataset-events";
 import { type FPaginateDatasetPageEventDetail } from "../FPaginator";
+import { useSortFilterDatasetEvents } from "../FSortFilterDataset/sort-filter-dataset-events";
 import { paginateDatasetKey } from "./provide";
 
 // Defines component props

--- a/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.vue
+++ b/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.vue
@@ -164,6 +164,7 @@ function onSearchInput(): void {
 }
 
 watch(sortAttribute, () => {
+    tableCallbackOnSort(sortAttribute.value.attribute, sortAttribute.value.ascending);
     emit("usedSortAttributes", sortAttribute.value);
 });
 

--- a/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.vue
+++ b/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.vue
@@ -10,8 +10,9 @@ import {
     type FSortFilterDatasetMountCallback,
     type FSortFilterDatasetSortCallback,
 } from "./f-sort-filter-dataset-interface";
+import { sortFilterDatasetEventsKey } from "./sort-filter-dataset-events";
 import { type SortOrder } from "./sort-order";
-import { useSortFilterDataset } from "./use-sort-filter-dataset";
+import { type SortFilterDatasetMode, useSortFilterDataset } from "./use-sort-filter-dataset";
 
 const {
     data,
@@ -27,6 +28,7 @@ const {
     /* eslint-disable-next-line vue/no-boolean-default -- technical debt, boolean attributes should be opt-in not opt-out */
     defaultSortAscending = true,
     filterAttributes = undefined,
+    mode = "none",
 } = defineProps<{
     /**
      * The data that you wish to sort or filter.
@@ -70,6 +72,13 @@ const {
      * Default includes all attributes.
      */
     filterAttributes?: PropertyKey[];
+    /**
+     * Controls when sort/filter result should be recalculated.
+     *
+     * - "none": recalculates on all data updates.
+     * - "lazy": skips recalculation on edits and appends added rows last.
+     */
+    mode?: SortFilterDatasetMode;
 }>();
 
 const emit = defineEmits<{
@@ -88,6 +97,9 @@ const emit = defineEmits<{
     usedSortAttributes: [sortAttribute: SortOrder];
 }>();
 
+const refreshCallbacks = new Set<() => void>();
+const lazyRowsAddedCallbacks = new Set<() => void>();
+
 const $t = useTranslate();
 const {
     searchString,
@@ -98,12 +110,26 @@ const {
     sortOrders,
     onUserChangeSortAttribute,
     onApiChangeSortAttribute,
+    refresh,
 } = useSortFilterDataset<T>(
     () => data,
     () => sortableAttributes,
     () => filterAttributes,
     defaultSortAttribute,
     defaultSortAscending,
+    mode,
+    {
+        onRefresh: () => {
+            for (const callback of refreshCallbacks) {
+                callback();
+            }
+        },
+        onLazyRowsAdded: () => {
+            for (const callback of lazyRowsAddedCallbacks) {
+                callback();
+            }
+        },
+    },
 );
 
 const clearableScreenReaderText = $t("fkui.sort-filter-dataset.clear.filter", "Rensa sökfält");
@@ -153,6 +179,19 @@ provide("registerCallbackOnSort", (callback: FSortFilterDatasetSortCallback) => 
 
 provide("registerCallbackOnMount", (callback: FSortFilterDatasetMountCallback) => {
     tableCallbackSortableColumns = callback;
+});
+
+provide(sortFilterDatasetEventsKey, {
+    onRefresh(callback: () => void): void {
+        refreshCallbacks.add(callback);
+    },
+    onLazyRowsAdded(callback: () => void): void {
+        lazyRowsAddedCallbacks.add(callback);
+    },
+});
+
+defineExpose({
+    refresh,
 });
 
 onMounted(() => {

--- a/packages/vue/src/components/FSortFilterDataset/index.ts
+++ b/packages/vue/src/components/FSortFilterDataset/index.ts
@@ -6,3 +6,9 @@ export {
 } from "./f-sort-filter-dataset-interface";
 export { default as FSortFilterDataset } from "./FSortFilterDataset.vue";
 export { type SortOrder } from "./sort-order";
+export {
+    type SortFilterDatasetEventCallback,
+    type SortFilterDatasetEvents,
+    sortFilterDatasetEventsKey,
+    useSortFilterDatasetEvents,
+} from "./sort-filter-dataset-events";

--- a/packages/vue/src/components/FSortFilterDataset/sort-filter-dataset-events.ts
+++ b/packages/vue/src/components/FSortFilterDataset/sort-filter-dataset-events.ts
@@ -1,0 +1,19 @@
+import { type InjectionKey, inject } from "vue";
+
+export type SortFilterDatasetEventCallback = () => void;
+
+export interface SortFilterDatasetEvents {
+    onRefresh(this: void, callback: SortFilterDatasetEventCallback): void;
+    onLazyRowsAdded(this: void, callback: SortFilterDatasetEventCallback): void;
+}
+
+export const sortFilterDatasetEventsKey = Symbol() as InjectionKey<SortFilterDatasetEvents>;
+
+export function useSortFilterDatasetEvents(): SortFilterDatasetEvents {
+    const defaultEvents: SortFilterDatasetEvents = {
+        onRefresh: () => undefined,
+        onLazyRowsAdded: () => undefined,
+    };
+
+    return inject(sortFilterDatasetEventsKey, defaultEvents);
+}

--- a/packages/vue/src/components/FSortFilterDataset/sort-filter-dataset-events.ts
+++ b/packages/vue/src/components/FSortFilterDataset/sort-filter-dataset-events.ts
@@ -7,7 +7,8 @@ export interface SortFilterDatasetEvents {
     onLazyRowsAdded(this: void, callback: SortFilterDatasetEventCallback): void;
 }
 
-export const sortFilterDatasetEventsKey = Symbol() as InjectionKey<SortFilterDatasetEvents>;
+export const sortFilterDatasetEventsKey =
+    Symbol() as InjectionKey<SortFilterDatasetEvents>;
 
 export function useSortFilterDatasetEvents(): SortFilterDatasetEvents {
     const defaultEvents: SortFilterDatasetEvents = {

--- a/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.spec.ts
+++ b/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.spec.ts
@@ -25,7 +25,7 @@ it("should output filtered rows directly", async () => {
     ]);
 });
 
-describe("filtered data after mutation of input data", () => {
+describe("filtered data after editing of input data in lazy mode", () => {
     it("should have new rows at the end of array", async () => {
         const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
 
@@ -35,6 +35,7 @@ describe("filtered data after mutation of input data", () => {
             [],
             "foo",
             true,
+            "lazy",
         );
 
         data.value.push({ foo: "barbaz" });
@@ -86,6 +87,7 @@ describe("filtered data after mutation of input data", () => {
             [],
             "foo",
             true,
+            "lazy",
         );
 
         data.value.splice(0, 1);
@@ -119,6 +121,7 @@ describe("filtered data after mutation of input data", () => {
             [],
             "foo",
             true,
+            "lazy",
         );
 
         data.value[0].foo = "foobar";
@@ -146,6 +149,7 @@ describe("filtered data after mutation of input data", () => {
             [],
             "foo",
             true,
+            "lazy",
         );
 
         data.value[0].foo = "alpha";
@@ -173,6 +177,7 @@ describe("filtered data after mutation of input data", () => {
             ["foo"],
             "foo",
             true,
+            "lazy",
         );
 
         searchString.value = "b";
@@ -200,7 +205,103 @@ describe("filtered data after mutation of input data", () => {
             },
         ]);
     });
+
+    it("should not be resorted in lazy mode when data is replaced", async () => {
+        const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
+
+        const { sortFilterResult } = useSortFilterDataset(
+            data,
+            { foo: "foo" },
+            [],
+            "foo",
+            true,
+            "lazy",
+        );
+
+        data.value = [{ foo: "zzz" }, { foo: "aaa" }, { foo: "mmm" }];
+        await nextTick();
+
+        expect(sortFilterResult.value).toMatchObject([
+            {
+                foo: "zzz",
+            },
+            {
+                foo: "aaa",
+            },
+            {
+                foo: "mmm",
+            },
+        ]);
+    });
 });
+
+describe("lazy callbacks and refresh", () => {
+    it("should call onLazyRowsAdded when new rows are appended", async () => {
+        const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
+        const onLazyRowsAdded = jest.fn();
+
+        useSortFilterDataset(
+            data,
+            { foo: "foo" },
+            [],
+            "foo",
+            true,
+            "lazy",
+            { onLazyRowsAdded },
+        );
+
+        data.value.push({ foo: "added" });
+        await nextTick();
+
+        expect(onLazyRowsAdded).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call onRefresh and rerun full sort when refresh is called", async () => {
+        const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
+        const onRefresh = jest.fn();
+
+        const { sortFilterResult, refresh } = useSortFilterDataset(
+            data,
+            { foo: "foo" },
+            [],
+            "foo",
+            true,
+            "lazy",
+            { onRefresh },
+        );
+
+        data.value[0].foo = "alpha";
+        await nextTick();
+
+        expect(sortFilterResult.value).toMatchObject([
+            {
+                foo: "bar",
+            },
+            {
+                foo: "baz",
+            },
+            {
+                foo: "alpha",
+            },
+        ]);
+
+        refresh();
+
+        expect(sortFilterResult.value).toMatchObject([
+            {
+                foo: "alpha",
+            },
+            {
+                foo: "bar",
+            },
+            {
+                foo: "baz",
+            },
+        ]);
+        expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+});
+
 
 describe("filtered data after replacement of input data", () => {
     it("should update filtered rows when data is replaced", async () => {

--- a/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.spec.ts
+++ b/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.spec.ts
@@ -240,15 +240,9 @@ describe("lazy callbacks and refresh", () => {
         const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
         const onLazyRowsAdded = jest.fn();
 
-        useSortFilterDataset(
-            data,
-            { foo: "foo" },
-            [],
-            "foo",
-            true,
-            "lazy",
-            { onLazyRowsAdded },
-        );
+        useSortFilterDataset(data, { foo: "foo" }, [], "foo", true, "lazy", {
+            onLazyRowsAdded,
+        });
 
         data.value.push({ foo: "added" });
         await nextTick();
@@ -301,7 +295,6 @@ describe("lazy callbacks and refresh", () => {
         expect(onRefresh).toHaveBeenCalledTimes(1);
     });
 });
-
 
 describe("filtered data after replacement of input data", () => {
     it("should update filtered rows when data is replaced", async () => {

--- a/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.spec.ts
+++ b/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.spec.ts
@@ -1,32 +1,32 @@
 import { nextTick, ref } from "vue";
 import { useSortFilterDataset } from "./use-sort-filter-dataset";
 
-describe("filtered rows", () => {
-    it("should output filtered rows directly", async () => {
-        const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
+it("should output filtered rows directly", async () => {
+    const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
 
-        const { sortFilterResult } = useSortFilterDataset(
-            data,
-            { foo: "foo" },
-            [],
-            "foo",
-            true,
-        );
+    const { sortFilterResult } = useSortFilterDataset(
+        data,
+        { foo: "foo" },
+        [],
+        "foo",
+        true,
+    );
 
-        expect(sortFilterResult.value).toMatchObject([
-            {
-                foo: "bar",
-            },
-            {
-                foo: "baz",
-            },
-            {
-                foo: "foo",
-            },
-        ]);
-    });
+    expect(sortFilterResult.value).toMatchObject([
+        {
+            foo: "bar",
+        },
+        {
+            foo: "baz",
+        },
+        {
+            foo: "foo",
+        },
+    ]);
+});
 
-    it("should update filtered rows when data is added", async () => {
+describe("filtered data after mutation of input data", () => {
+    it("should have new rows at the end of array", async () => {
         const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
 
         const { sortFilterResult } = useSortFilterDataset(
@@ -45,7 +45,22 @@ describe("filtered rows", () => {
                 foo: "bar",
             },
             {
+                foo: "baz",
+            },
+            {
+                foo: "foo",
+            },
+            {
                 foo: "barbaz",
+            },
+        ]);
+
+        data.value.unshift({ foo: "foobarbaz" });
+        await nextTick();
+
+        expect(sortFilterResult.value).toMatchObject([
+            {
+                foo: "bar",
             },
             {
                 foo: "baz",
@@ -53,10 +68,16 @@ describe("filtered rows", () => {
             {
                 foo: "foo",
             },
+            {
+                foo: "barbaz",
+            },
+            {
+                foo: "foobarbaz",
+            },
         ]);
     });
 
-    it("should update filtered rows when data is removed", async () => {
+    it("should not contain removed rows", async () => {
         const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
 
         const { sortFilterResult } = useSortFilterDataset(
@@ -78,9 +99,18 @@ describe("filtered rows", () => {
                 foo: "baz",
             },
         ]);
+
+        data.value.splice(0, 1);
+        await nextTick();
+
+        expect(sortFilterResult.value).toMatchObject([
+            {
+                foo: "baz",
+            },
+        ]);
     });
 
-    it("should update filtered rows when data is edited", async () => {
+    it("should contain edit updates", async () => {
         const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
 
         const { sortFilterResult } = useSortFilterDataset(
@@ -107,6 +137,72 @@ describe("filtered rows", () => {
         ]);
     });
 
+    it("should not be resorted", async () => {
+        const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
+
+        const { sortFilterResult } = useSortFilterDataset(
+            data,
+            { foo: "foo" },
+            [],
+            "foo",
+            true,
+        );
+
+        data.value[0].foo = "alpha";
+        await nextTick();
+
+        expect(sortFilterResult.value).toMatchObject([
+            {
+                foo: "bar",
+            },
+            {
+                foo: "baz",
+            },
+            {
+                foo: "alpha",
+            },
+        ]);
+    });
+
+    it("should not be refiltered", async () => {
+        const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
+
+        const { sortFilterResult, searchString } = useSortFilterDataset(
+            data,
+            { foo: "foo" },
+            ["foo"],
+            "foo",
+            true,
+        );
+
+        searchString.value = "b";
+        await nextTick();
+
+        expect(sortFilterResult.value).toMatchObject([
+            {
+                foo: "bar",
+            },
+            {
+                foo: "baz",
+            },
+        ]);
+
+        data.value[0].foo = "barbaz";
+        data.value[1].foo = "lorem";
+        await nextTick();
+
+        expect(sortFilterResult.value).toMatchObject([
+            {
+                foo: "lorem",
+            },
+            {
+                foo: "baz",
+            },
+        ]);
+    });
+});
+
+describe("filtered data after replacement of input data", () => {
     it("should update filtered rows when data is replaced", async () => {
         const data = ref([{ foo: "foo" }, { foo: "bar" }, { foo: "baz" }]);
 

--- a/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.ts
+++ b/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.ts
@@ -228,7 +228,7 @@ export function useSortFilterDataset<T extends object>(
             newResult.push(it);
         }
 
-        sortAttribute.value = defaultSortValue;
+        sortAttribute.value = { ...defaultSortValue };
         sortFilterResult.value.splice(
             0,
             sortFilterResult.value.length,

--- a/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.ts
+++ b/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.ts
@@ -217,17 +217,23 @@ export function useSortFilterDataset<T extends object>(
         const noLongerIncluded = newResult.filter(
             (it) => !newData.includes(it),
         );
-        noLongerIncluded.forEach((it) => {
+        for (const it of noLongerIncluded) {
             newResult.splice(newResult.indexOf(it), 1);
-        });
+        }
 
         const additions = newData
             .filter((it) => !dataSnapshot.includes(it))
             .filter((it) => !newResult.includes(it));
-        additions.forEach((it) => newResult.push(it));
+        for (const it of additions) {
+            newResult.push(it);
+        }
 
         sortAttribute.value = defaultSortValue;
-        sortFilterResult.value = newResult;
+        sortFilterResult.value.splice(
+            0,
+            sortFilterResult.value.length,
+            ...newResult,
+        );
     }
 
     /**

--- a/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.ts
+++ b/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.ts
@@ -113,6 +113,14 @@ export interface SortFilterDatasetState<T extends object> {
         attribute: string,
         ascending: boolean,
     ): void;
+    refresh(this: void): void;
+}
+
+export type SortFilterDatasetMode = "none" | "lazy";
+
+export interface SortFilterDatasetCallbacks {
+    onRefresh?: () => void;
+    onLazyRowsAdded?: () => void;
 }
 
 export function useSortFilterDataset<T extends object>(
@@ -123,11 +131,14 @@ export function useSortFilterDataset<T extends object>(
     filterAttributes: MaybeRefOrGetter<PropertyKey[] | undefined>,
     defaultSortAttribute: PropertyKey,
     defaultSortAscending: boolean,
+    mode: SortFilterDatasetMode = "none",
+    callbacks: SortFilterDatasetCallbacks = {},
 ): SortFilterDatasetState<T> {
     const searchString = ref("");
     const sortAttribute = ref<SortOrder>({ ...defaultSortValue });
     const sortFilterResult = ref(toDataset([])) as Ref<Dataset<T>>;
     const useDefaultSortOrder = ref(true);
+    let initialized = false;
 
     /**
      * Data snapshot taken when new sortfilter is run.
@@ -166,7 +177,7 @@ export function useSortFilterDataset<T extends object>(
         return searchString.value.length > 0;
     });
 
-    function onUserChangeSortAttribute(): void {
+    function runSortFilterData(): void {
         dataSnapshot = [...toValue(data)];
         sortFilterResult.value = sortFilterData(
             dataSnapshot,
@@ -174,6 +185,15 @@ export function useSortFilterDataset<T extends object>(
             searchString.value,
             sortAttribute.value,
         );
+    }
+
+    function notifyRefresh(): void {
+        callbacks.onRefresh?.();
+    }
+
+    function onUserChangeSortAttribute(): void {
+        runSortFilterData();
+        notifyRefresh();
     }
 
     function onApiChangeSortAttribute(
@@ -186,31 +206,24 @@ export function useSortFilterDataset<T extends object>(
             sortOrders.value,
         );
 
-        dataSnapshot = [...toValue(data)];
-        sortFilterResult.value = sortFilterData(
-            dataSnapshot,
-            internalFilterAttributes.value,
-            searchString.value,
-            sortAttribute.value,
-        );
+        runSortFilterData();
+        notifyRefresh();
+    }
+
+    function refresh(): void {
+        runSortFilterData();
+        notifyRefresh();
     }
 
     watch(searchString, () => {
-        dataSnapshot = [...toValue(data)];
-        sortFilterResult.value = sortFilterData(
-            dataSnapshot,
-            internalFilterAttributes.value,
-            searchString.value,
-            sortAttribute.value,
-        );
+        runSortFilterData();
+        notifyRefresh();
     });
 
     /**
-     * Visually resets sort without resorting the current output data.
-     *
-     * This is intended when existing input data is mutated.
+     * Applies lazy-mode update semantics without full sort/filter recomputation.
      */
-    function handleDataChanged(): void {
+    function handleLazyModeUpdate(): void {
         const newData = toValue(data);
         const newResult = [...sortFilterResult.value];
 
@@ -234,14 +247,16 @@ export function useSortFilterDataset<T extends object>(
             sortFilterResult.value.length,
             ...newResult,
         );
+
+        if (additions.length > 0) {
+            callbacks.onLazyRowsAdded?.();
+        }
     }
 
     /**
-     * Runs a full sort replacing the current output data.
-     *
-     * This is intended when the input data is fully replaced.
+     * Runs a full sort/filter recomputation and replaces current output data.
      */
-    function handleDataReplaced(): void {
+    function handleFullRecompute(): void {
         if (defaultSortAttribute !== "" && useDefaultSortOrder.value) {
             const foundAttribute = sortOrders.value.find((item) => {
                 return (
@@ -258,22 +273,22 @@ export function useSortFilterDataset<T extends object>(
             useDefaultSortOrder.value = false;
         }
 
-        dataSnapshot = [...toValue(data)];
-        sortFilterResult.value = sortFilterData(
-            dataSnapshot,
-            internalFilterAttributes.value,
-            searchString.value,
-            sortAttribute.value,
-        );
+        runSortFilterData();
     }
 
     watch(
         () => toValue(data),
-        (newData, oldData) => {
-            if (newData === oldData) {
-                handleDataChanged();
+        () => {
+            if (!initialized) {
+                initialized = true;
+                handleFullRecompute();
+                return;
+            }
+
+            if (mode === "lazy") {
+                handleLazyModeUpdate();
             } else {
-                handleDataReplaced();
+                handleFullRecompute();
             }
         },
         { immediate: true, deep: true },
@@ -289,5 +304,6 @@ export function useSortFilterDataset<T extends object>(
         sortAttribute,
         onUserChangeSortAttribute,
         onApiChangeSortAttribute,
+        refresh,
     };
 }

--- a/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.ts
+++ b/packages/vue/src/components/FSortFilterDataset/use-sort-filter-dataset.ts
@@ -129,6 +129,14 @@ export function useSortFilterDataset<T extends object>(
     const sortFilterResult = ref(toDataset([])) as Ref<Dataset<T>>;
     const useDefaultSortOrder = ref(true);
 
+    /**
+     * Data snapshot taken when new sortfilter is run.
+     *
+     * This data snapshot is used to be compare with new input data in order to
+     * distinguish added and removed rows.
+     */
+    let dataSnapshot: T[] = [];
+
     /* all enumerable keys from sortableAttributes */
     const sortableKeys = computed(() => {
         return Reflect.ownKeys(toValue(sortableAttributes)).filter((key) => {
@@ -159,8 +167,9 @@ export function useSortFilterDataset<T extends object>(
     });
 
     function onUserChangeSortAttribute(): void {
+        dataSnapshot = [...toValue(data)];
         sortFilterResult.value = sortFilterData(
-            toValue(data),
+            dataSnapshot,
             internalFilterAttributes.value,
             searchString.value,
             sortAttribute.value,
@@ -177,8 +186,9 @@ export function useSortFilterDataset<T extends object>(
             sortOrders.value,
         );
 
+        dataSnapshot = [...toValue(data)];
         sortFilterResult.value = sortFilterData(
-            toValue(data),
+            dataSnapshot,
             internalFilterAttributes.value,
             searchString.value,
             sortAttribute.value,
@@ -186,39 +196,79 @@ export function useSortFilterDataset<T extends object>(
     }
 
     watch(searchString, () => {
+        dataSnapshot = [...toValue(data)];
         sortFilterResult.value = sortFilterData(
-            toValue(data),
+            dataSnapshot,
             internalFilterAttributes.value,
             searchString.value,
             sortAttribute.value,
         );
     });
 
+    /**
+     * Visually resets sort without resorting the current output data.
+     *
+     * This is intended when existing input data is mutated.
+     */
+    function handleDataChanged(): void {
+        const newData = toValue(data);
+        const newResult = [...sortFilterResult.value];
+
+        const noLongerIncluded = newResult.filter(
+            (it) => !newData.includes(it),
+        );
+        noLongerIncluded.forEach((it) => {
+            newResult.splice(newResult.indexOf(it), 1);
+        });
+
+        const additions = newData
+            .filter((it) => !dataSnapshot.includes(it))
+            .filter((it) => !newResult.includes(it));
+        additions.forEach((it) => newResult.push(it));
+
+        sortAttribute.value = defaultSortValue;
+        sortFilterResult.value = newResult;
+    }
+
+    /**
+     * Runs a full sort replacing the current output data.
+     *
+     * This is intended when the input data is fully replaced.
+     */
+    function handleDataReplaced(): void {
+        if (defaultSortAttribute !== "" && useDefaultSortOrder.value) {
+            const foundAttribute = sortOrders.value.find((item) => {
+                return (
+                    item.attribute === defaultSortAttribute &&
+                    item.ascending === defaultSortAscending
+                );
+            });
+            if (foundAttribute) {
+                sortAttribute.value = {
+                    ...foundAttribute,
+                    name: toValue(foundAttribute.name),
+                };
+            }
+            useDefaultSortOrder.value = false;
+        }
+
+        dataSnapshot = [...toValue(data)];
+        sortFilterResult.value = sortFilterData(
+            dataSnapshot,
+            internalFilterAttributes.value,
+            searchString.value,
+            sortAttribute.value,
+        );
+    }
+
     watch(
         () => toValue(data),
-        () => {
-            if (defaultSortAttribute !== "" && useDefaultSortOrder.value) {
-                const foundAttribute = sortOrders.value.find((item) => {
-                    return (
-                        item.attribute === defaultSortAttribute &&
-                        item.ascending === defaultSortAscending
-                    );
-                });
-                if (foundAttribute) {
-                    sortAttribute.value = {
-                        ...foundAttribute,
-                        name: toValue(foundAttribute.name),
-                    };
-                }
-                useDefaultSortOrder.value = false;
+        (newData, oldData) => {
+            if (newData === oldData) {
+                handleDataChanged();
+            } else {
+                handleDataReplaced();
             }
-
-            sortFilterResult.value = sortFilterData(
-                toValue(data),
-                internalFilterAttributes.value,
-                searchString.value,
-                sortAttribute.value,
-            );
         },
         { immediate: true, deep: true },
     );

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -114,9 +114,13 @@ export {
     type FSortFilterDatasetInterface,
     type FSortFilterDatasetMountCallback,
     type FSortFilterDatasetSortCallback,
+    type SortFilterDatasetEventCallback,
+    type SortFilterDatasetEvents,
     type SortOrder,
     FSortFilterDataset,
     FSortFilterDatasetInjected,
+    sortFilterDatasetEventsKey,
+    useSortFilterDatasetEvents,
 } from "./FSortFilterDataset";
 export { FStaticField } from "./FStaticField";
 export { FTableButton } from "./FTableButton";


### PR DESCRIPTION
Sort will only be triggered when the data array is modified or replaced, not when a single field value is updated.

Related to SFKUI-7487.