### PR TITLE
refactor: rename value for some columns (refs SFKUI-6500)

### DIFF
--- a/etc/vue-labs.api.md
+++ b/etc/vue-labs.api.md
@@ -111,9 +111,9 @@ export interface TableColumnAnchor<T, K extends keyof T> extends TableColumnBase
     // (undocumented)
     key?: K;
     // (undocumented)
-    type: "anchor";
+    text(this: void, row: T): string | null;
     // (undocumented)
-    value(this: void, row: T): string | null;
+    type: "anchor";
 }
 
 // @public
@@ -137,13 +137,15 @@ export interface TableColumnButton<T, K extends keyof T> extends TableColumnBase
     // (undocumented)
     onClick?(this: void, row: T): void;
     // (undocumented)
-    type: "button";
+    text(this: void, row: T): string | null;
     // (undocumented)
-    value(this: void, row: T): string | null;
+    type: "button";
 }
 
 // @public (undocumented)
 export interface TableColumnCheckbox<T, K extends keyof T> extends TableColumnBase {
+    // (undocumented)
+    checked?(this: void, row: T): boolean;
     // (undocumented)
     editable?: boolean | ((this: void, row: T) => boolean);
     // (undocumented)
@@ -154,8 +156,6 @@ export interface TableColumnCheckbox<T, K extends keyof T> extends TableColumnBa
     type: "checkbox";
     // (undocumented)
     update?(this: void, row: T, newValue: boolean, oldValue: boolean): void;
-    // (undocumented)
-    value?(this: void, row: T): boolean;
 }
 
 // @public (undocumented)
@@ -189,6 +189,8 @@ export interface TableColumnNumber<T, K extends keyof T> extends TableColumnBase
 // @public (undocumented)
 export interface TableColumnRadio<T, K extends keyof T> extends TableColumnBase {
     // (undocumented)
+    checked?(this: void, row: T): boolean;
+    // (undocumented)
     key?: K;
     // (undocumented)
     label?(this: void, row: T): string;
@@ -196,8 +198,6 @@ export interface TableColumnRadio<T, K extends keyof T> extends TableColumnBase 
     type: "radio";
     // (undocumented)
     update?(this: void, row: T, newValue: boolean, oldValue: boolean): void;
-    // (undocumented)
-    value?(this: void, row: T): boolean;
 }
 
 // @public (undocumented)
@@ -213,9 +213,9 @@ export interface TableColumnRowHeader<T, K extends keyof T> extends TableColumnB
     // (undocumented)
     key?: K;
     // (undocumented)
-    type: "rowheader";
+    text?(this: void, row: T): string;
     // (undocumented)
-    value?(this: void, row: T): string;
+    type: "rowheader";
 }
 
 // @public (undocumented)
@@ -229,11 +229,11 @@ export interface TableColumnSelect<T, K extends keyof T> extends TableColumnBase
     // (undocumented)
     options: string[];
     // (undocumented)
+    selected?(this: void, row: T): string;
+    // (undocumented)
     type: "select";
     // (undocumented)
     update?(this: void, row: T, newValue: string, oldValue: string): void;
-    // (undocumented)
-    value?(this: void, row: T): string;
 }
 
 // @public (undocumented)

--- a/packages/vue-labs/src/components/FTable/FTable.cy.ts
+++ b/packages/vue-labs/src/components/FTable/FTable.cy.ts
@@ -123,14 +123,14 @@ describe("1.5 Separator", () => {
             header: "Button",
             key: "button",
             icon: "trashcan",
-            value: (row) => row.button,
+            text: (row) => row.button,
         },
         {
             header: "Anchor",
             type: "anchor",
             key: "anchor",
             href: "#",
-            value: (row) => row.anchor,
+            text: (row) => row.anchor,
         },
     ]);
 
@@ -390,7 +390,7 @@ describe("5 tabstop", () => {
                 type: "button",
                 header: "remove",
                 icon: "trashcan",
-                value(row) {
+                text(row) {
                     return row.bar;
                 },
                 onClick(row) {
@@ -452,7 +452,7 @@ describe("5 tabstop", () => {
                 type: "button",
                 header: "remove",
                 icon: "trashcan",
-                value(row) {
+                text(row) {
                     return row.bar;
                 },
                 onClick(row) {
@@ -549,7 +549,7 @@ describe("5 tabstop", () => {
             {
                 type: "button",
                 header: "button header",
-                value(row) {
+                text(row) {
                     return row.button;
                 },
                 icon: "bell",
@@ -557,7 +557,7 @@ describe("5 tabstop", () => {
             {
                 type: "anchor",
                 header: "anchor header",
-                value(row) {
+                text(row) {
                     return row.anchor;
                 },
                 href: "awesome href",

--- a/packages/vue-labs/src/components/FTable/ITableAnchor.vue
+++ b/packages/vue-labs/src/components/FTable/ITableAnchor.vue
@@ -11,7 +11,7 @@ const { column, row } = defineProps<{
 const targetElement = useTemplateRef("target");
 
 const renderAnchor = computed(() => {
-    return column.enabled(row) && column.value(row) !== null;
+    return column.enabled(row) && column.text(row) !== null;
 });
 
 const expose: FTableCellApi = { tabstopEl: targetElement };
@@ -21,7 +21,7 @@ defineExpose(expose);
 <template>
     <td v-if="renderAnchor" class="table-ng__cell table-ng__cell--anchor">
         <a ref="target" class="anchor anchor--block" target="_blank" :href="column.href" tabindex="-1">
-            {{ column.value(row) }}
+            {{ column.text(row) }}
         </a>
     </td>
     <td v-else ref="target" tabindex="-1" class="table-ng__cell"></td>

--- a/packages/vue-labs/src/components/FTable/ITableButton.vue
+++ b/packages/vue-labs/src/components/FTable/ITableButton.vue
@@ -23,7 +23,7 @@ function onClickButton(): void {
 }
 
 const renderButton = computed(() => {
-    return column.enabled(row) && column.value(row) !== null;
+    return column.enabled(row) && column.text(row) !== null;
 });
 
 const expose: FTableCellApi = { tabstopEl: renderButton.value ? buttonElement : tdElement };
@@ -34,7 +34,7 @@ defineExpose(expose);
     <td v-if="renderButton" class="table-ng__cell table-ng__cell--button">
         <button ref="button" class="icon-button" type="button" tabindex="-1" @click="onClickButton">
             <f-icon v-if="column.icon" :name="column.icon"></f-icon>
-            <span class="sr-only">{{ column.value(row) }}</span>
+            <span class="sr-only">{{ column.text(row) }}</span>
         </button>
     </td>
     <td v-else ref="td" tabindex="-1" class="table-ng__cell"></td>

--- a/packages/vue-labs/src/components/FTable/ITableCheckbox.vue
+++ b/packages/vue-labs/src/components/FTable/ITableCheckbox.vue
@@ -25,9 +25,16 @@ defineExpose(expose);
 
 <template>
     <td v-if="column.editable(row)" class="table-ng__cell table-ng__cell--checkbox">
-        <input ref="target" :checked="column.value(row)" type="checkbox" :aria-label tabindex="-1" @change="onChange" />
+        <input
+            ref="target"
+            :checked="column.checked(row)"
+            type="checkbox"
+            :aria-label
+            tabindex="-1"
+            @change="onChange"
+        />
     </td>
     <td v-else ref="target" tabindex="-1" class="table-ng__cell table-ng__cell--checkbox">
-        <input :checked="column.value(row)" type="checkbox" :aria-label />
+        <input :checked="column.checked(row)" type="checkbox" :aria-label />
     </td>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableRadio.vue
+++ b/packages/vue-labs/src/components/FTable/ITableRadio.vue
@@ -27,6 +27,6 @@ defineExpose(expose);
 
 <template>
     <td class="table-ng__cell table-ng__cell--radio">
-        <input ref="input" type="radio" :checked="column.value(row)" :aria-label tabindex="-1" @change="onChange" />
+        <input ref="input" type="radio" :checked="column.checked(row)" :aria-label tabindex="-1" @change="onChange" />
     </td>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableRowheader.vue
+++ b/packages/vue-labs/src/components/FTable/ITableRowheader.vue
@@ -9,6 +9,6 @@ const { row, column } = defineProps<{
 
 <template>
     <th ref="th" class="table-ng__cell table-ng__cell--rowheader" scope="row">
-        {{ column.value(row) }}
+        {{ column.text(row) }}
     </th>
 </template>

--- a/packages/vue-labs/src/components/FTable/ITableSelect.vue
+++ b/packages/vue-labs/src/components/FTable/ITableSelect.vue
@@ -23,7 +23,7 @@ const editRef = useTemplateRef("edit");
 
 const { stopEdit } = useStartStopEdit();
 
-const viewValue = ref(column.value(row));
+const viewValue = ref(column.selected(row));
 
 const ariaLabel = computed(() => {
     const value = column.label(row);
@@ -273,7 +273,7 @@ function cancel(): void {
         ></i-combobox-dropdown>
     </td>
     <td v-else tabindex="-1" class="table-ng__cell table-ng__cell--static">
-        {{ column.value(row) }}
+        {{ column.selected(row) }}
     </td>
 </template>
 

--- a/packages/vue-labs/src/components/FTable/ITableSelectable.vue
+++ b/packages/vue-labs/src/components/FTable/ITableSelectable.vue
@@ -42,7 +42,7 @@ const multiSelectColumn: NormalizedTableColumnCheckbox<T, K> = {
         /** Screen reader text for checkbox in multi select table row. */
         return $t("fkui.table.selectable.checkbox", "Välj rad");
     },
-    value() {
+    checked() {
         return state;
     },
     editable() {
@@ -65,7 +65,7 @@ const singleSelectColumn: NormalizedTableColumnRadio<T, K> = {
         /** Screen reader text for radio button in single select table row. */
         return $t("fkui.table.selectable.radio", "Välj rad");
     },
-    value() {
+    checked() {
         return state;
     },
     update() {

--- a/packages/vue-labs/src/components/FTable/examples/FTableColumnLiveExample.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableColumnLiveExample.vue
@@ -115,13 +115,13 @@ const columnData: Record<TableColumnType, TableColumn<Row>> = {
     anchor: {
         type: "anchor",
         header: "Länk",
-        value: () => "value",
+        text: () => "value",
         href: "#",
     },
     button: {
         type: "button",
         header: "Knapp",
-        value: () => "value",
+        text: () => "value",
         icon: "bell",
     },
     select: {

--- a/packages/vue-labs/src/components/FTable/examples/FTableExample.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableExample.vue
@@ -71,7 +71,7 @@ const columns = defineTableColumns<Row>([
         header: "Knapp",
         icon: "trashcan",
         size: "shrink",
-        value(row) {
+        text(row) {
             return `Ta bort ${row.id}`;
         },
         onClick: onRemoveRow,
@@ -80,7 +80,7 @@ const columns = defineTableColumns<Row>([
         header: "Länk",
         type: "anchor",
         href: "#",
-        value() {
+        text() {
             return "Länktext";
         },
     },

--- a/packages/vue-labs/src/components/FTable/examples/FTableLiveExample.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableLiveExample.vue
@@ -67,7 +67,7 @@ const columnsBase = defineTableColumns<Row>([
         type: "button",
         header: "Knapp",
         icon: "bell",
-        value(row) {
+        text(row) {
             return `Exempeltext för knapp med id ${row.id}`;
         },
         onClick: (row) => {
@@ -78,7 +78,7 @@ const columnsBase = defineTableColumns<Row>([
         header: "Länk",
         type: "anchor",
         href: "#",
-        value() {
+        text() {
             return "Länktext";
         },
     },
@@ -117,7 +117,7 @@ const columnsWithHeader = [
         {
             type: "rowheader",
             header: "Oformaterad text",
-            value(row) {
+            text(row) {
                 /* eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion -- technical debt */
                 return String(row.antal);
             },

--- a/packages/vue-labs/src/components/FTable/table-column.ts
+++ b/packages/vue-labs/src/components/FTable/table-column.ts
@@ -92,7 +92,7 @@ export interface TableColumnRowHeader<
 > extends TableColumnBase {
     type: "rowheader";
     key?: K;
-    value?(this: void, row: T): string;
+    text?(this: void, row: T): string;
 }
 
 /**
@@ -107,7 +107,7 @@ export interface NormalizedTableColumnRowHeader<
         row: T;
         column: NormalizedTableColumnRowHeader<T, K>;
     }>;
-    value(this: void, row: T): string;
+    text(this: void, row: T): string;
 }
 
 /**
@@ -120,7 +120,7 @@ export interface TableColumnCheckbox<
     type: "checkbox";
     key?: K;
     label?(this: void, row: T): string;
-    value?(this: void, row: T): boolean;
+    checked?(this: void, row: T): boolean;
     update?(this: void, row: T, newValue: boolean, oldValue: boolean): void;
     editable?: boolean | ((this: void, row: T) => boolean);
 }
@@ -138,7 +138,7 @@ export interface NormalizedTableColumnCheckbox<
         column: NormalizedTableColumnCheckbox<T, K>;
     }>;
     label(this: void, row: T): string;
-    value(this: void, row: T): boolean;
+    checked(this: void, row: T): boolean;
     update(this: void, row: T, newValue: boolean, oldValue: boolean): void;
     editable(this: void, row: T): boolean;
 }
@@ -153,7 +153,7 @@ export interface TableColumnRadio<
     type: "radio";
     key?: K;
     label?(this: void, row: T): string;
-    value?(this: void, row: T): boolean;
+    checked?(this: void, row: T): boolean;
     update?(this: void, row: T, newValue: boolean, oldValue: boolean): void;
 }
 
@@ -170,7 +170,7 @@ export interface NormalizedTableColumnRadio<
         column: NormalizedTableColumnRadio<T, K>;
     }>;
     label(this: void, row: T): string;
-    value(this: void, row: T): boolean;
+    checked(this: void, row: T): boolean;
     update(this: void, row: T, newValue: boolean, oldValue: boolean): void;
 }
 
@@ -274,7 +274,7 @@ export interface TableColumnAnchor<
 > extends TableColumnBase {
     type: "anchor";
     key?: K;
-    value(this: void, row: T): string | null;
+    text(this: void, row: T): string | null;
     enabled?: boolean | ((this: void, row: T) => boolean);
     href: string;
 }
@@ -292,7 +292,7 @@ export interface NormalizedTableColumnAnchor<
         row: T;
         column: NormalizedTableColumnAnchor<T, K>;
     }>;
-    value(this: void, row: T): string | null;
+    text(this: void, row: T): string | null;
     enabled(this: void, row: T): boolean;
 }
 
@@ -305,7 +305,7 @@ export interface TableColumnButton<
 > extends TableColumnBase {
     type: "button";
     key?: K;
-    value(this: void, row: T): string | null;
+    text(this: void, row: T): string | null;
     onClick?(this: void, row: T): void;
     enabled?: boolean | ((this: void, row: T) => boolean);
     icon?: string;
@@ -324,7 +324,7 @@ export interface NormalizedTableColumnButton<
         row: T;
         column: NormalizedTableColumnButton<T, K>;
     }>;
-    value(this: void, row: T): string | null;
+    text(this: void, row: T): string | null;
     onClick?(this: void, row: T): void;
     enabled(this: void, row: T): boolean;
 }
@@ -339,7 +339,7 @@ export interface TableColumnSelect<
     type: "select";
     key?: K;
     label?(this: void, row: T): string;
-    value?(this: void, row: T): string;
+    selected?(this: void, row: T): string;
     update?(this: void, row: T, newValue: string, oldValue: string): void;
     editable?: boolean | ((this: void, row: T) => boolean);
     options: string[];
@@ -359,7 +359,7 @@ export interface NormalizedTableColumnSelect<
         column: NormalizedTableColumnSelect<T, K>;
     }>;
     label(this: void, row: T): string;
-    value(this: void, row: T): string;
+    selected(this: void, row: T): string;
     update(this: void, row: T, newValue: string, oldValue: string): void;
     editable(this: void, row: T): boolean;
 }
@@ -553,7 +553,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 description,
                 size,
                 label: getLabelFn(column.label),
-                value: getValueFn(column.value, column.key, Boolean, false),
+                checked: getValueFn(column.checked, column.key, Boolean, false),
                 update: getUpdateFn(column.update, column.key),
                 editable:
                     typeof column.editable === "function"
@@ -570,7 +570,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 description,
                 size,
                 label: getLabelFn(column.label),
-                value: getValueFn(column.value, column.key, Boolean, false),
+                checked: getValueFn(column.checked, column.key, Boolean, false),
                 update: getUpdateFn(column.update, column.key),
                 sortable: column.key ?? null,
                 component: ITableRadio,
@@ -660,7 +660,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 header: toRef(column.header),
                 description,
                 size,
-                value: getValueFn(column.value, column.key, String, ""),
+                text: getValueFn(column.text, column.key, String, ""),
                 sortable: column.key ?? null,
                 component: ITableRowheader,
             } satisfies NormalizedTableColumnRowHeader<T, K>;
@@ -671,7 +671,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 header: toRef(column.header),
                 description,
                 size,
-                value: getValueFn(column.value, column.key, String, ""),
+                text: getValueFn(column.text, column.key, String, ""),
                 href: column.href,
                 enabled:
                     typeof column.enabled === "function"
@@ -687,7 +687,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 header: toRef(column.header),
                 description,
                 size,
-                value: getValueFn(column.value, column.key, String, ""),
+                text: getValueFn(column.text, column.key, String, ""),
                 onClick: column.onClick,
                 enabled:
                     typeof column.enabled === "function"
@@ -705,7 +705,7 @@ export function normalizeTableColumn<T, K extends keyof T = keyof T>(
                 description,
                 size,
                 label: getLabelFn(column.label),
-                value: getValueFn(column.value, column.key, String, ""),
+                selected: getValueFn(column.selected, column.key, String, ""),
                 update: getUpdateFn(column.update, column.key),
                 editable:
                     typeof column.editable === "function"

--- a/packages/vue-labs/src/cypress/FTable.pageobject.cy.ts
+++ b/packages/vue-labs/src/cypress/FTable.pageobject.cy.ts
@@ -73,7 +73,7 @@ const columns = defineTableColumns<(typeof rows)[number]>([
         description: "Column 4",
         key: "button",
         icon: "trashcan",
-        value(row) {
+        text(row) {
             return row.button;
         },
     },
@@ -83,7 +83,7 @@ const columns = defineTableColumns<(typeof rows)[number]>([
         type: "anchor",
         key: "anchor",
         href: "#",
-        value(row) {
+        text(row) {
             return row.anchor;
         },
     },

--- a/packages/vue-labs/src/demo/Demo-2-FTable.vue
+++ b/packages/vue-labs/src/demo/Demo-2-FTable.vue
@@ -79,7 +79,7 @@ const columns = defineTableColumns<FruitOrder>([
         editable(row) {
             return !erp.isReadonly(row);
         },
-        value(row) {
+        selected(row) {
             return row.orderflode;
         },
         update(row, value) {
@@ -116,7 +116,7 @@ const columns = defineTableColumns<FruitOrder>([
         header: "Spårningsnummer",
         type: "anchor",
         href: "#",
-        value(row) {
+        text(row) {
             return row.tracking;
         },
     },
@@ -127,7 +127,7 @@ const columns = defineTableColumns<FruitOrder>([
         enabled(row) {
             return row.status === OrderStatus.PENDING;
         },
-        value() {
+        text() {
             return "Bekräfta";
         },
         onClick(row) {
@@ -141,7 +141,7 @@ const columns = defineTableColumns<FruitOrder>([
         enabled(row) {
             return row.status === OrderStatus.CONFIRMED || row.status === OrderStatus.PROCESSING;
         },
-        value() {
+        text() {
             return "Plocka";
         },
         onClick(row) {
@@ -159,7 +159,7 @@ const columns = defineTableColumns<FruitOrder>([
         enabled(row) {
             return row.status === OrderStatus.INTRANSIT && row.invoice === null;
         },
-        value() {
+        text() {
             return "Fakturera";
         },
         onClick(row) {
@@ -173,7 +173,7 @@ const columns = defineTableColumns<FruitOrder>([
         enabled(row) {
             return row.status === OrderStatus.PENDING || row.status === OrderStatus.CONFIRMED;
         },
-        value() {
+        text() {
             return "Makulera";
         },
     },


### PR DESCRIPTION
Byter namn på `value()` där det inte är rimligt namn (in my opinion):

* Länkar -> `text()`
* Knappar -> `text()`
* Radrubrik -> `text()`
* Kryssruta -> `checked()`
* Radioknapp -> `selected()` (fast `checked()` är kanske bättre?)
* Dropplista -> `selected()`