### PR TITLE
refactor: extract common styling for checkbox/radio button into `selectable-item` (refs SFKUI-6500)

### DIFF
--- a/packages/design/src/components/_index.scss
+++ b/packages/design/src/components/_index.scss
@@ -39,6 +39,7 @@
 @forward "progressbar/variables";
 @forward "radio-button/variables";
 @forward "select-field/variables";
+@forward "selectable-item/variables";
 @forward "sort-filter-dataset/variables";
 @forward "static-panel/variables";
 @forward "table/variables";
@@ -89,6 +90,7 @@
 @use "progressbar";
 @use "radio-button";
 @use "select-field";
+@use "selectable-item";
 @use "sort-filter-dataset";
 @use "static-panel";
 @use "table";

--- a/packages/design/src/components/checkbox/_checkbox-group.scss
+++ b/packages/design/src/components/checkbox/_checkbox-group.scss
@@ -1,5 +1,5 @@
 @use "../../core/size";
-@use ".././radio-button/item";
+@use ".././selectable-item/selectable-item";
 
 .checkbox-group {
     &__content {

--- a/packages/design/src/components/radio-button/_radio-button-group.scss
+++ b/packages/design/src/components/radio-button/_radio-button-group.scss
@@ -1,7 +1,7 @@
 @use "../../core/size";
 @use "../../core/mixins/breakpoints" as bp;
+@use "../selectable-item/selectable-item";
 @use "./radio-button";
-@use "./item";
 
 .radio-button-group {
     &__content {

--- a/packages/design/src/components/radio-button/_variables.scss
+++ b/packages/design/src/components/radio-button/_variables.scss
@@ -11,6 +11,3 @@ $radio-button-color-background-disabled: var(--fkds-color-background-disabled) !
 $radio-button-color-border-default: var(--fkds-color-border-primary) !default;
 $radio-button-color-border-selected: transparent !default;
 $radio-button-color-border-disabled: var(--fkds-color-border-disabled) !default;
-
-// RADIO BUTTON WITH BORDER
-$radio-button-border-color-border-default: var(--fkds-color-border-primary) !default;

--- a/packages/design/src/components/selectable-item/_index.scss
+++ b/packages/design/src/components/selectable-item/_index.scss
@@ -1,0 +1,1 @@
+@use "selectable-item";

--- a/packages/design/src/components/selectable-item/_selectable-item.scss
+++ b/packages/design/src/components/selectable-item/_selectable-item.scss
@@ -12,7 +12,7 @@
     }
 
     input:focus + label {
-        outline: 2px solid $radio-button-border-color-border-default;
+        outline: 2px solid $selectable-item-button-border-color-border-default;
         outline-offset: -2px;
     }
     input + label::after {

--- a/packages/design/src/components/selectable-item/_variables.scss
+++ b/packages/design/src/components/selectable-item/_variables.scss
@@ -1,0 +1,2 @@
+// SELECTABLE ITEM BUTTON WITH BORDER
+$selectable-item-button-border-color-border-default: var(--fkds-color-border-primary) !default;


### PR DESCRIPTION
Splittrad ifrån #929:

> **Off topic**
> Varför ligger styling för kryssrutor i mappen `radio-button`?
> Borde inte styling för kryssrutor ligga i mappen `checkbox` eller en delad mapp för kryssrutor/radioknappar?

_Originally posted by @udenius in https://github.com/Forsakringskassan/designsystem/pull/929#discussion_r2689241104_

Jag har valt att extrahera den gemensamma stylingen för kryssruta/radioknapp från `radio-button/_item` till `selectable-item/_selectable-item`.
Det leder till att `checkbox` inte längre har ett beroende till `radio-button`.

Det finns betydligt mer gemensam styling i `checkbox` och `radio-button` som skulle kunna samordnas i `selectable-item`.