### PR TITLE
fix: `not-allowed` cursor displayed for disabled chips (fixes SFKUI-7537)

### DIFF
--- a/packages/design/src/components/chip/_chip.scss
+++ b/packages/design/src/components/chip/_chip.scss
@@ -25,7 +25,6 @@ $chip-border-width: var(--f-border-width-medium);
                     background: $chip-color-background-disabled;
                     border-color: $chip-color-border-disabled;
                     color: $chip-color-text-disabled;
-                    cursor: not-allowed;
 
                     @media (forced-colors: active) {
                         color: GrayText;


### PR DESCRIPTION
**Liveexempel**
https://forsakringskassan.github.io/designsystem/pr-preview/pr-940/components/chip.html