### PR TITLE
refactor: `ITableSelect` prevent default space scroll (refs SFKUI-7580)

### DIFF
--- a/packages/vue-labs/src/components/FTable/ITableSelect.vue
+++ b/packages/vue-labs/src/components/FTable/ITableSelect.vue
@@ -150,6 +150,10 @@ async function onEditKeyDown(e: KeyboardEvent): Promise<void> {
             e.preventDefault();
             setPreviousOption();
             break;
+        case "Space":
+            // Prevent default scrolling with space while editing dropdown.
+            e.preventDefault();
+            break;
         default:
             break;
     }


### PR DESCRIPTION
Blockerar spacebar när man använder dropdown så att den har samma beteende som select elementet.

https://forsakringskassan.github.io/designsystem/pr-preview/pr-965/vue-labs/components/FTable/