### PR TITLE
fix: revert typescript config emit (refs SB-4982)

### DIFF
--- a/packages/tsconfig/presets/tsconfig-cypress.json
+++ b/packages/tsconfig/presets/tsconfig-cypress.json
@@ -5,7 +5,6 @@
     "compilerOptions": {
         "module": "esnext",
         "moduleResolution": "bundler",
-        "noEmit": true,
         "resolveJsonModule": true,
         "strict": true,
         "target": "esnext",

--- a/packages/vue-labs/tsconfig.cypress.json
+++ b/packages/vue-labs/tsconfig.cypress.json
@@ -5,7 +5,6 @@
         "outDir": "temp",
         "rootDir": "src",
         "target": "es2023",
-        "noEmit": false,
         "emitDeclarationOnly": true,
         "allowSyntheticDefaultImports": true,
         "declarationDir": "temp/cypress",

--- a/packages/vue/tsconfig.cypress.json
+++ b/packages/vue/tsconfig.cypress.json
@@ -4,7 +4,6 @@
         "composite": true,
         "outDir": "temp",
         "rootDir": "src",
-        "noEmit": false,
         "emitDeclarationOnly": true,
         "allowSyntheticDefaultImports": true,
         "declarationDir": "temp/cypress",


### PR DESCRIPTION
This reverts commit a29becbdcf1c4e997f5f546fa1d104bccff8c6c5.

Backar då tidigare ändring gav sidoeffekter i applikationer till följd att de inte kunde bygga.