### PR TITLE
docs: add doc for `FTableColumn` variants

### DIFF
--- a/packages/vue-labs/docs/components/FTable/FTable-columns.md
+++ b/packages/vue-labs/docs/components/FTable/FTable-columns.md
@@ -1,0 +1,370 @@
+---
+title: Kolumntyper - AI
+status: Draft
+layout: component
+sortorder: 1
+component:
+    - FTable
+    - TableColumn
+search:
+    terms:
+        - radrubrik
+        - kolumntyper
+---
+
+## FTable — Kolumntyper
+
+Denna sida beskriver alla kolumntyper som FTable stödjer och deras egenskaper,
+beteenden vid visning och redigering, samt exempel på hur de används.
+
+## Översikt
+
+FTable accepterar kolumnbeskrivningar via `defineTableColumns([...])`. Varje kolumn beskrivs med en union-typ som omfattar olika specialiseringar (text, checkbox, radio, mm). Fält som `key` används för värde-åtkomst och sortering; specialiserade text-typer använder interna parser/formatter/validation-konfigurationer.
+
+## Gemensamma egenskaper (TableColumnBase)
+
+Alla kolumntyper delar följande proppar:
+
+- `header` (`string` | `Ref<string>`) — kolumnrubrik som visas i thead.
+- `description?` (`string` | `Ref<string | null>`) — valfri beskrivning/formatbeskrivning.
+- `size?` ("grow" | "shrink" | Ref<...>) — hur kolumnen skalas. Standard: "grow".
+
+Basnormalisering (internt) ger varje kolumn:
+
+- unikt `id` (Symbol), `header` som Ref, `description` som Ref och `size` som Ref.
+
+## Kolumntyper — detaljer
+
+Följande avsnitt förklarar var och en av kolumntyperna, deras viktiga proppar och rekommendationer.
+
+### text (allmänt)
+
+- `type`: `"text"` eller specialvarianter `text:...`.
+- Används för fri text och för redigerbara fält.
+- Vanliga proppar:
+    - `key?: K` — property i row som används för värde och sortering.
+    - `label?(row): string` — label för redigerbart fält.
+    - `value?(row): string` — egen value-funktion (annars används key).
+    - `update?(row, newValue, oldValue)` — callback vid ändring.
+    - `editable?: boolean | (row => boolean)` — om cellen är redigerbar.
+    - `tnum?: boolean` — tabular figures (sätts automatiskt för vissa typer).
+    - `align?: "left" | "right"` — textjustering.
+
+Observera: specialiserade `text:...`-typer (t.ex. `text:currency`, `text:personnummer`) har parser/formatter/validation kopplat via `input-fields-config`.
+
+### Specialiserade text-typer (lista)
+
+Följande `text:...`-typer finns implementerade:
+
+- text:personnummer
+- text:bankAccountNumber
+- text:bankgiro
+- text:clearingNumber
+- text:currency
+- text:date
+- text:email
+- text:organisationsnummer
+- text:number
+- text:percent
+- text:phoneNumber
+- text:plusgiro
+- text:postalCode
+
+Nedan följer per-typ sammanfattning av beteende och rekommendationer.
+
+#### text:personnummer
+
+- Formatter/parser: normaliserar och formatterar personnummer (via @fkui/logic).
+- Validering: personnummerformat + Luhn + maxLength.
+- Input-attribut: inputmode=numeric, maxlength=23.
+- Modell: rekommenderas string (parser normaliserar format).
+
+```ts
+interface TableRow {
+    id: string;
+    pnr: string;
+}
+
+const columns = defineTableColumns<TableRow, keyof TableRow>([
+    {
+        type: "text:personnummer",
+        header: "Personnummer",
+        key: "pnr",
+        editable: true,
+        label: (row) => `Personnummer för rad ${row.id}`,
+    },
+]);
+```
+
+#### text:bankAccountNumber
+
+- Parser/formatter: parseBankAccountNumber.
+- Validering: bankAccountNumber.
+- Attribut: inputmode=numeric, maxlength=40.
+- Modell: string.
+
+#### text:bankgiro
+
+- Parser/formatter: parseBankgiro.
+- Validering: bankgiro + maxLength.
+- Attribut: inputmode=numeric, maxlength=40.
+- Modell: string.
+
+#### text:clearingNumber
+
+- Parser/formatter: parseClearingNumber (trim).
+- Validering: clearingNumber.
+- Attribut: inputmode=numeric, maxlength=16.
+- Modell: string.
+
+#### text:currency
+
+- Formatter: formatNumber (tusentalsavgränsare).
+- Parser: parseNumber.
+- Validering: currency, integer.
+- Attribut: inputmode=numeric, maxlength=20.
+- Modell: kan sparas som number vid lyckad parse; annars sträng.
+
+#### text:number
+
+- Formatter/parser: formatNumber/parseNumber, stöder `decimals`.
+- Validering: number.
+- Attribut: inputmode=numeric, maxlength=20.
+- Modell: number vid lyckad parse.
+
+#### text:percent
+
+- Formatter/parser: formatNumber/parseNumber med decimals.
+- Validering: percent, min/max (0–999).
+- Attribut: inputmode=numeric, maxlength=20.
+- Modell: number.
+
+#### text:date
+
+- Formatter/parser: parseDate (ex. YYYY-MM-DD).
+- Validering: date.
+- Attribut: input type text (fungerar med datumformat-kontroller).
+- Modell: string i ISO-liknande format.
+
+#### text:email
+
+- Formatter/parser: ingen automatiserad formatering (returnerar value).
+- Validering: email-format + maxLength.
+- Attribut: type=email, maxlength=80.
+- Modell: string (sparas exakt som inmatat).
+
+#### text:organisationsnummer
+
+- Formatter/parser: parseOrganisationsnummer.
+- Validering: organisationsnummer + maxLength.
+- Attribut: inputmode=numeric, maxlength=20.
+- Modell: string.
+
+#### text:phoneNumber
+
+- Formatter/parser: specialfunktion (från logikpaketet).
+- Attribut: inputmode=numeric.
+- Modell: string.
+
+#### text:plusgiro
+
+- Formatter/parser: parsePlusgiro.
+- Validering: relevant plusgiro-format.
+- Attribut: inputmode=numeric.
+- Modell: string.
+
+#### text:postalCode
+
+- Formatter/parser: formatPostalCode / parse.
+- Validering: postnummer-specifik.
+- Attribut: inputmode=numeric.
+- Modell: string.
+
+### checkbox
+
+- `type: "checkbox"`.
+- Proppar:
+    - `key?: K`
+    - `label?(row): string`
+    - `checked?(row): boolean`
+    - `update?(row, newVal, oldVal)`
+    - `editable?: boolean | (row => boolean)`
+- Beteende: visas som en kryssruta; `checked` eller `key` används för status; `update` kallas vid ändring.
+
+### radio
+
+- `type: "radio"`.
+- Proppar:
+    - `key?: K`
+    - `label?(row): string`
+    - `checked?(row): boolean`
+    - `update?(row, newVal, oldVal)`
+    - `editable?: boolean | (row => boolean)`
+- Används när en kolumn representerar en radiovalsstatus.
+
+### rowheader (radrubrik)
+
+- `type: "rowheader"`.
+- Används för celler som ska vara rad-rubriker (t.ex. identifierare).
+- Ger förbättrad tillgänglighet: cellen markeras som radrubrik (th scope=row).
+- Proppar:
+    - `text?(row)`
+    - `key?`.
+- Rekommendation: använd när en cell tydligt identifierar raden och du vill underlätta skärmläsarnavigering.
+
+### anchor (länk)
+
+- `type: "anchor"`.
+- Proppar:
+    - `text(row): string | null`
+    - `href: string` — länkens url (kan vara statisk eller interpolerad).
+    - `enabled?: boolean | (row => boolean)`
+- Beteende: visas som länk; `enabled` kan styra om länken ska vara interaktiv.
+
+### button
+
+- `type: "button"`.
+- Proppar:
+    - `text(row): string | null`
+    - `onClick?(row)` — callback vid knappklick.
+    - `icon?: string`
+    - `enabled?: boolean | (row => boolean)`
+
+### select (dropplista)
+
+- `type: "select"`.
+- Proppar:
+    - `options: string[]`
+    - `selected?(row): string`
+    - `update?(row, newVal, oldVal)`
+    - `editable?: boolean | (row => boolean)`
+    - `label?(row)`
+- Presenteras som ett select-fält i redigeringsläge.
+
+### menu (kontextmeny)
+
+- `type: "menu"`.
+- Proppar:
+    - `text(row): string | null`
+    - `enabled?: boolean | (row => boolean)`
+    - `actions?: Array<{ label: string; icon?: string; onClick?(row): void }>`
+- Beteende: visar en meny med actions; varje action får onClick-row callback.
+
+### render (egendefinierad rendering)
+
+- Ingen `type` — istället används `render(this, row)` i kolumn-objektet.
+- Returnerar en VNode eller Component.
+- Använd när full kontroll över cellens DOM/komponentinnehåll behövs.
+- Normaliseras till typ `undefined` internt och blir normalt inte sortbar.
+
+### simple (ingen type - read-only)
+
+- Om `type` inte sätts i kolumnobjektet används en "simple" kolumn som normaliseras till en text-kolumn med default-värden: icke-redigerbar, ingen label, etc.
+- Praktiskt för snabba read-only-kolumner.
+
+## Sortering, storlek och synlighet
+
+- Sortering:
+    - En kolumn blir sorteringsbar om `sortable` sätts internt från `key` (d.v.s. om du anger `key` i kolumnen).
+    - Tabell-komponenten kan hantera uppdatering av sort-order via interna funktioner (se `updateSortOrder` i koden).
+
+- Storlek (size):
+    - `size` kan vara `"grow"` (expanderar) eller `"shrink"` (krymper).
+    - Du kan också använda `expand` / `shrink` props på komponentnivå (beroende på implementation) för att påverka kolumnens layout.
+
+- Synlighet:
+    - Intern logik tillåter att kolumner göms/visas (funktioner som `setVisibilityColumn` används av API).
+
+## Redigering, parser/formatter och validering
+
+- Specialiserade text-typer använder centrala parser/formatter/validation-konfig i `input-fields-config.ts` (se utdrag ovan).
+- Vid redigering:
+    - Inmatningsfält får attribut från `attributes()` (t.ex. `inputmode`, `maxlength`, `type`).
+    - Parser används när användaren lämnar (blur) redigeringsläge för att omvandla visningsvärdet till modellvärde.
+    - Formatter används för att visa modellvärdet i läsvy (span) i ett formaterat sätt (t.ex. tusentalsseparator).
+    - Om parser lyckas returneras normalt en `number` för numeriska typer; vid parserfel kan modellen uppdateras med den råa strängen och cellen markeras med error-klass.
+- ValidationConfig används för att utföra valideringar och visa felmarkeringar i cellen.
+
+Testbeteenden (ur testkod):
+
+- Valuta-kolumn (`text:currency`) formaterar visning med tusentalsavgränsare och uppdaterar modell med `number` när parser lyckas.
+- Email-kolumn (`text:email`) gör ingen automatisk formatering; modellen sparas som inmatad text.
+
+## Accessibility (tillgänglighet)
+
+- Använd `rowheader` när en cell identifierar raden — detta hjälper skärmläsare att läsa ut rubriker per rad.
+- `header` och `description` kan användas som Ref för dynamiska rubriker / beskrivningar.
+- Menyer, knappar och länkar bör ha tydliga labels och aria-attribut vid behov (komponentimplementeringen tar hand om grundläggande markup).
+
+## Snabbstart / Exempel
+
+Exempel: definiera en uppsättning kolumner och rader:
+
+```ts
+import { defineTableColumns } from "@fkui/vue-labs";
+
+interface TableRow {
+    id: string;
+    name: string;
+    amount: string;
+    active: string;
+}
+const columns = defineTableColumns<TableRow, keyof TableRow>([
+    { type: "rowheader", header: "ID", key: "id" },
+    {
+        type: "text",
+        header: "Namn",
+        key: "name",
+        editable: true,
+        label: () => "Namn",
+    },
+    { type: "text:currency", header: "Belopp", key: "amount", editable: true },
+    { type: "checkbox", header: "Aktiv", key: "active" },
+    {
+        type: "button",
+        header: "Åtgärd",
+        text: () => "Ta bort",
+        onClick(row) {
+            /* ... */
+        },
+    },
+]);
+```
+
+Exempel på `text:number` med decimals:
+
+```ts
+const columns = defineTableColumns<TableRow, keyof TableRow>([
+    {
+        type: "text:number",
+        header: "Vikt",
+        key: "weight",
+        decimals: 3,
+        editable: true,
+    },
+]);
+```
+
+Exempel på `menu`-kolumn:
+
+```ts
+const columns = defineTableColumns<TableRow, keyof TableRow>([
+    {
+        type: "menu",
+        header: "Åtgärder",
+        text: (row) => `Åtgärder för ${row.id}`,
+        actions: [
+            {
+                label: "Visa",
+                icon: "search",
+                onClick: (row) => console.log("visa", row),
+            },
+            {
+                label: "Ta bort",
+                icon: "trashcan",
+                onClick: (row) => console.log("ta bort", row),
+            },
+        ],
+    },
+]);
+```

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/anchor.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/anchor.md
@@ -1,0 +1,32 @@
+---
+title: Länk
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+---
+
+## Here be dragons
+
+## Parametrar
+
+**`description:`** `string | Readonly<Ref<string | null>>` {@optional}
+: Formatbeskrivning
+
+**`enabled:`** `boolean | ((row: T): boolean => {})` {@optional}
+: Om länken ska visas.
+Default `true`.
+
+**`header:`** `string | Readonly<Ref<string>>`
+: Kolumnrubrik som visas i thead.
+
+**`key:`** `K` {@optional}
+: Kopplar cellens värde till värde i `T`.
+
+**`size:`** `TableColumnSize | Readonly<Ref<TableColumnSize | null>>` {@optional}
+: Hur kolumnens bredd skalas. `"grow"` ger största möjliga bredd och `"shrink"` minsta möjliga bredd.
+Default: `grow`.
+
+**`type:`** `InputTypeText`
+: Kolumnens typ, sätts till `anchor`.

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/button.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/button.md
@@ -1,0 +1,41 @@
+---
+title: Knapp
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+---
+
+## Here be dragons
+
+## Parametrar
+
+**`description:`** `string | Readonly<Ref<string | null>>` {@optional}
+: Formatbeskrivning
+
+**`enabled:`** `boolean | ((row: T): boolean => {})` {@optional}
+: Om knappen ska visas.
+Default `true`.
+
+**`header:`** `string | Readonly<Ref<string>>`
+: Kolumnrubrik som visas i thead.
+
+**`icon`** `string` {@optional}
+: Namn på den ikon som ska visas på knappen, se FIcon.
+
+**`key:`** `K` {@optional}
+: Kopplar cellens värde till värde i `T`.
+
+**`onClick:`** `(row: T):void => {}` {@optional}
+: Funktion som anropas vid klick på knapp.
+
+**`size:`** `TableColumnSize | Readonly<Ref<TableColumnSize | null>>` {@optional}
+: Hur kolumnens bredd skalas. `"grow"` ger största möjliga bredd och `"shrink"` minsta möjliga bredd.
+Default: `grow`.
+
+**`text:`** `(row: T): string | null => {}`
+: Funktion som retunerar knappens text.
+
+**`type:`** `InputTypeText`
+: Kolumnens typ, sätts till `button`.

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/checkbox.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/checkbox.md
@@ -1,0 +1,41 @@
+---
+title: Kryssruta
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+---
+
+## Here be dragons
+
+## Parametrar
+
+**`checked:`** `(row: T): boolean  => {}` {@optional}
+: Funktion som avgör om kryssrutan är kryssad.
+
+**`description:`** `string | Readonly<Ref<string | null>>` {@optional}
+: Formatbeskrivning
+
+**`editable:`** `boolean | ((row: T) => boolean)  => {}` {@optional}
+: Om kryssrutan är redigerbar.
+Default `true`.
+
+**`header:`** `string | Readonly<Ref<string>>`
+: Kolumnrubrik som visas i thead.
+
+**`key:`** `K` {@optional}
+: Kopplar cellens värde till värde i `T`.
+
+**`label:`** `(row: T): string  => {}` {@optional}
+: Skärmläsartext för kryssruta.
+
+**`size:`** `TableColumnSize | Readonly<Ref<TableColumnSize | null>>` {@optional}
+: Hur kolumnens bredd skalas. `"grow"` ger största möjliga bredd och `"shrink"` minsta möjliga bredd.
+Default: `grow`.
+
+**`type:`** `InputTypeText`
+: Kolumnens typ, sätts till `checkbox`.
+
+**`update:`** `(row: T, newValue: string, oldValue: string): void  => {}` {@optional}
+: Anropas vid uppdaterat värde.

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableText.vue
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableText.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { FTable, defineTableColumns } from "@fkui/vue-labs";
+
+interface Row {
+    value1: string;
+    value2: string;
+}
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Kolumnrubrik 1",
+        key: "value1",
+    },
+    {
+        type: "text",
+        header: "Kolumnrubrik 2",
+        key: "value2",
+        editable: true,
+    },
+]);
+
+const rows = ref<Row[]>([
+    {
+        value1: "Text 1",
+        value2: "Text 2",
+    },
+    {
+        value1: "Text 3",
+        value2: "Text 4",
+    },
+    {
+        value1: "Text 5",
+        value2: "Text 6",
+    },
+]);
+</script>
+
+<template>
+    <f-table :columns :rows></f-table>
+</template>

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextBankAccount.vue
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextBankAccount.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { FTable, defineTableColumns } from "@fkui/vue-labs";
+
+interface Row {
+    bankAccountNumber: string;
+}
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text:bankAccountNumber",
+        header: "Kontonummer",
+        key: "bankAccountNumber",
+        editable: true,
+    },
+]);
+
+const rows = ref<Row[]>([
+    {
+        bankAccountNumber: "12345678",
+    },
+    {
+        bankAccountNumber: "0012345678",
+    },
+    {
+        bankAccountNumber: "123456",
+    },
+]);
+</script>
+
+<template>
+    <f-table :columns :rows></f-table>
+</template>

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextFormatter.vue
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextFormatter.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { FTable, defineTableColumns } from "@fkui/vue-labs";
+
+interface Row {
+    value1: string;
+    value2: string;
+}
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Col 1",
+        key: "value1",
+    },
+    {
+        type: "text",
+        header: "Col 2",
+        key: "value2",
+    },
+    {
+        type: "text",
+        header: "Col 3",
+        value(row: Row): string {
+            return `${row.value1}:${row.value2}`;
+        },
+        formatter(value: string): string {
+            return value.toLowerCase();
+        },
+    },
+]);
+
+const rows = ref<Row[]>([
+    {
+        value1: "A",
+        value2: "B",
+    },
+    {
+        value1: "C",
+        value2: "D",
+    },
+    {
+        value1: "E",
+        value2: "F",
+    },
+]);
+</script>
+
+<template>
+    <f-table :columns :rows></f-table>
+</template>

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextParser.vue
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextParser.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { FTable, defineTableColumns } from "@fkui/vue-labs";
+
+interface Row {
+    id: string;
+    value1: string;
+    value2: string;
+}
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Col",
+        key: "value",
+        parser(value: string): string {
+            return value.toLowerCase();
+        },
+        editable: true,
+    },
+]);
+
+const rows = ref<Row[]>([
+    {
+        value: "A",
+    },
+    {
+        value: "C",
+    },
+    {
+        value: "F",
+    },
+]);
+</script>
+
+<template>
+    <f-table :columns :rows></f-table>
+    <pre> rows: {{ rows }}</pre>
+</template>

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextUpdate.vue
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextUpdate.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { FTable, defineTableColumns } from "@fkui/vue-labs";
+
+interface Row {
+    value: string;
+}
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Col",
+        key: "value",
+        update(row: T, newValue: string, oldValue: string): void {
+            if (newValue.startsWith("a")) {
+                row.value = newValue;
+                return;
+            }
+            row.value = oldValue;
+        },
+        editable: true,
+    },
+]);
+
+const rows = ref<Row[]>([
+    {
+        value: "apelsin",
+    },
+    {
+        value: "annanas",
+    },
+    {
+        value: "avokado",
+    },
+]);
+</script>
+
+<template>
+    <f-table :columns :rows></f-table>
+    <pre> rows: {{ rows }}</pre>
+</template>

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextValidation.vue
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextValidation.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { FTable, defineTableColumns } from "@fkui/vue-labs";
+
+interface Row {
+    id: string;
+    value1: string;
+    value2: string;
+}
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Col",
+        key: "value",
+        editable: true,
+        validation: {
+            minLength: { length: 2 },
+            maxLength: { length: 3 },
+        },
+    },
+]);
+
+const rows = ref<Row[]>([
+    {
+        value: "A",
+    },
+    {
+        value: "BBB",
+    },
+    {
+        value: "CCCC",
+    },
+]);
+</script>
+
+<template>
+    <f-table :columns :rows></f-table>
+</template>

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextValue.vue
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/examples/text/FTableTextValue.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { FTable, defineTableColumns } from "@fkui/vue-labs";
+
+interface Row {
+    value1: string;
+    value2: string;
+}
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Col 1",
+        key: "value1",
+    },
+    {
+        type: "text",
+        header: "Col 2",
+        key: "value2",
+    },
+    {
+        type: "text",
+        header: "Col 3",
+        value(row): string {
+            return `${row.value1}:${row.value2}`;
+        },
+    },
+]);
+
+const rows = ref<Row[]>([
+    {
+        value1: "A",
+        value2: "B",
+    },
+    {
+        value1: "C",
+        value2: "D",
+    },
+    {
+        value1: "E",
+        value2: "F",
+    },
+]);
+</script>
+
+<template>
+    <f-table :columns :rows></f-table>
+</template>

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-bank-account-number.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-bank-account-number.md
@@ -1,0 +1,17 @@
+---
+title: Kontonummer
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:bankAccountNumber
+---
+
+## Here be dragons
+
+```import
+FTableTextBankAccount.vue
+```

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-bankgiro.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-bankgiro.md
@@ -1,0 +1,13 @@
+---
+title: Bankgiro
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:bankgiro
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-clearing-number.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-clearing-number.md
@@ -1,0 +1,13 @@
+---
+title: Clearingnummer
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:clearingNumber
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-currency.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-currency.md
@@ -1,0 +1,13 @@
+---
+title: Valuta
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:currency
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-date.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-date.md
@@ -1,0 +1,13 @@
+---
+title: Datum
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:date
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-email.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-email.md
@@ -1,0 +1,13 @@
+---
+title: Mejladress
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:email
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-number.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-number.md
@@ -1,0 +1,13 @@
+---
+title: Numeriskt
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:number
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-organisationsnummer.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-organisationsnummer.md
@@ -1,0 +1,13 @@
+---
+title: Organisationsnummer
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:organisationsnummer
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-percent.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-percent.md
@@ -1,0 +1,13 @@
+---
+title: Procent
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:percent
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-personnummer.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-personnummer.md
@@ -1,0 +1,13 @@
+---
+title: Personnummer
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:personnummer
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-phoneNumber.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-phoneNumber.md
@@ -1,0 +1,13 @@
+---
+title: Telefonnummer
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:phoneNumber
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-plusgiro.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-plusgiro.md
@@ -1,0 +1,13 @@
+---
+title: Plusgiro
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:plusgiro
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-postal-code.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/Specialiserade/text-postal-code.md
@@ -1,0 +1,13 @@
+---
+title: Postnummer
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+search:
+    terms:
+        - text:postalCode
+---
+
+## Here be dragons

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/index.json
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/index.json
@@ -1,0 +1,3 @@
+{
+    "title": "Textfält"
+}

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/group/index.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/group/index.md
@@ -1,0 +1,350 @@
+---
+title: Textfält
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+    - TableColumn
+---
+
+Kolumntypen `text` används för att visa text i `FTable`, texten går att anpassa med egen formaterare, parser och validator.
+
+Tabellens kolumner och dess egenskaper defineras med hjälp av hjälpfunktionen `defineTableColumns`.
+
+```ts name=column-base
+interface Row {
+    value: string;
+}
+
+const rows = ref<Row[]>([
+    {
+        value: "It´s a string",
+    },
+]);
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Kolumnrubrik",
+        key: "value",
+    },
+]);
+```
+
+Nedan visas ett komplett exempel tillsammans med `FTable`.
+
+```import
+FTableText.vue
+```
+
+## Value
+
+Texten som ska visas kan manipuleras med hjälp av callbackfunktionen `value(row: T): string`. Parametern `row` innehåller det aktuella rad-objektet.
+
+```ts compare=column-base
+interface Row {
+    value: string;
+}
+
+const rows = ref<Row[]>([
+    {
+        value: "It´s a string",
+    },
+]);
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Kolumnrubrik",
+        value(row): string {
+            const newValue = row.value;
+            /* do stuff with newValue */
+            return newValue;
+        },
+    },
+]);
+```
+
+I exemplet nedan visas hur man med hjälp av `value()` kan slå samman två värden för att visa i en egen kolumn.
+
+```import
+FTableTextValue.vue
+```
+
+## Formaterare
+
+Om innehållet i rad-objektet behöver formateras innan det visas i tabellen så används callbackfunktionen `formatter(value: string): string`.
+Inparametern `value` är värdet från rad-objektet vars prop matchar värdet i kolumndefinitionens `key`.
+Om formateraren kombineras med callbackfunktionen `value()` så anropas den med resultatet från `value()` som inparameter.
+Om formateraren kombineras med validering så krävs en lyckad validering för att formatteraren ska anropas.
+
+```ts compare=column-base
+interface Row {
+    value: string;
+}
+
+const rows = ref<Row[]>([
+    {
+        value: "It´s a string",
+    },
+]);
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Kolumnrubrik",
+        key: "value",
+        formatter(value: string): string {
+            const newValue = value;
+            /* do stuff with newValue */
+            return newValue;
+        },
+    },
+]);
+```
+
+Exemplet nedan visar hur formateraren gör om texten till gemener.
+
+```import
+FTableTextFormatter.vue
+```
+
+## Parsning
+
+Om cellen är redigerbar så kan datan manipuleras innan den skrivs ned i rad-objeket, det görs med hälp av callbackfunktionen `parser(value: string): string | undefined`.
+Parsern anropas med cellens värde då editeringen avslutas.
+Om parsern kombineras med validering så krävs en lyckad validering för att parsern ska anropas.
+
+```ts compare=column-base
+interface Row {
+    value: string;
+}
+
+const rows = ref<Row[]>([
+    {
+        value: "It´s a string",
+    },
+]);
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Kolumnrubrik",
+        key: "value",
+        editable: true,
+        parser(value: string): string {
+            const newValue = value;
+            /* do stuff with newValue */
+            return newValue;
+        },
+    },
+]);
+```
+
+Nedan visas ett exempel där inmatad text görs om till gemener då editering av celll avslutas.
+Notera att parsen inte anropas förens editeringen avslutas, därav så innehåller rad-objektet versaler ända tills cellen har redigerats.
+
+```import
+FTableTextParser.vue
+```
+
+## Update
+
+Som en sista möjlighet att påverka vad som skrivs ner i rad-objektet så kan callbackfunktionen `update(row: T, newValue: string, oldValue: string): void` användas.
+`update()` anropas efter eventuell parser och har tillgång till det aktuella rad-objektet `row`.
+Det nya värdet `newValue`, om pareser används så är detta det parsade värdet, samt det gamla värdet `oldValue`.
+
+```ts compare=column-base
+interface Row {
+    value: string;
+}
+
+const rows = ref<Row[]>([
+    {
+        value: "It´s a string",
+    },
+]);
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Kolumnrubrik",
+        key: "value",
+        editable: true,
+        update(row: T, newValue: string, oldValue: string): void {
+            /* do stuff */
+            row.value = "Some new value";
+        },
+    },
+]);
+```
+
+Exemplet nedan visar hur värdet i rad-objektet bara uppdateras om det nya värdet börjar på bokstaven a.
+
+```import
+FTableTextUpdate.vue
+```
+
+## Validering
+
+Redigerbara celler kan valideras med hjälp av "@link validators validatorer", det görs genom parameten `validation: ValidatorConfigs`.
+
+```ts compare=column-base
+interface Row {
+    value: string;
+}
+
+const rows = ref<Row[]>([
+    {
+        value: "It´s a string",
+    },
+]);
+
+const columns = defineTableColumns<Row>([
+    {
+        type: "text",
+        header: "Kolumnrubrik",
+        key: "value",
+        editable: true,
+        validation: {
+            minLength: { length: 2 },
+            maxLength: { length: 3 },
+        },
+    },
+]);
+```
+
+Alternativt så använder man sig av någon av de färdiga subtyperna, som motsvarar de "@link textfield-specialized specialiserade inmatningsfälten":
+
+- {@link text-bank-account-number text:bankAccountNumber}
+- text:bankgiro
+- text:clearingNumber
+- text:currency
+- text:date
+- text:email
+- text:number
+- text:organisationsnummer
+- text:percent
+- text:personnummer
+- text:phoneNumber
+- text:plusgiro
+- text:postalCode
+
+Nedan visas ett exempel där texten i cellen valideras mot både en min-längd och en max-längd.
+
+```import
+FTableTextValidation.vue
+```
+
+## Flödesdiagram
+
+```mermaid
+flowchart TD
+ accTitle: Flödesdiagram
+ accDescr: Bilden visar hur callbackfunktionerna value, formatter, parser och update förhåller sig till varandra.
+ A@{ shape: "circle", label: "row value" }
+ B@{ shape: "diam", label: "validation"}
+ C@{ shape: "rounded", label: "formatter()"}
+ E@{ shape: "rounded", label: "value()"}
+ G@{ shape: "circle", label: "view value"}
+
+  A --> E;
+  B -- NOK --> G;
+  C --> G;
+  B -- OK --> C;
+  E -- no validation--> C;
+  E --> B;
+
+ X@{ shape: "rounded", label: "parser()"}
+ Y@{ shape: "diam", label: "validation"}
+ Z@{ shape: "rounded", label: "update()"}
+
+  G --> Y;
+  Y -- OK --> X;
+  Y -- NOK --> Z;
+  G -- no validation --> X;
+  X --> Z;
+  Z --> A;
+```
+
+Alternativ layout:
+
+```mermaid
+flowchart TD
+ accTitle: Flödesdiagram
+ accDescr: Bilden visar hur callbackfunktionerna value, formatter, parser och update förhåller sig till varandra.
+ A@{ shape: "circle", label: "row value" }
+ B@{ shape: "diam", label: "validation"}
+ C@{ shape: "rounded", label: "formatter()"}
+ E@{ shape: "rounded", label: "value()"}
+ G@{ shape: "circle", label: "view value"}
+
+  A --> E;
+  B -- NOK --> G;
+  C --> G;
+  B -- OK --> C;
+  E -- no validation--> C;
+  E --> B;
+
+ V@{ shape: "circle", label: "row value" }
+ W@{ shape: "circle", label: "view value"}
+ X@{ shape: "rounded", label: "parser()"}
+ Y@{ shape: "diam", label: "validation"}
+ Z@{ shape: "rounded", label: "update()"}
+
+  W --> Y;
+  Y -- OK --> X;
+  Y -- NOK --> Z;
+  W -- no validation --> X;
+  X --> Z;
+  Z --> V;
+```
+
+## Parametrar
+
+**`align:`** `"left" | "right"` {@optional}
+: Höger eller vänsterställd text och kolumnrubrik.
+Default `left`.
+
+**`description:`** `string | Readonly<Ref<string | null>>` {@optional}
+: Formatbeskrivning
+
+**`editable:`** `boolean | ((row: T) => boolean)  => {}` {@optional}
+: Om cellen är redigerbar.
+Default `false`.
+
+**`formatter:`** `(value: string): string | undefined  => {}` {@optional}
+: Funktion som används för att formatera värdet som visas. Parametern `value` är värdet från funktionen `value()` nedan.
+Anropas ej vid misslyckad validering.
+
+**`header:`** `string | Readonly<Ref<string>>`
+: Kolumnrubrik som visas i thead.
+
+**`key:`** `K` {@optional}
+: Kopplar cellens värde till värde i `T`.
+
+**`label:`** `(row: T): string  => {}` {@optional}
+: Etikett kopplad till cellen för skärmläsare, ej synlig.
+
+**`parser:`** `(value: string): string | undefined  => {}` {@optional}
+: Funktion som parsar värdet innan `update()` anropas. Anropas ej vid misslyckad validering.
+
+**`size:`** `TableColumnSize | Readonly<Ref<TableColumnSize | null>>` {@optional}
+: Hur kolumnens bredd skalas. `"grow"` ger största möjliga bredd och `"shrink"` minsta möjliga bredd.
+Default: `grow`.
+
+**`tnum:`** `boolean` {@optional}
+: Tabular figures, till exempel att tal 111 ta samma plats som 000.
+
+**`type:`** `InputTypeText`
+: Kolumnens typ, sätts till `text`.
+
+**`update:`** `(row: T, newValue: string, oldValue: string): void  => {}` {@optional}
+: Funktion som uppdater det parsade värdet från `parse()` innan det uppdateras i rad-objektet `T`.
+
+**`validation:`** `ValidatorConfigs` {@optional}
+: Konfiguration för validering, till exempel `{ minLength: { length: 2 }, maxLength: { length: 3 }}`. Se [ValidatorConfigs](../../../logic/types/ValidatorConfigs.html)
+
+**`value`:** `(row: T): string => {}` {@optional}
+: Anropas vid läsning av värde från `T`. Ger möjlighet att manipulera värdet innan till exempel formattering.

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/menu.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/menu.md
@@ -1,0 +1,35 @@
+---
+title: Kontextmeny
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+---
+
+## Here be dragons
+
+## Parametrar
+
+**`actions:`** `Array<{ label: string, icon?: string, onClick(row: T):void }>` {@optional}
+: Lista med menyval. `label` är menyvalets text, `icon` är menyvalets ikon (se FIcon) och `onClick()` anropas vid menyval.
+
+**`description:`** `string | Readonly<Ref<string | null>>` {@optional}
+: Formatbeskrivning
+
+**`enabled:`** `boolean | ((row: T): boolean => {})` {@optional}
+: Om menyn ska visas.
+Default `true`.
+
+**`header:`** `string | Readonly<Ref<string>>`
+: Kolumnrubrik som visas i thead.
+
+**`size:`** `TableColumnSize | Readonly<Ref<TableColumnSize | null>>` {@optional}
+: Hur kolumnens bredd skalas. `"grow"` ger största möjliga bredd och `"shrink"` minsta möjliga bredd.
+Default: `grow`.
+
+**`text:`** `(row: T): string | null => {}`
+: Särmläsartext för menyns knapp.
+
+**`type:`** `InputTypeText`
+: Kolumnens typ, sätts till `menu`.

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/radio.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/radio.md
@@ -1,0 +1,41 @@
+---
+title: Radioknapp
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+---
+
+## Here be dragons
+
+## Parametrar
+
+**`checked:`** `(row: T): boolean => {}` {@optional}
+: Funktion som avgör om radioknappen är vald.
+
+**`description:`** `string | Readonly<Ref<string | null>>` {@optional}
+: Formatbeskrivning
+
+**`editable:`** `boolean | ((row: T) => boolean)  => {}` {@optional}
+: Om radioknappen är redigerbar.
+Default `true`.
+
+**`header:`** `string | Readonly<Ref<string>>`
+: Kolumnrubrik som visas i thead.
+
+**`key:`** `K` {@optional}
+: Kopplar cellens värde till värde i `T`.
+
+**`label:`** `(row: T): string  => {}` {@optional}
+: Skärmläsartext för radioknappen.
+
+**`size:`** `TableColumnSize | Readonly<Ref<TableColumnSize | null>>` {@optional}
+: Hur kolumnens bredd skalas. `"grow"` ger största möjliga bredd och `"shrink"` minsta möjliga bredd.
+Default: `grow`.
+
+**`type:`** `InputTypeText`
+: Kolumnens typ, sätts till `radio`.
+
+**`update:`** `(row: T, newValue: string, oldValue: string): void  => {}` {@optional}
+: Anropas vid uppdaterat värde.

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/render.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/render.md
@@ -1,0 +1,31 @@
+---
+title: Anpassad
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+---
+
+## Here be dragons
+
+## Parametrar
+
+**`description:`** `string | Readonly<Ref<string | null>>` {@optional}
+: Formatbeskrivning
+
+**`header:`** `string | Readonly<Ref<string>>`
+: Kolumnrubrik som visas i thead.
+
+**`key:`** `K` {@optional}
+: Kopplar cellens värde till värde i `T`.
+
+**`size:`** `TableColumnSize | Readonly<Ref<TableColumnSize | null>>` {@optional}
+: Hur kolumnens bredd skalas. `"grow"` ger största möjliga bredd och `"shrink"` minsta möjliga bredd.
+Default: `grow`.
+
+**`render:`** `(row: T): VNode | Component => {}`
+: Funktion som retunerar den komponent som ska renderas i cellen.
+
+**`type:`** `InputTypeText`
+: Kolumnens typ, sätts till `render`.

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/rowheader.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/rowheader.md
@@ -1,0 +1,31 @@
+---
+title: Radrubrik
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+---
+
+## Here be dragons
+
+## Parametrar
+
+**`description:`** `string | Readonly<Ref<string | null>>` {@optional}
+: Formatbeskrivning
+
+**`header:`** `string | Readonly<Ref<string>>`
+: Kolumnrubrik som visas i thead.
+
+**`key:`** `K` {@optional}
+: Kopplar cellens värde till värde i `T`.
+
+**`size:`** `TableColumnSize | Readonly<Ref<TableColumnSize | null>>` {@optional}
+: Hur kolumnens bredd skalas. `"grow"` ger största möjliga bredd och `"shrink"` minsta möjliga bredd.
+Default: `grow`.
+
+**`text:`** `(row: T): string => {}` {@optional}
+: Radens rubrik.
+
+**`type:`** `InputTypeText`
+: Kolumnens typ, sätts till `rowheader`.

--- a/packages/vue-labs/docs/components/FTable/Kolumntyper/select.md
+++ b/packages/vue-labs/docs/components/FTable/Kolumntyper/select.md
@@ -1,0 +1,44 @@
+---
+title: Dropplista
+status: Draft
+layout: api
+sortorder: 1
+component:
+    - FTable
+---
+
+## Here be dragons
+
+## Parametrar
+
+**`description:`** `string | Readonly<Ref<string | null>>` {@optional}
+: Formatbeskrivning
+
+**`editable:`** `boolean | ((row: T) => boolean)  => {})` {@optional}
+: Om dropplistan är aktiv.
+Default `true`.
+
+**`header:`** `string | Readonly<Ref<string>>`
+: Kolumnrubrik som visas i thead.
+
+**`key:`** `K` {@optional}
+: Kopplar cellens värde till värde i `T`.
+
+**`label:`** `(row: T): string  => {}` {@optional}
+: Skärmläsartext för dropplistan.
+
+**`options:`** `string[]`
+: Lista med val.
+
+**`size:`** `TableColumnSize | Readonly<Ref<TableColumnSize | null>>` {@optional}
+: Hur kolumnens bredd skalas. `"grow"` ger största möjliga bredd och `"shrink"` minsta möjliga bredd.
+Default: `grow`.
+
+**`type:`** `InputTypeText`
+: Kolumnens typ, sätts till `select`.
+
+**`selected:`** `(rox: T): string => {}`
+Funktion som retunerar värdet för aktivt val.
+
+**`update:`** `(row: T, newValue: string, oldValue: string): void  => {}` {@optional}
+: Anropas vid uppdaterat val.

--- a/packages/vue-labs/docs/components/code-table.md
+++ b/packages/vue-labs/docs/components/code-table.md
@@ -34,15 +34,34 @@ Tabellrubriken ska hjälpa användaren att hitta till, navigera i och förstå t
 
 Om tabellen har en rubrik (heading) i nära anslutning som också förklarar tabellens innebörd assoccierar du den med `aria-labelledby`:
 
-// plats för kodexempel
+```diff
+-<h3>Tabellrubrik</h3>
+-<f-table :columns :rows>
++<h3 id="awesome-heading">Tabellrubrik</h3>
++<f-table :columns :rows aria-labelledby="awesome-header">
+ ...
+</f-table>
+```
 
 Använd caption om tabellen inte har en naturlig rubrik:
 
-// plats för kodexempel
+```diff
+<f-table :columns :rows>
++   <template #caption> Tabellrubrik </template>
+ ...
+</f-table>
+```
 
 I undantagsfall kan du också använda en dold skärmläsartext i caption, men tänk på att tabellens innehåll måste vara begripligt för alla:
 
-// plats för kodexempel
+```diff
+<f-table :columns :rows>
++   <template #caption>
++       <span class="sr-only"> Tabellrubrik </span>
++   </template>
+ ...
+</f-table>
+```
 
 ## Kolumner
 
@@ -92,7 +111,7 @@ Tabellen har nio olika kolumntyper som påverkar hur cellen presenteras:
 - länk: `anchor`
 - dropplista: `select`
 - kontextmeny: `contextmenu`
-- specialiserade inmatningsfält: `text:namn på specialiserat inmatningsfält `
+- specialiserade inmatningsfält: `text:namn på specialiserat inmatningsfält`
 - eget innehåll: `render`
 
 Specialiserade inmatningsfält som tabellen stödjer:


### PR DESCRIPTION
Provade att låta CoPilot generera dokumentation till våra kolumntyper.
Jag har bara gjort en mycket ytlig och snabb granskning och tagit bort icke relevanta referenser till "intern" kod.
(Texten har lite faktafel)

Så granska inte den delenj,  men tänker att vi kan använda det som en grund att diskutera kring:
AI-genererad grund:
https://forsakringskassan.github.io/designsystem/pr-preview/pr-975/vue-labs/components/FTable/ftable-columns.html

Ny struktur för kolumntyper:
https://forsakringskassan.github.io/designsystem/pr-preview/pr-975/vue-labs/components/FTable/Kolumntyper/text.html