### PR TITLE
fix: close combobox list on scroll (refs SFKUI-7584)

### DIFF
--- a/packages/vue/src/internal-components/IPopupListbox/IPopupListbox.cy.ts
+++ b/packages/vue/src/internal-components/IPopupListbox/IPopupListbox.cy.ts
@@ -341,3 +341,249 @@ describe("IPopupListbox scrolling", () => {
         cy.toMatchScreenshot();
     });
 });
+
+describe("IPopupListbox events", () => {
+    beforeEach(() => {
+        setViewport({ height: 300, width: 480 });
+    });
+
+    it("should emit close when clicking outside", () => {
+        const component = defineComponent({
+            template: /* HTML */ `
+                <div id="outside-container">
+                    <label for="input">Items</label>
+                    <input
+                        id="input"
+                        ref="input"
+                        type="text"
+                        style="height: 50px; margin-top: 200px"
+                    />
+                    <i-popup-listbox
+                        :is-open
+                        :anchor="$refs.input"
+                        :num-of-items="3"
+                        @close="isOpen=false"
+                    >
+                        <ul
+                            style="list-style-type: none; padding: 0; margin: 0"
+                        >
+                            <li v-for="index in 3" :key="index">
+                                Item {{ index }}
+                            </li>
+                        </ul>
+                    </i-popup-listbox>
+                    <button type="button" @click="isOpen = !isOpen">
+                        Open listbox
+                    </button>
+                </div>
+            `,
+            components: {
+                IPopupListbox,
+            },
+            data() {
+                return {
+                    isOpen: false,
+                };
+            },
+        });
+        cy.mount(component);
+        cy.get("button").click();
+        cy.get("ul").should("be.visible");
+
+        cy.get("#outside-container").click();
+        cy.get("ul").should("not.exist");
+    });
+
+    it("should not emit close when clicking inside popup", () => {
+        const component = defineComponent({
+            template: /* HTML */ `
+                <div>
+                    <label for="input">Items</label>
+                    <input
+                        id="input"
+                        ref="input"
+                        type="text"
+                        style="height: 50px; margin-top: 200px"
+                    />
+                    <i-popup-listbox
+                        :is-open
+                        :anchor="$refs.input"
+                        :num-of-items="3"
+                        @close="isOpen=false"
+                    >
+                        <ul
+                            style="list-style-type: none; padding: 0; margin: 0"
+                        >
+                            <li v-for="index in 3" :key="index">
+                                Item {{ index }}
+                            </li>
+                        </ul>
+                    </i-popup-listbox>
+                    <button type="button" @click="isOpen = !isOpen">
+                        Open listbox
+                    </button>
+                </div>
+            `,
+            components: {
+                IPopupListbox,
+            },
+            data() {
+                return {
+                    isOpen: false,
+                };
+            },
+        });
+        cy.mount(component);
+        cy.get("button").click();
+        cy.get("ul").should("be.visible");
+
+        cy.get(".popup__wrapper").click({ force: true });
+        cy.get("ul").should("be.visible");
+    });
+
+    it("should emit close when scrolling window", () => {
+        const component = defineComponent({
+            template: /* HTML */ `
+                <div style="width: 600px">
+                    <label for="input">Items</label>
+                    <input
+                        id="input"
+                        ref="input"
+                        type="text"
+                        style="height: 50px; margin-top: 200px"
+                    />
+                    <i-popup-listbox
+                        :is-open
+                        :anchor="$refs.input"
+                        :num-of-items="3"
+                        @close="isOpen=false"
+                    >
+                        <ul
+                            style="list-style-type: none; padding: 0; margin: 0"
+                        >
+                            <li v-for="index in 3" :key="index">
+                                Item {{ index }}
+                            </li>
+                        </ul>
+                    </i-popup-listbox>
+                    <button type="button" @click="isOpen = !isOpen">
+                        Open listbox
+                    </button>
+                </div>
+            `,
+            components: {
+                IPopupListbox,
+            },
+            data() {
+                return {
+                    isOpen: false,
+                };
+            },
+        });
+        cy.mount(component);
+        cy.get("button").click();
+        cy.get("ul").should("be.visible");
+
+        cy.scrollTo(1);
+        cy.get("ul").should("not.exist");
+    });
+
+    it("should emit close when scrolling container", () => {
+        const component = defineComponent({
+            template: /* HTML */ `
+                <div
+                    id="scroll-container"
+                    style="width: 500px; overflow: scroll"
+                >
+                    <div style="width: 600px">
+                        <label for="input">Items</label>
+                        <input
+                            id="input"
+                            ref="input"
+                            type="text"
+                            style="height: 50px;"
+                        />
+                        <i-popup-listbox
+                            :is-open
+                            :anchor="$refs.input"
+                            :num-of-items="3"
+                            @close="isOpen=false"
+                        >
+                            <ul
+                                style="list-style-type: none; padding: 0; margin: 0"
+                            >
+                                <li v-for="index in 3" :key="index">
+                                    Item {{ index }}
+                                </li>
+                            </ul>
+                        </i-popup-listbox>
+                        <button type="button" @click="isOpen = !isOpen">
+                            Open listbox
+                        </button>
+                    </div>
+                </div>
+            `,
+            components: {
+                IPopupListbox,
+            },
+            data() {
+                return {
+                    isOpen: false,
+                };
+            },
+        });
+        cy.mount(component);
+        cy.get("button").click();
+        cy.get("ul").should("be.visible");
+
+        cy.get("#scroll-container").scrollTo(1);
+        cy.get("ul").should("not.exist");
+    });
+
+    it("should not emit close when scrolling popup", () => {
+        const component = defineComponent({
+            template: /* HTML */ `
+                <div style="width: 600px">
+                    <label for="input">Items</label>
+                    <input
+                        id="input"
+                        ref="input"
+                        type="text"
+                        style="height: 50px; margin-top: 200px"
+                    />
+                    <i-popup-listbox
+                        :is-open
+                        :anchor="$refs.input"
+                        :num-of-items="15"
+                        @close="isOpen=false"
+                    >
+                        <ul
+                            style="list-style-type: none; padding: 0; margin: 0"
+                        >
+                            <li v-for="index in 15" :key="index">
+                                Item {{ index }}
+                            </li>
+                        </ul>
+                    </i-popup-listbox>
+                    <button type="button" @click="isOpen = !isOpen">
+                        Open listbox
+                    </button>
+                </div>
+            `,
+            components: {
+                IPopupListbox,
+            },
+            data() {
+                return {
+                    isOpen: false,
+                };
+            },
+        });
+        cy.mount(component);
+        cy.get("button").click();
+        cy.get("ul").should("be.visible");
+
+        cy.get(".popup__wrapper").scrollTo(0, 1);
+        cy.get("ul").should("be.visible");
+    });
+});

--- a/packages/vue/src/internal-components/IPopupListbox/IPopupListbox.vue
+++ b/packages/vue/src/internal-components/IPopupListbox/IPopupListbox.vue
@@ -28,6 +28,7 @@ const contentRef = useTemplateRef<HTMLElement>("content");
 const teleportDisabled = false;
 const popupClasses = ["popup", "popup--overlay"];
 const teleportTarget = computed(() => config.teleportTarget);
+const debouncedOnResize = debounce(onResize, 100);
 let guessedItemHeight: number | undefined = undefined;
 let verticalSpacing: number | undefined = undefined;
 
@@ -53,13 +54,13 @@ watchEffect(() => {
 
 function addListeners(): void {
     document.addEventListener("click", onDocumentClickHandler);
-    window.addEventListener("resize", debounce(onResize, 100));
+    window.addEventListener("resize", debouncedOnResize);
     window.addEventListener("scroll", onScroll, { capture: true });
 }
 
 function removeListeners(): void {
     document.removeEventListener("click", onDocumentClickHandler);
-    window.removeEventListener("resize", debounce(onResize, 100));
+    window.removeEventListener("resize", debouncedOnResize);
     window.removeEventListener("scroll", onScroll, { capture: true });
 }
 

--- a/packages/vue/src/internal-components/IPopupListbox/IPopupListbox.vue
+++ b/packages/vue/src/internal-components/IPopupListbox/IPopupListbox.vue
@@ -54,11 +54,13 @@ watchEffect(() => {
 function addListeners(): void {
     document.addEventListener("click", onDocumentClickHandler);
     window.addEventListener("resize", debounce(onResize, 100));
+    window.addEventListener("scroll", onScroll, { capture: true });
 }
 
 function removeListeners(): void {
     document.removeEventListener("click", onDocumentClickHandler);
     window.removeEventListener("resize", debounce(onResize, 100));
+    window.removeEventListener("scroll", onScroll, { capture: true });
 }
 
 function isElementInsideViewport(element: Element): boolean {
@@ -108,6 +110,14 @@ function onResize(): void {
     if (isOpen) {
         calculatePosition();
     }
+}
+
+function onScroll(event: Event): void {
+    const isPopupTarget = event.target instanceof HTMLElement && Boolean(event.target.closest(".popup"));
+    if (isPopupTarget) {
+        return;
+    }
+    emit("close");
 }
 
 function onKeyEsc(event: KeyboardEvent): void {


### PR DESCRIPTION
Ändrar beteendet för `IPopupListbox` så att den stängs vid scroll för att efterlikna select elementet. Påverkar kombobox och tabellens dropplista.

Kombobox: https://forsakringskassan.github.io/designsystem/pr-preview/pr-982/components/input/combobox.html
Tabell (dropplista): https://forsakringskassan.github.io/designsystem/pr-preview/pr-982/vue-labs/components/FTable/

PR för alternativ lösning: https://github.com/Forsakringskassan/designsystem/pull/1003