### PR TITLE
fix: `line-height` CSS prop not set for anchor (fixes SFKUI-7583)

### DIFF
--- a/packages/design/src/core/mixins/_anchor.scss
+++ b/packages/design/src/core/mixins/_anchor.scss
@@ -11,6 +11,7 @@ $anchor-underline-width: 2px !default;
     text-underline-offset: $anchor-underline-offset;
     text-decoration-color: $anchor-color-text-standard-default;
     font-weight: var(--f-font-weight-medium);
+    line-height: var(--f-line-height-large);
 
     &:hover {
         text-decoration-thickness: 3px;


### PR DESCRIPTION
Ersätter Forsakringskassan/docs-generator#318.

**Liveexempel**
https://forsakringskassan.github.io/designsystem/pr-preview/pr-992/components/links/anchor.html