### PR TITLE
refactor: `ITableMenu` close on focusout (refs SFKUI-7590)

### DIFF
--- a/packages/vue-labs/src/components/FTable/ITableMenu.cy.ts
+++ b/packages/vue-labs/src/components/FTable/ITableMenu.cy.ts
@@ -141,6 +141,34 @@ describe("ITableMenu", () => {
         table.cell({ row: 1, col: 2 }).find("button").should("be.focused");
     });
 
+    it("should close current context menu when opening another", () => {
+        const rows = [
+            { id: 1, text: "Text 1" },
+            { id: 1, text: "Text 2" },
+        ];
+        const columns = defineTableColumns<(typeof rows)[number]>([
+            { type: "text", header: "Text", key: "text" },
+            {
+                type: "menu",
+                header: "Actions",
+                text() {
+                    return "Actions";
+                },
+                actions: [{ label: "foo" }, { label: "bar" }],
+            },
+        ]);
+
+        cy.mount(FTable<(typeof rows)[number]>, {
+            props: { rows, columns },
+        });
+
+        table.cell({ row: 2, col: 2 }).click();
+        table.contextmenu().should("have.length", 1);
+
+        table.cell({ row: 1, col: 2 }).click();
+        table.contextmenu().should("have.length", 1);
+    });
+
     it("should call action when menu item is selected", () => {
         const rows = [{ id: 1, text: "Text" }];
         const foo = cy.stub().as("fooClick");

--- a/packages/vue-labs/src/components/FTable/ITableMenu.vue
+++ b/packages/vue-labs/src/components/FTable/ITableMenu.vue
@@ -32,7 +32,7 @@ const renderButton = computed(() => {
 });
 
 function onOpen(event: MouseEvent): void {
-    /* prevent FTable from activaging the cell (which moves the focus back to
+    /* prevent FTable from activating the cell (which moves the focus back to
      * the cell instead of the context menu) */
     event.stopPropagation();
 
@@ -40,6 +40,15 @@ function onOpen(event: MouseEvent): void {
 }
 
 function onClose(): void {
+    isOpen.value = false;
+}
+
+function onFocusout(event: FocusEvent): void {
+    const validTarget = event.relatedTarget && event.relatedTarget instanceof HTMLElement;
+    const inPopup = validTarget && Boolean(event.relatedTarget.closest(".popup"));
+    if (inPopup) {
+        return;
+    }
     isOpen.value = false;
 }
 
@@ -63,6 +72,7 @@ defineExpose(expose);
             :anchor="buttonRef ?? undefined"
             @close="onClose"
             @select="onSelect"
+            @focusout="onFocusout"
         ></f-context-menu>
     </td>
     <td v-else tabindex="-1" class="table-ng__cell"></td>


### PR DESCRIPTION
Problemet: i tabell, om man trycker på knappen för att öppna en annan kontextmeny när en kontextmeny redan är öppen så stängs inte den gamla på grund av att `event.stopPropagation` på knappen hindrar att click fångas. `event.stopPropagation`  är där för att stoppa att fokus återgår till cell/knapp istället för kontextmenyn.

Enda sättet jag hittat hittils för att komma runt det är att göra liknande som tabellens dropplista och stänga på `focusout`.

- [x] Lägg till test för nya beteendet