### PR TITLE
fix: sandbox button `:hover` border margin not equal to other topnav buttons (fixes SFKUI-7308)

### DIFF
--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -24,10 +24,6 @@ $fk-logo-large: "fk-logo-primary-large.svg";
     color-scheme: light dark;
 }
 
-.sandbox-link {
-    padding: 0 0.75rem;
-}
-
 #content a.button.docs-button {
     color: #fff;
 }

--- a/docs/templates/partials/sandbox.html
+++ b/docs/templates/partials/sandbox.html
@@ -1,3 +1,3 @@
 <div class="toolbar__item">
-    <a class="sandbox-link docs-topnav__anchor" target="_blank" rel="external" href="{{ sandboxLink }}"> Sandlåda </a>
+    <a class="docs-topnav__anchor" target="_blank" rel="external" href="{{ sandboxLink }}"> Sandlåda </a>
 </div>


### PR DESCRIPTION
Löser enbart problemet med knappens mellanrum till den gröna linjen som visas vid `:hover`.
Problemet med placeringen av knappens text förvärras då den placeras ännu högre upp.

Jag ser också två andra lösningsförslag:

- Ta bort knappen i sidhuvudet och hänvisa till länken i sidfoten.
- Lägg in en länk till sandlådan bland övriga knappar i sidhuvdet för _Kom igång_, _Komponenter_ och så vidare.

Fixes #605