### PR TITLE
fix: visible page header separator (fixes SFKUI-7284)

### DIFF
--- a/packages/design/src/components/page-header/_page-header.scss
+++ b/packages/design/src/components/page-header/_page-header.scss
@@ -25,7 +25,6 @@ $page-header-separator-width: 1px !default;
         }
         &::after {
             content: " ";
-            background-color: $pageheader-color-separator-inverted;
             height: 1.38rem;
             padding: calc($page-header-separator-width / 2);
             margin: 0 size.$padding-100 0.155rem;

--- a/packages/design/src/components/page-header/_variables.scss
+++ b/packages/design/src/components/page-header/_variables.scss
@@ -1,4 +1,3 @@
 $pageheader-color-text: var(--fkds-color-header-text-primary) !default;
 $pageheader-appname-color-text: var(--fkds-color-header-text-primary) !default;
-$pageheader-color-separator-inverted: var(--fkds-color-header-text-primary) !default;
 $pageheader-color-background: var(--fkds-color-header-background-primary) !default;


### PR DESCRIPTION
**Dokumentation**
https://forsakringskassan.github.io/designsystem/pr-preview/pr-1030/components/page-layout/fpageheader.html

Fixar enbart det synliga strecket.
Utrymmet till höger om logotypen finns fortfarande kvar.