### PR TITLE
feat: add `useDatasetRef()` for creating datasets with metadata (refs SFKUI-7348)

### DIFF
--- a/docs/functions/functions/use-dataset-ref.md
+++ b/docs/functions/functions/use-dataset-ref.md
@@ -1,0 +1,66 @@
+---
+title: useDatasetRef() composable
+short-title: useDatasetRef()
+name: useDatasetRef
+layout: api.composable
+search:
+    terms:
+        - dataset
+        - datamängd
+---
+
+Composable för att skapa en reaktiv datamängd inkapslad i en Vue ref.
+
+Datamängder är arrayer utökade med extra metadata för att hantera tillgänglighet i tabeller och listor, specifikt när datamängden är ett urval av en större mängd, och används lämpligtvis av komponenter så som {@link FSortFilterDataset datamängdsorterare} (FSortFilterDataset) och {@link FTable tabell} (FTable).
+
+## Syntax
+
+```ts nocompile
+function useDatasetRef<T>(initial?: T[]): Ref<Dataset<T>>;
+```
+
+### Parametrar
+
+`initial` {@optional}
+: Initialt värde. Default är en tom array.
+
+### Returvärde
+
+`Ref<Dataset<T>>`
+: En Vue ref som kapslar in en datamängd.
+
+## Exempel
+
+Skapa en ny datamängd:
+
+```ts
+import { useDatasetRef } from "@fkui/vue";
+
+const dataset = useDatasetRef([
+    { id: "1", name: "Äpple" },
+    { id: "2", name: "Banan" },
+]);
+```
+
+Datamängden hanterar alla vanliga operationer en array har:
+
+```ts
+import { useDatasetRef } from "@fkui/vue";
+
+const dataset = useDatasetRef([
+    { id: "1", name: "Äpple" },
+    { id: "2", name: "Banan" },
+]);
+
+/* --- cut above --- */
+
+console.log(dataset.value.length); // 2
+console.log(dataset.value.at(0)); // { id: "1", name: "Äpple" }
+console.log(dataset.value.filter((it) => it.name.startsWith("B"))); // [{ id: "2", name: "Banan" }]
+```
+
+## Relaterat
+
+- {@link FSortFilterDataset Datamängdsorterare} (FSortFilterDataset)
+- {@link component:FPaginateDataset Paginering} (FPaginateDataset)
+- {@link FTable Tabell} (FTable)

--- a/etc/docs-manifest.md
+++ b/etc/docs-manifest.md
@@ -157,6 +157,7 @@ functions/functions/render-slot-text.html
 functions/functions/table-scroll-classes.html
 functions/functions/table-scroll.html
 functions/functions/use-area-data.html
+functions/functions/use-dataset-ref.html
 functions/functions/use-details-panel.html
 functions/functions/use-modal.html
 functions/functions/use-resize.html

--- a/etc/vue.api.md
+++ b/etc/vue.api.md
@@ -139,6 +139,12 @@ export interface ContextMenuTextItem {
     label: string;
 }
 
+// @public
+export type Dataset<T> = T[] & {
+    readonly [datasetSymbol]: true;
+    readonly __type: T;
+};
+
 // Warning: (ae-forgotten-export) The symbol "__VLS_export_67" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -1422,6 +1428,9 @@ export function useCombobox(inputRef: Readonly<ShallowRef<HTMLInputElement | nul
     selectOption: (value: string) => void;
     closeDropdown: () => void;
 };
+
+// @public
+export function useDatasetRef<T>(initial?: T[]): Ref<Dataset<T>>;
 
 // @public (undocumented)
 export interface UseDetailsPanel<T = unknown> {

--- a/packages/vue/src/utils/dataset.spec.ts
+++ b/packages/vue/src/utils/dataset.spec.ts
@@ -1,0 +1,76 @@
+import { isDataset, toDataset, useDatasetRef } from "./dataset";
+
+describe("Dataset", () => {
+    it("should function as an array", () => {
+        expect.assertions(2);
+        const values = [1, 2, 3];
+        const dataset = toDataset(values);
+        expect(dataset).toEqual([1, 2, 3]);
+        expect(dataset.map((x) => x * 2)).toEqual([2, 4, 6]);
+    });
+});
+
+describe("isDataset()", () => {
+    it("should return true for dataset", () => {
+        expect.assertions(1);
+        const dataset = toDataset([{ foo: "bar" }]);
+        expect(isDataset(dataset)).toBeTruthy();
+    });
+
+    it("should return false for regular array", () => {
+        expect.assertions(1);
+        const dataset = [{ foo: "bar" }];
+        expect(isDataset(dataset)).toBeFalsy();
+    });
+
+    it("should return false for undefined and null", () => {
+        expect.assertions(2);
+        expect(isDataset(null)).toBeFalsy();
+        expect(isDataset(undefined)).toBeFalsy();
+    });
+});
+
+describe("toDataset", () => {
+    it("should create a dataset from array", () => {
+        expect.assertions(1);
+        const dataset = [{ foo: "bar", baz: 42 }];
+        const result = toDataset(dataset);
+        expect(isDataset(result)).toBeTruthy();
+    });
+
+    it("should be idempotent", () => {
+        expect.assertions(3);
+        const dataset = [{ foo: "bar" }];
+        const first = toDataset(dataset);
+        const second = toDataset(first);
+        expect(first).toBe(second);
+        expect(isDataset(first)).toBeTruthy();
+        expect(isDataset(second)).toBeTruthy();
+    });
+
+    it("should not add enumerable properties", () => {
+        expect.assertions(3);
+        const dataset = [{ foo: "bar", spam: "ham" }];
+        const result = toDataset(dataset);
+        expect(Object.keys(result)).toEqual(["0"]); // indices
+        expect(Object.keys(result[0])).toEqual(["foo", "spam"]);
+        expect(JSON.stringify(result)).toBe(JSON.stringify(dataset));
+    });
+});
+
+describe("useDatasetRef()", () => {
+    it("should create a ref with dataset", () => {
+        expect.assertions(2);
+        const initial = [{ foo: "bar" }];
+        const dataset = useDatasetRef(initial);
+        expect(isDataset(dataset.value)).toBeTruthy();
+        expect(dataset.value).toEqual(initial);
+    });
+
+    it("should create an empty dataset if no initial value is provided", () => {
+        expect.assertions(2);
+        const dataset = useDatasetRef();
+        expect(isDataset(dataset.value)).toBeTruthy();
+        expect(dataset.value).toEqual([]);
+    });
+});

--- a/packages/vue/src/utils/dataset.ts
+++ b/packages/vue/src/utils/dataset.ts
@@ -1,0 +1,67 @@
+import { type Ref, ref } from "vue";
+
+const datasetSymbol = Symbol("dataset");
+
+/**
+ * Dataset contains row metadata for components such as `FSortFilterDataset`
+ * and `FTable`.
+ *
+ * Use `useDatasetRef()` to create a new dataset.
+ *
+ * @public
+ * @since %version%
+ */
+export type Dataset<T> = T[] & {
+    readonly [datasetSymbol]: true;
+
+    /**
+     * Type tag for better type inference. Not used at runtime.
+     *
+     * @internal
+     */
+    readonly __type: T;
+};
+
+/**
+ * Check if a dataset is a dataset.
+ *
+ * @internal
+ * @since %version%
+ */
+export function isDataset<T>(
+    dataset: T[] | null | undefined,
+): dataset is Dataset<T> {
+    if (!Array.isArray(dataset)) {
+        return false;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(dataset, datasetSymbol);
+    return descriptor?.value === true;
+}
+
+/**
+ * Creates a dataset from an array.
+ *
+ * @internal
+ * @since %version%
+ */
+export function toDataset<T>(dataset: T[]): Dataset<T> {
+    if (isDataset(dataset)) {
+        return dataset;
+    }
+    return Object.defineProperty(dataset, datasetSymbol, {
+        value: true,
+        enumerable: false,
+        configurable: false,
+        writable: false,
+    }) as Dataset<T>;
+}
+
+/**
+ * Creates a dataset as a Vue ref.
+ *
+ * @public
+ * @since %version%
+ */
+export function useDatasetRef<T>(initial?: T[]): Ref<Dataset<T>> {
+    return ref(toDataset(initial ?? [])) as Ref<Dataset<T>>;
+}

--- a/packages/vue/src/utils/index.ts
+++ b/packages/vue/src/utils/index.ts
@@ -44,3 +44,4 @@ export {
     setItemIdentifier,
     setItemIdentifiers,
 } from "./item-identifier";
+export { type Dataset, useDatasetRef } from "./dataset";


### PR DESCRIPTION
Skapar upp funktionerna för att skapa och testa om en datamängd innehåller metadatan.

I denna PR läggs inte någon metadata till och funktionen för att hämta ut metadata är inte heller med.