### PR TITLE
Extended `forced-colors` media feature support for icons and tooltip icon stack (fixes SFKUI-7567/SFKUI-7672)

### DIFF
--- a/packages/design/src/components/icon/_icon-stack.scss
+++ b/packages/design/src/components/icon/_icon-stack.scss
@@ -108,6 +108,17 @@
                 color: CanvasText;
             }
         }
+
+        &--tooltip {
+            .f-icon-circle {
+                color: Canvas;
+                fill: ButtonBorder;
+            }
+
+            .f-icon-i {
+                color: ButtonText;
+            }
+        }
     }
 
     &--large {


### PR DESCRIPTION
@johancarnegard har noterat att jag missade inkludera support för vissa ikoner i #1032.

Denna PR implementerar även support för tooltips.