### PR TITLE
docs: use `docs-generator/theme/fkui` in `docs-theme` (refs SFKUI-7399)

### DIFF
--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -7,7 +7,7 @@
 @use "@fkui/design/src/core/mixins/breakpoints";
 @use "@fkui/design" as fkui;
 @use "@forsakringskassan/docs-generator/style";
-@use "@forsakringskassan/docs-generator/theme/fkui";
+@use "@forsakringskassan/docs-generator/theme/fkui" as theme-fkui;
 @use "@forsakringskassan/docs-live-example";
 
 $fk-logo-small: "fk-logo-primary-small.svg";


### PR DESCRIPTION
Implementerar stöd för Forsakringskassan/docs-generator#329.