### PR TITLE
fix: font weight variable values (fixes SFKUI-7399)

### DIFF
--- a/packages/theme-default/src/shared/_index.scss
+++ b/packages/theme-default/src/shared/_index.scss
@@ -46,7 +46,7 @@
 
     /// Font weight
     --f-font-weight-normal: 400;
-    --f-font-weight-medium: 700;
+    --f-font-weight-medium: 600;
     --f-font-weight-bold: 700;
 
     /// Font line height


### PR DESCRIPTION
Justerar värden för fontviktsvariabler:

| Variabel | Värde |
| ----------- | ----------- |
| `f-font-weight-normal` | `400` |
| `f-font-weight-medium` | `600` |
| `f-font-weight-bold` | `700` |