### PR TITLE
feat: update cypress configuration to use ES2023 by default

### DIFF
--- a/packages/tsconfig/presets/tsconfig-cypress.json
+++ b/packages/tsconfig/presets/tsconfig-cypress.json
@@ -8,7 +8,7 @@
         "resolveJsonModule": true,
         "strict": true,
         "target": "esnext",
-        "lib": ["es6", "dom"],
+        "lib": ["es2023", "dom"],
         "types": ["cypress", "node"]
     }
 }


### PR DESCRIPTION
Annars fungerar inte moderna funktioner så som `toReversed()`, `toSorted()` osv. De har varit baseline ett tag och lämpligtvis så bör konsumenter köra corejs om de ska bygga för plattformar som är äldre.