### PR TITLE
fix: restore focus for buttons on modal close (refs SFKUI-7549)

### DIFF
--- a/packages/design/src/components/button/_button.scss
+++ b/packages/design/src/components/button/_button.scss
@@ -323,7 +323,8 @@ $button--tertiary: (
             }
         }
 
-        &:disabled {
+        &:disabled,
+        &[aria-disabled="true"] {
             border: none;
         }
 
@@ -337,7 +338,8 @@ $button--tertiary: (
                 background-color: $button-tertiary-inverted-color-background-focus;
             }
 
-            &:disabled {
+            &:disabled,
+            &[aria-disabled="true"] {
                 color: $button-tertiary-inverted-color-text-disabled;
                 border: none;
                 border-width: 0;
@@ -350,7 +352,8 @@ $button--tertiary: (
             text-decoration-thickness: 2px;
             text-underline-offset: 4px;
 
-            &:disabled {
+            &:disabled,
+            &[aria-disabled="true"] {
                 text-decoration: none;
             }
         }
@@ -464,6 +467,8 @@ $button--tertiary: (
     &.disabled:hover,
     &:disabled,
     &:disabled:hover,
+    &[aria-disabled="true"],
+    &[aria-disabled="true"]:hover,
     &.button--disabled {
         border-width: var(--f-border-width-medium);
         box-shadow: none;

--- a/packages/design/src/core/mixins/_button.scss
+++ b/packages/design/src/core/mixins/_button.scss
@@ -50,10 +50,21 @@
     &.disabled:hover,
     &:disabled,
     &:disabled:hover,
+    &[aria-disabled="true"],
+    &[aria-disabled="true"]:hover,
     &#{$name}--disabled,
     &#{$name}--disabled:hover {
         background-color: $background-color--disabled;
         border-color: $border-color--disabled;
         color: $color--disabled;
+        pointer-events: none;
+    }
+
+    &[aria-disabled="true"] {
+        pointer-events: none;
+        @media (forced-colors: active) {
+            color: GrayText;
+            border-color: GrayText;
+        }
     }
 }

--- a/packages/vue/src/components/FButton/FButton.spec.ts
+++ b/packages/vue/src/components/FButton/FButton.spec.ts
@@ -19,7 +19,7 @@ expect.addSnapshotSerializer({
 
 describe("props", () => {
     describe("disabled", () => {
-        it("should disable the button when true", () => {
+        it("should set aria-disabled on the button element when true", () => {
             expect.assertions(1);
             const wrapper = shallowMount(FButton, {
                 props: {
@@ -27,14 +27,14 @@ describe("props", () => {
                 },
             });
             const button = wrapper.get("button");
-            expect(button.attributes("disabled")).toBeDefined();
+            expect(button.attributes("aria-disabled")).toBe("true");
         });
 
-        it("should not disable the button as default", () => {
+        it("should not set aria-disabled on the button as default", () => {
             expect.assertions(1);
             const wrapper = shallowMount(FButton);
             const button = wrapper.get("button");
-            expect(button.attributes("disabled")).toBeUndefined();
+            expect(button.attributes("aria-disabled")).toBe("false");
         });
     });
 

--- a/packages/vue/src/components/FButton/FButton.vue
+++ b/packages/vue/src/components/FButton/FButton.vue
@@ -115,7 +115,11 @@ defineOptions({
     inheritAttrs: false,
 });
 const originalAttrs = useAttrs();
-const { inflight, fn: onClick } = useInflight(originalAttrs.onClick);
+
+const disabled = computed((): boolean => {
+    return props.disabled || inflight.value;
+});
+const { inflight, fn: onClick } = useInflight(originalAttrs.onClick, disabled);
 const attrs = { ...originalAttrs, onClick };
 
 const hasIconLeft = computed((): boolean => {
@@ -155,14 +159,10 @@ const buttonClass = computed((): string[] => {
 
     return classes;
 });
-
-const disabled = computed((): boolean => {
-    return props.disabled || inflight.value;
-});
 </script>
 
 <template>
-    <button :type :class="buttonClass" :disabled v-bind="attrs">
+    <button :type :class="buttonClass" :aria-disabled="disabled" v-bind="attrs">
         <template v-if="hasIconLeft">
             <f-icon v-if="inflight" name="circle-notch-solid" class="button__icon button__spinner"></f-icon>
             <f-icon

--- a/packages/vue/src/components/FButton/use-inflight.ts
+++ b/packages/vue/src/components/FButton/use-inflight.ts
@@ -8,7 +8,7 @@ export interface UseInflight {
     fn: UseInflightWrapped | undefined;
 }
 
-export function useInflight(fn: unknown): UseInflight {
+export function useInflight(fn: unknown, disabled: Ref<boolean>): UseInflight {
     const inflight = ref(false);
 
     if (!fn || typeof fn !== "function") {
@@ -18,6 +18,9 @@ export function useInflight(fn: unknown): UseInflight {
     const originalFn = fn;
 
     async function wrapper(): Promise<void> {
+        if (disabled.value) {
+            return;
+        }
         try {
             inflight.value = true;
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-call -- technical debt */

--- a/packages/vue/src/components/FModal/FModal.cy.ts
+++ b/packages/vue/src/components/FModal/FModal.cy.ts
@@ -1,5 +1,6 @@
 import { type DefineComponent, defineComponent } from "vue";
 import {
+    FButton,
     FConfirmModal,
     FFormModal,
     FModal,
@@ -61,14 +62,14 @@ function generateModalMarkup(focusStrategy = "on"): string {
                     </f-select-field>
                 </div>
             </div>
-            <button
-                type="button"
-                class="button button--secondary"
+            <f-button
                 data-test="open-example-modal-button"
+                variant="secondary"
+                size="large"
                 @click="onClickOpenModal"
             >
                 Öppna modal
-            </button>
+            </f-button>
             <f-modal
                 :is-open="isOpen"
                 data-test="modul-open"
@@ -88,21 +89,22 @@ function generateModalMarkup(focusStrategy = "on"): string {
                 </template>
                 <template #footer>
                     <div class="button-group">
-                        <button
+                        <f-button
                             data-test="closeButton"
-                            type="button"
-                            class="button button--secondary button-group__item button--large"
+                            size="large"
+                            variant="secondary"
+                            class="button-group__item"
                             @click="onClickCloseModal"
                         >
                             Stäng sekundär
-                        </button>
-                        <button
-                            type="button"
-                            class="button button--primary button-group__item button--large"
+                        </f-button>
+                        <f-button
+                            size="large"
+                            class="button-group__item"
                             @click="onClickCloseModal"
                         >
                             Stäng
-                        </button>
+                        </f-button>
                     </div>
                 </template>
             </f-modal>
@@ -153,7 +155,7 @@ const content = {
 function createComponent(template: string): DefineComponent {
     return defineComponent({
         template,
-        components: { FModal, FSelectField },
+        components: { FButton, FModal, FSelectField },
         data() {
             return {
                 fullscreen: false,
@@ -273,6 +275,13 @@ describe("FModal", () => {
                 "data-test",
                 "open-example-modal-button",
             );
+        });
+
+        it("default should set focus on button that opened modal when modal is closed", () => {
+            cy.mount(createComponent(generateModalMarkup("on")));
+            cy.get(openModalButton).click();
+            modal.secondaryButton().click();
+            cy.get(openModalButton).should("have.focus");
         });
 
         it("should be able to disable focus strategy", () => {


### PR DESCRIPTION
Rättar bugg med att fokus inte återställs när man stänger en modal som har öppnats via en knapp. Kanske behöver lägga till något test men vet inte om det hör till knappen eller modalen.