### PR TITLE
docs: remove sandbox link from page header (fixes SFKUI-7769)

### DIFF
--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -26,10 +26,6 @@ $fk-logo-large: "fk-logo-primary-large.svg";
     color-scheme: light dark;
 }
 
-.sandbox-link {
-    padding: 0 0.75rem;
-}
-
 #content a.button.docs-button {
     color: #fff;
 }

--- a/docs/templates/partials/sandbox.html
+++ b/docs/templates/partials/sandbox.html
@@ -1,3 +1,0 @@
-<div class="toolbar__item">
-    <a class="sandbox-link docs-topnav__anchor" target="_blank" rel="external" href="{{ sandboxLink }}"> Sandlåda </a>
-</div>

--- a/generate-docs.mjs
+++ b/generate-docs.mjs
@@ -103,9 +103,6 @@ function sandboxProcessor(folder) {
                 "sandboxLink",
                 `https://play.vuejs.org/#${hash}`,
             );
-            context.addTemplateBlock("toolbar", "sandbox-toolbar", {
-                filename: "partials/sandbox.html",
-            });
         },
     };
 }


### PR DESCRIPTION
Ersätter #1007.

Härstammar från denna kommentar i #1007:

> Vi bör kanske pausa denna en stund då jag håller på att kolla på om vi kan göra mindre / snabba förbättringar på dokumentationssajten i mobilt läge.
> 
> Jag är inne på ditt första förslag att ta bort länken till sandlådan i sidhuvudet.

_Originally posted by @niklasfk in https://github.com/Forsakringskassan/designsystem/issues/1007#issuecomment-3906905508_

Closes #605