### PR TITLE
chore: new color palette with darkmode support (refs SFKUI-6500)

### DIFF
--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -65,7 +65,7 @@ $fk-logo-large: "fk-logo-primary-large.svg";
 }
 
 footer {
-    background: palette.$palette-color-green-a-85;
+    background: palette.$palette-color-green-600;
     color: var(--fkds-color-text-inverted);
     padding: 3rem;
 
@@ -100,8 +100,8 @@ footer {
     .anchor,
     #version button {
         &:hover {
-            color: palette.$palette-color-fk-black-100;
-            text-decoration-color: palette.$palette-color-fk-black-100;
+            color: palette.$palette-color-neutral-900;
+            text-decoration-color: palette.$palette-color-neutral-900;
         }
     }
 

--- a/packages/theme-default/src/_palette-variables-deprecated.scss
+++ b/packages/theme-default/src/_palette-variables-deprecated.scss
@@ -1,0 +1,75 @@
+// Deprecated palette colors
+// Palette colors should follow the following palette-color-<name> convention.
+
+/// @group FK-Black
+$palette-color-fk-black-100: #1b1e23 !default;
+$palette-color-fk-black-70: #5f6165 !default;
+$palette-color-fk-black-50: #8d8e91 !default;
+$palette-color-fk-black-30: #bbbbbd !default;
+$palette-color-fk-black-15: #ddddde !default;
+$palette-color-fk-black-5: #f4f4f4 !default;
+$palette-color-white-100: #ffffff !default;
+
+/// @group Bluebell
+$palette-color-bluebell-120: #3b4292 !default;
+$palette-color-bluebell-100: #4a52b6 !default;
+$palette-color-bluebell-85: #656cc1 !default;
+$palette-color-bluebell-50: #a4a8db !default;
+$palette-color-bluebell-15: #e5e5f5 !default;
+$palette-color-bluebell-5: #f5f6fa !default;
+
+/// @group Green A
+$palette-color-green-a-120: #0e5532 !default;
+$palette-color-green-a-100: #116a3e !default;
+$palette-color-green-a-85: #35805b !default;
+$palette-color-green-a-50: #88b49f !default;
+$palette-color-green-a-15: #dbe9e2 !default;
+$palette-color-green-a-5: #f3f8f5 !default;
+
+/// @group Green B
+$palette-color-green-b-120: #4c7e56 !default;
+$palette-color-green-b-100: #5f9e6c !default;
+$palette-color-green-b-85: #77ad82 !default;
+$palette-color-green-b-50: #afcfb5 !default;
+$palette-color-green-b-15: #e7f0e9 !default;
+$palette-color-green-b-5: #f7faf8 !default;
+
+/// @group Yellow
+$palette-color-yellow-120: #cc980d !default;
+$palette-color-yellow-100: #ffbe10 !default;
+$palette-color-yellow-85: #ffc834 !default;
+$palette-color-yellow-50: #ffdf87 !default;
+$palette-color-yellow-15: #fff5db !default;
+$palette-color-yellow-5: #fffcf3 !default;
+
+/// @group Red
+$palette-color-red-120: #a21111 !default;
+$palette-color-red-100: #ca1515 !default;
+$palette-color-red-85: #d23838 !default;
+$palette-color-red-50: #e48a8a !default;
+$palette-color-red-15: #f7dcdc !default;
+$palette-color-red-5: #fcf3f3 !default;
+
+/// @group Orange
+$palette-color-orange-120: #c2700d !default;
+$palette-color-orange-100: #f38c10 !default;
+$palette-color-orange-85: #f59d34 !default;
+$palette-color-orange-50: #f9c587 !default;
+$palette-color-orange-15: #ffefdc !default;
+$palette-color-orange-5: #fef9f3 !default;
+
+/// @group Tegel
+$palette-color-tegel-100: #d34503 !default;
+$palette-color-tegel-15: #f8e3d9 !default;
+
+/// @group Plommon
+$palette-color-plommon-100: #a73a64 !default;
+$palette-color-plommon-15: #f2e1e8 !default;
+
+/// @group Senap
+$palette-color-senap-100: #ba7918 !default;
+$palette-color-senap-15: #f5ebdc !default;
+
+/// @group Hav
+$palette-color-hav-100: #4c669f !default;
+$palette-color-hav-15: #e4e8f1 !default;

--- a/packages/theme-default/src/dark/_variables.scss
+++ b/packages/theme-default/src/dark/_variables.scss
@@ -2,109 +2,109 @@
 
 @mixin variables {
     // TEXT
-    --fkds-color-text-primary: #{$palette-color-fk-black-15};
-    --fkds-color-text-secondary: #{$palette-color-fk-black-30};
-    --fkds-color-text-inverted: #{$palette-color-fk-black-100};
-    --fkds-color-text-disabled: #{$palette-color-fk-black-50};
+    --fkds-color-text-primary: #{$palette-color-neutral-100};
+    --fkds-color-text-secondary: #{$palette-color-neutral-300};
+    --fkds-color-text-inverted: #{$palette-color-neutral-900};
+    --fkds-color-text-disabled: #{$palette-color-neutral-300};
 
     // BACKGROUND
-    --fkds-color-background-primary: #{$palette-color-fk-black-100};
-    --fkds-color-background-secondary: #{$palette-color-fk-black-100};
-    --fkds-color-background-tertiary: #{$palette-color-fk-black-50};
-    --fkds-color-background-disabled: #{$palette-color-fk-black-70};
+    --fkds-color-background-primary: #{$palette-color-neutral-900};
+    --fkds-color-background-secondary: #{$palette-color-neutral-800};
+    --fkds-color-background-tertiary: #{$palette-color-neutral-700};
+    --fkds-color-background-disabled: #{$palette-color-neutral-800};
 
     // BORDER
-    --fkds-color-border-primary: #{$palette-color-fk-black-30};
-    --fkds-color-border-strong: #{$palette-color-fk-black-15};
-    --fkds-color-border-weak: #{$palette-color-fk-black-50};
-    --fkds-color-border-disabled: #{$palette-color-fk-black-30};
-    --fkds-color-border-inverted: #{$palette-color-fk-black-100};
+    --fkds-color-border-primary: #{$palette-color-neutral-400};
+    --fkds-color-border-strong: #{$palette-color-neutral-200};
+    --fkds-color-border-weak: #{$palette-color-neutral-600};
+    --fkds-color-border-disabled: #{$palette-color-neutral-500};
+    --fkds-color-border-inverted: #{$palette-color-neutral-900};
 
     // ACTION - TEXT
-    --fkds-color-action-text-primary-default: #{$palette-color-bluebell-50};
-    --fkds-color-action-text-primary-hover: #{$palette-color-bluebell-15};
-    --fkds-color-action-text-primary-active: #{$palette-color-bluebell-15};
-    --fkds-color-action-text-primary-focus: #{$palette-color-bluebell-50};
-    --fkds-color-action-text-secondary-default: #{$palette-color-fk-black-15};
-    --fkds-color-action-text-secondary-hover: #{$palette-color-bluebell-15};
-    --fkds-color-action-text-secondary-active: #{$palette-color-bluebell-15};
-    --fkds-color-action-text-secondary-focus: #{$palette-color-bluebell-15};
-    --fkds-color-action-text-inverted-default: #{$palette-color-fk-black-100};
-    --fkds-color-action-text-inverted-hover: #{$palette-color-fk-black-100};
-    --fkds-color-action-text-inverted-active: #{$palette-color-fk-black-100};
-    --fkds-color-action-text-inverted-focus: #{$palette-color-fk-black-100};
+    --fkds-color-action-text-primary-default: #{$palette-color-blue-300};
+    --fkds-color-action-text-primary-hover: #{$palette-color-blue-200};
+    --fkds-color-action-text-primary-active: #{$palette-color-blue-200};
+    --fkds-color-action-text-primary-focus: #{$palette-color-blue-300};
+    --fkds-color-action-text-secondary-default: #{$palette-color-neutral-100};
+    --fkds-color-action-text-secondary-hover: #{$palette-color-neutral-200};
+    --fkds-color-action-text-secondary-active: #{$palette-color-neutral-200};
+    --fkds-color-action-text-secondary-focus: #{$palette-color-neutral-100};
+    --fkds-color-action-text-inverted-default: #{$palette-color-neutral-900};
+    --fkds-color-action-text-inverted-hover: #{$palette-color-neutral-900};
+    --fkds-color-action-text-inverted-active: #{$palette-color-neutral-900};
+    --fkds-color-action-text-inverted-focus: #{$palette-color-neutral-900};
 
     // ACTION - BACKGROUND
-    --fkds-color-action-background-primary-default: #{$palette-color-bluebell-50};
-    --fkds-color-action-background-primary-hover: #{$palette-color-bluebell-15};
-    --fkds-color-action-background-primary-active: #{$palette-color-bluebell-15};
-    --fkds-color-action-background-primary-focus: #{$palette-color-bluebell-50};
-    --fkds-color-action-background-secondary-default: #{$palette-color-fk-black-100};
-    --fkds-color-action-background-secondary-hover: #{$palette-color-fk-black-70};
-    --fkds-color-action-background-secondary-active: #{$palette-color-fk-black-70};
-    --fkds-color-action-background-secondary-focus: #{$palette-color-fk-black-100};
+    --fkds-color-action-background-primary-default: #{$palette-color-blue-300};
+    --fkds-color-action-background-primary-hover: #{$palette-color-blue-200};
+    --fkds-color-action-background-primary-active: #{$palette-color-blue-200};
+    --fkds-color-action-background-primary-focus: #{$palette-color-blue-300};
+    --fkds-color-action-background-secondary-default: #{$palette-color-neutral-900};
+    --fkds-color-action-background-secondary-hover: #{$palette-color-neutral-800};
+    --fkds-color-action-background-secondary-active: #{$palette-color-neutral-800};
+    --fkds-color-action-background-secondary-focus: #{$palette-color-neutral-900};
 
     // ACTION - BORDER
-    --fkds-color-action-border-primary-default: #{$palette-color-bluebell-50};
-    --fkds-color-action-border-primary-hover: #{$palette-color-bluebell-15};
-    --fkds-color-action-border-primary-active: #{$palette-color-bluebell-15};
-    --fkds-color-action-border-primary-focus: #{$palette-color-bluebell-50};
+    --fkds-color-action-border-primary-default: #{$palette-color-blue-300};
+    --fkds-color-action-border-primary-hover: #{$palette-color-blue-200};
+    --fkds-color-action-border-primary-active: #{$palette-color-blue-200};
+    --fkds-color-action-border-primary-focus: #{$palette-color-blue-300};
 
     // FEEDBACK - BACKGROUND
-    --fkds-color-feedback-background-neutral: #{$palette-color-fk-black-100};
-    --fkds-color-feedback-background-neutral-strong: #{$palette-color-fk-black-50};
-    --fkds-color-feedback-background-info: #{$palette-color-fk-black-100};
-    --fkds-color-feedback-background-info-strong: #{$palette-color-bluebell-50};
-    --fkds-color-feedback-background-positive: #{$palette-color-fk-black-100};
-    --fkds-color-feedback-background-positive-strong: #{$palette-color-green-a-50};
-    --fkds-color-feedback-background-warning: #{$palette-color-fk-black-100};
-    --fkds-color-feedback-background-warning-strong: #{$palette-color-yellow-50};
-    --fkds-color-feedback-background-negative: #{$palette-color-fk-black-100};
-    --fkds-color-feedback-background-negative-strong: #{$palette-color-red-50};
+    --fkds-color-feedback-background-neutral: #{$palette-color-neutral-800};
+    --fkds-color-feedback-background-neutral-strong: #{$palette-color-neutral-600};
+    --fkds-color-feedback-background-info: #{$palette-color-blue-900};
+    --fkds-color-feedback-background-info-strong: #{$palette-color-blue-400};
+    --fkds-color-feedback-background-positive: #{$palette-color-green-900};
+    --fkds-color-feedback-background-positive-strong: #{$palette-color-green-400};
+    --fkds-color-feedback-background-warning: #{$palette-color-yellow-900};
+    --fkds-color-feedback-background-warning-strong: #{$palette-color-yellow-400};
+    --fkds-color-feedback-background-negative: #{$palette-color-red-900};
+    --fkds-color-feedback-background-negative-strong: #{$palette-color-red-400};
 
     // FEEDBACK - BORDER
-    --fkds-color-feedback-border-neutral: #{$palette-color-fk-black-50};
-    --fkds-color-feedback-border-info: #{$palette-color-bluebell-50};
-    --fkds-color-feedback-border-positive: #{$palette-color-green-a-50};
-    --fkds-color-feedback-border-warning: #{$palette-color-yellow-50};
-    --fkds-color-feedback-border-negative: #{$palette-color-red-50};
+    --fkds-color-feedback-border-neutral: #{$palette-color-neutral-400};
+    --fkds-color-feedback-border-info: #{$palette-color-blue-400};
+    --fkds-color-feedback-border-positive: #{$palette-color-green-400};
+    --fkds-color-feedback-border-warning: #{$palette-color-yellow-400};
+    --fkds-color-feedback-border-negative: #{$palette-color-red-400};
 
     // FEEDBACK - TEXT
-    --fkds-color-feedback-text-negative: #{$palette-color-red-50};
-    --fkds-color-feedback-text-positive: #{$palette-color-green-a-50};
-    --fkds-color-feedback-text-on-warning: #{$palette-color-fk-black-100};
+    --fkds-color-feedback-text-negative: #{$palette-color-red-400};
+    --fkds-color-feedback-text-positive: #{$palette-color-green-400};
+    --fkds-color-feedback-text-on-warning: #{$palette-color-neutral-900};
 
     // SELECT - BACKGROUND
-    --fkds-color-select-background-primary-default: #{$palette-color-bluebell-50};
-    --fkds-color-select-background-primary-hover: #{$palette-color-bluebell-85};
-    --fkds-color-select-background-primary-active: #{$palette-color-bluebell-85};
-    --fkds-color-select-background-primary-focus: #{$palette-color-bluebell-85};
-    --fkds-color-select-background-secondary-default: #{$palette-color-green-a-50};
-    --fkds-color-select-background-secondary-hover: #{$palette-color-green-a-85};
-    --fkds-color-select-background-secondary-active: #{$palette-color-green-a-85};
-    --fkds-color-select-background-secondary-focus: #{$palette-color-green-a-85};
+    --fkds-color-select-background-primary-default: #{$palette-color-blue-300};
+    --fkds-color-select-background-primary-hover: #{$palette-color-neutral-700};
+    --fkds-color-select-background-primary-active: #{$palette-color-neutral-800};
+    --fkds-color-select-background-primary-focus: #{$palette-color-neutral-900};
+    --fkds-color-select-background-secondary-default: #{$palette-color-green-300};
+    --fkds-color-select-background-secondary-hover: #{$palette-color-neutral-700};
+    --fkds-color-select-background-secondary-active: #{$palette-color-neutral-800};
+    --fkds-color-select-background-secondary-focus: #{$palette-color-neutral-900};
 
     // INTERACTIVE SURFACE - BACKGROUND
-    --fkds-color-interactive-surface-background-primary-default: #{$palette-color-fk-black-100};
-    --fkds-color-interactive-surface-background-primary-hover: #{$palette-color-fk-black-70};
-    --fkds-color-interactive-surface-background-primary-active: #{$palette-color-fk-black-70};
-    --fkds-color-interactive-surface-background-primary-focus: #{$palette-color-fk-black-70};
+    --fkds-color-interactive-surface-background-primary-default: #{$palette-color-neutral-800};
+    --fkds-color-interactive-surface-background-primary-hover: #{$palette-color-neutral-700};
+    --fkds-color-interactive-surface-background-primary-active: #{$palette-color-neutral-700};
+    --fkds-color-interactive-surface-background-primary-focus: #{$palette-color-neutral-700};
 
     // NAVIGATION - BORDER
-    --fkds-color-navigation-border-hover: #{$palette-color-green-a-15};
-    --fkds-color-navigation-border-selected: #{$palette-color-green-a-85};
+    --fkds-color-navigation-border-hover: #{$palette-color-green-200};
+    --fkds-color-navigation-border-selected: #{$palette-color-green-500};
 
     // NAVIGATION - BACKGROUND
-    --fkds-color-navigation-background-hover: #{$palette-color-green-a-50};
-    --fkds-color-navigation-background-selected: #{$palette-color-green-a-85};
+    --fkds-color-navigation-background-hover: #{$palette-color-green-200};
+    --fkds-color-navigation-background-selected: #{$palette-color-green-500};
 
     // HEADER - BACKGROUND
-    --fkds-color-header-background-primary: #{$palette-color-green-a-85};
+    --fkds-color-header-background-primary: #{$palette-color-green-400};
 
     // HEADER - TEXT
-    --fkds-color-header-text-primary: #{$palette-color-white-100};
+    --fkds-color-header-text-primary: #{$palette-color-neutral-0};
 
     // FOCUS INDICATOR
-    --fkds-focus-indicator-color: #{$palette-color-white-100};
-    --fkds-focus-indicator-color-background: #{$palette-color-fk-black-100};
+    --fkds-focus-indicator-color: #{$palette-color-neutral-0};
+    --fkds-focus-indicator-color-background: #{$palette-color-neutral-900};
 }

--- a/packages/theme-default/src/fkui-css-variables-deprecated.scss
+++ b/packages/theme-default/src/fkui-css-variables-deprecated.scss
@@ -1,6 +1,6 @@
 // stylelint-disable custom-property-empty-line-before -- technical debt, should just add a comment before each block
 
-@use "palette-variables" as *;
+@use "palette-variables-deprecated" as *;
 
 $global: true !default;
 $palette-color-red-10: #fdeaea !default;

--- a/packages/theme-default/src/light/_variables.scss
+++ b/packages/theme-default/src/light/_variables.scss
@@ -2,109 +2,109 @@
 
 @mixin variables {
     // TEXT
-    --fkds-color-text-primary: #{$palette-color-fk-black-100};
-    --fkds-color-text-secondary: #{$palette-color-fk-black-70};
-    --fkds-color-text-inverted: #{$palette-color-white-100};
-    --fkds-color-text-disabled: #{$palette-color-fk-black-50};
+    --fkds-color-text-primary: #{$palette-color-neutral-900};
+    --fkds-color-text-secondary: #{$palette-color-neutral-600};
+    --fkds-color-text-inverted: #{$palette-color-neutral-0};
+    --fkds-color-text-disabled: #{$palette-color-neutral-600};
 
     // BACKGROUND
-    --fkds-color-background-primary: #{$palette-color-white-100};
-    --fkds-color-background-secondary: #{$palette-color-fk-black-5};
-    --fkds-color-background-tertiary: #{$palette-color-fk-black-15};
-    --fkds-color-background-disabled: #{$palette-color-fk-black-5};
+    --fkds-color-background-primary: #{$palette-color-neutral-0};
+    --fkds-color-background-secondary: #{$palette-color-neutral-50};
+    --fkds-color-background-tertiary: #{$palette-color-neutral-100};
+    --fkds-color-background-disabled: #{$palette-color-neutral-100};
 
     // BORDER
-    --fkds-color-border-primary: #{$palette-color-fk-black-50};
-    --fkds-color-border-strong: #{$palette-color-fk-black-70};
-    --fkds-color-border-weak: #{$palette-color-fk-black-15};
-    --fkds-color-border-disabled: #{$palette-color-fk-black-50};
-    --fkds-color-border-inverted: #{$palette-color-white-100};
+    --fkds-color-border-primary: #{$palette-color-neutral-500};
+    --fkds-color-border-strong: #{$palette-color-neutral-700};
+    --fkds-color-border-weak: #{$palette-color-neutral-200};
+    --fkds-color-border-disabled: #{$palette-color-neutral-400};
+    --fkds-color-border-inverted: #{$palette-color-neutral-0};
 
     // ACTION - TEXT
-    --fkds-color-action-text-primary-default: #{$palette-color-bluebell-100};
-    --fkds-color-action-text-primary-hover: #{$palette-color-bluebell-120};
-    --fkds-color-action-text-primary-active: #{$palette-color-bluebell-120};
-    --fkds-color-action-text-primary-focus: #{$palette-color-bluebell-100};
-    --fkds-color-action-text-secondary-default: #{$palette-color-fk-black-100};
-    --fkds-color-action-text-secondary-hover: #{$palette-color-bluebell-120};
-    --fkds-color-action-text-secondary-active: #{$palette-color-bluebell-120};
-    --fkds-color-action-text-secondary-focus: #{$palette-color-bluebell-100};
-    --fkds-color-action-text-inverted-default: #{$palette-color-white-100};
-    --fkds-color-action-text-inverted-hover: #{$palette-color-white-100};
-    --fkds-color-action-text-inverted-active: #{$palette-color-white-100};
-    --fkds-color-action-text-inverted-focus: #{$palette-color-white-100};
+    --fkds-color-action-text-primary-default: #{$palette-color-blue-600};
+    --fkds-color-action-text-primary-hover: #{$palette-color-blue-700};
+    --fkds-color-action-text-primary-active: #{$palette-color-blue-800};
+    --fkds-color-action-text-primary-focus: #{$palette-color-blue-600};
+    --fkds-color-action-text-secondary-default: #{$palette-color-neutral-900};
+    --fkds-color-action-text-secondary-hover: #{$palette-color-blue-700};
+    --fkds-color-action-text-secondary-active: #{$palette-color-blue-800};
+    --fkds-color-action-text-secondary-focus: #{$palette-color-neutral-900};
+    --fkds-color-action-text-inverted-default: #{$palette-color-neutral-0};
+    --fkds-color-action-text-inverted-hover: #{$palette-color-neutral-0};
+    --fkds-color-action-text-inverted-active: #{$palette-color-neutral-0};
+    --fkds-color-action-text-inverted-focus: #{$palette-color-neutral-0};
 
     // ACTION - BACKGROUND
-    --fkds-color-action-background-primary-default: #{$palette-color-bluebell-100};
-    --fkds-color-action-background-primary-hover: #{$palette-color-bluebell-120};
-    --fkds-color-action-background-primary-active: #{$palette-color-bluebell-120};
-    --fkds-color-action-background-primary-focus: #{$palette-color-bluebell-100};
-    --fkds-color-action-background-secondary-default: #{$palette-color-bluebell-5};
-    --fkds-color-action-background-secondary-hover: #{$palette-color-bluebell-15};
-    --fkds-color-action-background-secondary-active: #{$palette-color-bluebell-15};
-    --fkds-color-action-background-secondary-focus: #{$palette-color-bluebell-5};
+    --fkds-color-action-background-primary-default: #{$palette-color-blue-600};
+    --fkds-color-action-background-primary-hover: #{$palette-color-blue-700};
+    --fkds-color-action-background-primary-active: #{$palette-color-blue-800};
+    --fkds-color-action-background-primary-focus: #{$palette-color-blue-600};
+    --fkds-color-action-background-secondary-default: #{$palette-color-neutral-0};
+    --fkds-color-action-background-secondary-hover: #{$palette-color-blue-100};
+    --fkds-color-action-background-secondary-active: #{$palette-color-blue-200};
+    --fkds-color-action-background-secondary-focus: #{$palette-color-neutral-0};
 
     // ACTION - BORDER
-    --fkds-color-action-border-primary-default: #{$palette-color-bluebell-100};
-    --fkds-color-action-border-primary-hover: #{$palette-color-bluebell-120};
-    --fkds-color-action-border-primary-active: #{$palette-color-bluebell-120};
-    --fkds-color-action-border-primary-focus: #{$palette-color-bluebell-100};
+    --fkds-color-action-border-primary-default: #{$palette-color-blue-600};
+    --fkds-color-action-border-primary-hover: #{$palette-color-blue-700};
+    --fkds-color-action-border-primary-active: #{$palette-color-blue-800};
+    --fkds-color-action-border-primary-focus: #{$palette-color-blue-600};
 
     // FEEDBACK - BACKGROUND
-    --fkds-color-feedback-background-neutral: #{$palette-color-fk-black-5};
-    --fkds-color-feedback-background-neutral-strong: #{$palette-color-fk-black-15};
-    --fkds-color-feedback-background-info: #{$palette-color-bluebell-5};
-    --fkds-color-feedback-background-info-strong: #{$palette-color-bluebell-100};
-    --fkds-color-feedback-background-positive: #{$palette-color-green-a-5};
-    --fkds-color-feedback-background-positive-strong: #{$palette-color-green-a-85};
-    --fkds-color-feedback-background-warning: #{$palette-color-yellow-5};
-    --fkds-color-feedback-background-warning-strong: #{$palette-color-yellow-100};
-    --fkds-color-feedback-background-negative: #{$palette-color-red-5};
-    --fkds-color-feedback-background-negative-strong: #{$palette-color-red-100};
+    --fkds-color-feedback-background-neutral: #{$palette-color-neutral-0};
+    --fkds-color-feedback-background-neutral-strong: #{$palette-color-neutral-200};
+    --fkds-color-feedback-background-info: #{$palette-color-blue-50};
+    --fkds-color-feedback-background-info-strong: #{$palette-color-blue-500};
+    --fkds-color-feedback-background-positive: #{$palette-color-green-50};
+    --fkds-color-feedback-background-positive-strong: #{$palette-color-green-600};
+    --fkds-color-feedback-background-warning: #{$palette-color-yellow-50};
+    --fkds-color-feedback-background-warning-strong: #{$palette-color-yellow-500};
+    --fkds-color-feedback-background-negative: #{$palette-color-red-50};
+    --fkds-color-feedback-background-negative-strong: #{$palette-color-red-500};
 
     // FEEDBACK - BORDER
-    --fkds-color-feedback-border-neutral: #{$palette-color-fk-black-50};
-    --fkds-color-feedback-border-info: #{$palette-color-bluebell-100};
-    --fkds-color-feedback-border-positive: #{$palette-color-green-a-85};
-    --fkds-color-feedback-border-warning: #{$palette-color-yellow-100};
-    --fkds-color-feedback-border-negative: #{$palette-color-red-100};
+    --fkds-color-feedback-border-neutral: #{$palette-color-neutral-500};
+    --fkds-color-feedback-border-info: #{$palette-color-blue-500};
+    --fkds-color-feedback-border-positive: #{$palette-color-green-500};
+    --fkds-color-feedback-border-warning: #{$palette-color-yellow-500};
+    --fkds-color-feedback-border-negative: #{$palette-color-red-500};
 
     // FEEDBACK - TEXT
-    --fkds-color-feedback-text-negative: #{$palette-color-red-100};
-    --fkds-color-feedback-text-positive: #{$palette-color-green-a-85};
-    --fkds-color-feedback-text-on-warning: #{$palette-color-fk-black-100};
+    --fkds-color-feedback-text-negative: #{$palette-color-red-500};
+    --fkds-color-feedback-text-positive: #{$palette-color-green-600};
+    --fkds-color-feedback-text-on-warning: #{$palette-color-neutral-900};
 
     // SELECT - BACKGROUND
-    --fkds-color-select-background-primary-default: #{$palette-color-bluebell-100};
-    --fkds-color-select-background-primary-hover: #{$palette-color-bluebell-15};
-    --fkds-color-select-background-primary-active: #{$palette-color-bluebell-15};
-    --fkds-color-select-background-primary-focus: #{$palette-color-bluebell-15};
-    --fkds-color-select-background-secondary-default: #{$palette-color-green-a-85};
-    --fkds-color-select-background-secondary-hover: #{$palette-color-green-a-15};
-    --fkds-color-select-background-secondary-active: #{$palette-color-green-a-15};
-    --fkds-color-select-background-secondary-focus: #{$palette-color-green-a-15};
+    --fkds-color-select-background-primary-default: #{$palette-color-blue-600};
+    --fkds-color-select-background-primary-hover: #{$palette-color-blue-100};
+    --fkds-color-select-background-primary-active: #{$palette-color-blue-200};
+    --fkds-color-select-background-primary-focus: #{$palette-color-blue-100};
+    --fkds-color-select-background-secondary-default: #{$palette-color-green-600};
+    --fkds-color-select-background-secondary-hover: #{$palette-color-green-100};
+    --fkds-color-select-background-secondary-active: #{$palette-color-green-200};
+    --fkds-color-select-background-secondary-focus: #{$palette-color-green-100};
 
     // INTERACTIVE SURFACE - BACKGROUND
-    --fkds-color-interactive-surface-background-primary-default: #{$palette-color-fk-black-5};
-    --fkds-color-interactive-surface-background-primary-hover: #{$palette-color-fk-black-15};
-    --fkds-color-interactive-surface-background-primary-active: #{$palette-color-fk-black-15};
-    --fkds-color-interactive-surface-background-primary-focus: #{$palette-color-fk-black-15};
+    --fkds-color-interactive-surface-background-primary-default: #{$palette-color-neutral-50};
+    --fkds-color-interactive-surface-background-primary-hover: #{$palette-color-neutral-100};
+    --fkds-color-interactive-surface-background-primary-active: #{$palette-color-neutral-100};
+    --fkds-color-interactive-surface-background-primary-focus: #{$palette-color-neutral-100};
 
     // NAVIGATION - BORDER
-    --fkds-color-navigation-border-hover: #{$palette-color-green-a-50};
-    --fkds-color-navigation-border-selected: #{$palette-color-green-a-85};
+    --fkds-color-navigation-border-hover: #{$palette-color-green-200};
+    --fkds-color-navigation-border-selected: #{$palette-color-green-600};
 
     // NAVIGATION - BACKGROUND
-    --fkds-color-navigation-background-hover: #{$palette-color-green-a-15};
-    --fkds-color-navigation-background-selected: #{$palette-color-green-a-85};
+    --fkds-color-navigation-background-hover: #{$palette-color-green-200};
+    --fkds-color-navigation-background-selected: #{$palette-color-green-600};
 
     // HEADER - BACKGROUND
-    --fkds-color-header-background-primary: #{$palette-color-green-a-100};
+    --fkds-color-header-background-primary: #{$palette-color-green-600};
 
     // HEADER - TEXT
-    --fkds-color-header-text-primary: #{$palette-color-white-100};
+    --fkds-color-header-text-primary: #{$palette-color-neutral-0};
 
     // FOCUS INDICATOR
-    --fkds-focus-indicator-color: #{$palette-color-fk-black-100};
-    --fkds-focus-indicator-color-background: #{$palette-color-white-100};
+    --fkds-focus-indicator-color: #{$palette-color-neutral-900};
+    --fkds-focus-indicator-color-background: #{$palette-color-neutral-0};
 }

--- a/packages/theme-default/src/palette-variables.scss
+++ b/packages/theme-default/src/palette-variables.scss
@@ -1,75 +1,63 @@
-// Palette colors
+// New palette colors
 // Palette colors should follow the following palette-color-<name> convention.
 
-/// @group FK-Black
-$palette-color-fk-black-100: #1b1e23 !default;
-$palette-color-fk-black-70: #5f6165 !default;
-$palette-color-fk-black-50: #8d8e91 !default;
-$palette-color-fk-black-30: #bbbbbd !default;
-$palette-color-fk-black-15: #ddddde !default;
-$palette-color-fk-black-5: #f4f4f4 !default;
-$palette-color-white-100: #ffffff !default;
+/// @group Neutral
+$palette-color-neutral-900: #1b1e23 !default;
+$palette-color-neutral-800: #2d3139 !default;
+$palette-color-neutral-700: #494f5b !default;
+$palette-color-neutral-600: #606876 !default;
+$palette-color-neutral-500: #777f8d !default;
+$palette-color-neutral-400: #8e949f !default;
+$palette-color-neutral-300: #afb3bb !default;
+$palette-color-neutral-200: #d6d8dc !default;
+$palette-color-neutral-100: #ecedef !default;
+$palette-color-neutral-50: #f7f7f8 !default;
+$palette-color-neutral-0: #ffffff !default;
 
-/// @group Bluebell
-$palette-color-bluebell-120: #3b4292 !default;
-$palette-color-bluebell-100: #4a52b6 !default;
-$palette-color-bluebell-85: #656cc1 !default;
-$palette-color-bluebell-50: #a4a8db !default;
-$palette-color-bluebell-15: #e5e5f5 !default;
-$palette-color-bluebell-5: #f5f6fa !default;
+/// @group Blue
+$palette-color-blue-900: #061023 !default;
+$palette-color-blue-800: #14336c !default;
+$palette-color-blue-700: #1b478d !default;
+$palette-color-blue-600: #2358af !default;
+$palette-color-blue-500: #3472d5 !default;
+$palette-color-blue-400: #578edb !default;
+$palette-color-blue-300: #76a6e0 !default;
+$palette-color-blue-200: #97bbe7 !default;
+$palette-color-blue-100: #dee9f7 !default;
+$palette-color-blue-50: #f3f7fc !default;
 
-/// @group Green A
-$palette-color-green-a-120: #0e5532 !default;
-$palette-color-green-a-100: #116a3e !default;
-$palette-color-green-a-85: #35805b !default;
-$palette-color-green-a-50: #88b49f !default;
-$palette-color-green-a-15: #dbe9e2 !default;
-$palette-color-green-a-5: #f3f8f5 !default;
-
-/// @group Green B
-$palette-color-green-b-120: #4c7e56 !default;
-$palette-color-green-b-100: #5f9e6c !default;
-$palette-color-green-b-85: #77ad82 !default;
-$palette-color-green-b-50: #afcfb5 !default;
-$palette-color-green-b-15: #e7f0e9 !default;
-$palette-color-green-b-5: #f7faf8 !default;
+/// @group Green
+$palette-color-green-900: #041f12 !default;
+$palette-color-green-800: #0b4c2b !default;
+$palette-color-green-700: #116a3e !default;
+$palette-color-green-600: #1b7e4d !default;
+$palette-color-green-500: #248f59 !default;
+$palette-color-green-400: #41aa75 !default;
+$palette-color-green-300: #70bd96 !default;
+$palette-color-green-200: #96cfb2 !default;
+$palette-color-green-100: #d9ede3 !default;
+$palette-color-green-50: #f5faf7 !default;
 
 /// @group Yellow
-$palette-color-yellow-120: #cc980d !default;
-$palette-color-yellow-100: #ffbe10 !default;
-$palette-color-yellow-85: #ffc834 !default;
-$palette-color-yellow-50: #ffdf87 !default;
-$palette-color-yellow-15: #fff5db !default;
-$palette-color-yellow-5: #fffcf3 !default;
+$palette-color-yellow-900: #231c00 !default;
+$palette-color-yellow-800: #795b01 !default;
+$palette-color-yellow-700: #b18502 !default;
+$palette-color-yellow-600: #d6a103 !default;
+$palette-color-yellow-500: #f1b604 !default;
+$palette-color-yellow-400: #f2cc4d !default;
+$palette-color-yellow-300: #f6db80 !default;
+$palette-color-yellow-200: #f9e49f !default;
+$palette-color-yellow-100: #fef4cd !default;
+$palette-color-yellow-50: #fffbf0 !default;
 
 /// @group Red
-$palette-color-red-120: #a21111 !default;
-$palette-color-red-100: #ca1515 !default;
-$palette-color-red-85: #d23838 !default;
-$palette-color-red-50: #e48a8a !default;
-$palette-color-red-15: #f7dcdc !default;
-$palette-color-red-5: #fcf3f3 !default;
-
-/// @group Orange
-$palette-color-orange-120: #c2700d !default;
-$palette-color-orange-100: #f38c10 !default;
-$palette-color-orange-85: #f59d34 !default;
-$palette-color-orange-50: #f9c587 !default;
-$palette-color-orange-15: #ffefdc !default;
-$palette-color-orange-5: #fef9f3 !default;
-
-/// @group Tegel
-$palette-color-tegel-100: #d34503 !default;
-$palette-color-tegel-15: #f8e3d9 !default;
-
-/// @group Plommon
-$palette-color-plommon-100: #a73a64 !default;
-$palette-color-plommon-15: #f2e1e8 !default;
-
-/// @group Senap
-$palette-color-senap-100: #ba7918 !default;
-$palette-color-senap-15: #f5ebdc !default;
-
-/// @group Hav
-$palette-color-hav-100: #4c669f !default;
-$palette-color-hav-15: #e4e8f1 !default;
+$palette-color-red-900: #220506 !default;
+$palette-color-red-800: #6e1517 !default;
+$palette-color-red-700: #9f2024 !default;
+$palette-color-red-600: #bf272b !default;
+$palette-color-red-500: #df3035 !default;
+$palette-color-red-400: #e85b60 !default;
+$palette-color-red-300: #ef8a8e !default;
+$palette-color-red-200: #f4afb2 !default;
+$palette-color-red-100: #f9dcdc !default;
+$palette-color-red-50: #fdf3f3 !default;

--- a/packages/theme-desktop/src/palette-variables.scss
+++ b/packages/theme-desktop/src/palette-variables.scss
@@ -1,75 +1,63 @@
-// Palette colors
+// New palette colors
 // Palette colors should follow the following palette-color-<name> convention.
 
-/// @group FK-Black
-$palette-color-fk-black-100: #1b1e23 !default;
-$palette-color-fk-black-70: #5f6165 !default;
-$palette-color-fk-black-50: #8d8e91 !default;
-$palette-color-fk-black-30: #bbbbbd !default;
-$palette-color-fk-black-15: #ddddde !default;
-$palette-color-fk-black-5: #f4f4f4 !default;
-$palette-color-white-100: #ffffff !default;
+/// @group Neutral
+$palette-color-neutral-900: #1b1e23 !default;
+$palette-color-neutral-800: #2d3139 !default;
+$palette-color-neutral-700: #494f5b !default;
+$palette-color-neutral-600: #606876 !default;
+$palette-color-neutral-500: #777f8d !default;
+$palette-color-neutral-400: #8e949f !default;
+$palette-color-neutral-300: #afb3bb !default;
+$palette-color-neutral-200: #d6d8dc !default;
+$palette-color-neutral-100: #ecedef !default;
+$palette-color-neutral-50: #f7f7f8 !default;
+$palette-color-neutral-0: #ffffff !default;
 
-/// @group Bluebell
-$palette-color-bluebell-120: #3b4292 !default;
-$palette-color-bluebell-100: #4a52b6 !default;
-$palette-color-bluebell-85: #656cc1 !default;
-$palette-color-bluebell-50: #a4a8db !default;
-$palette-color-bluebell-15: #e5e5f5 !default;
-$palette-color-bluebell-5: #f5f6fa !default;
+/// @group Blue
+$palette-color-blue-900: #061023 !default;
+$palette-color-blue-800: #14336c !default;
+$palette-color-blue-700: #1b478d !default;
+$palette-color-blue-600: #2358af !default;
+$palette-color-blue-500: #3472d5 !default;
+$palette-color-blue-400: #578edb !default;
+$palette-color-blue-300: #76a6e0 !default;
+$palette-color-blue-200: #97bbe7 !default;
+$palette-color-blue-100: #dee9f7 !default;
+$palette-color-blue-50: #f3f7fc !default;
 
-/// @group Green A
-$palette-color-green-a-120: #0e5532 !default;
-$palette-color-green-a-100: #116a3e !default;
-$palette-color-green-a-85: #35805b !default;
-$palette-color-green-a-50: #88b49f !default;
-$palette-color-green-a-15: #dbe9e2 !default;
-$palette-color-green-a-5: #f3f8f5 !default;
-
-/// @group Green B
-$palette-color-green-b-120: #4c7e56 !default;
-$palette-color-green-b-100: #5f9e6c !default;
-$palette-color-green-b-85: #77ad82 !default;
-$palette-color-green-b-50: #afcfb5 !default;
-$palette-color-green-b-15: #e7f0e9 !default;
-$palette-color-green-b-5: #f7faf8 !default;
+/// @group Green
+$palette-color-green-900: #041f12 !default;
+$palette-color-green-800: #0b4c2b !default;
+$palette-color-green-700: #116a3e !default;
+$palette-color-green-600: #1b7e4d !default;
+$palette-color-green-500: #248f59 !default;
+$palette-color-green-400: #41aa75 !default;
+$palette-color-green-300: #70bd96 !default;
+$palette-color-green-200: #96cfb2 !default;
+$palette-color-green-100: #d9ede3 !default;
+$palette-color-green-50: #f5faf7 !default;
 
 /// @group Yellow
-$palette-color-yellow-120: #cc980d !default;
-$palette-color-yellow-100: #ffbe10 !default;
-$palette-color-yellow-85: #ffc834 !default;
-$palette-color-yellow-50: #ffdf87 !default;
-$palette-color-yellow-15: #fff5db !default;
-$palette-color-yellow-5: #fffcf3 !default;
+$palette-color-yellow-900: #231c00 !default;
+$palette-color-yellow-800: #795b01 !default;
+$palette-color-yellow-700: #b18502 !default;
+$palette-color-yellow-600: #d6a103 !default;
+$palette-color-yellow-500: #f1b604 !default;
+$palette-color-yellow-400: #f2cc4d !default;
+$palette-color-yellow-300: #f6db80 !default;
+$palette-color-yellow-200: #f9e49f !default;
+$palette-color-yellow-100: #fef4cd !default;
+$palette-color-yellow-50: #fffbf0 !default;
 
 /// @group Red
-$palette-color-red-120: #a21111 !default;
-$palette-color-red-100: #ca1515 !default;
-$palette-color-red-85: #d23838 !default;
-$palette-color-red-50: #e48a8a !default;
-$palette-color-red-15: #f7dcdc !default;
-$palette-color-red-5: #fcf3f3 !default;
-
-/// @group Orange
-$palette-color-orange-120: #c2700d !default;
-$palette-color-orange-100: #f38c10 !default;
-$palette-color-orange-85: #f59d34 !default;
-$palette-color-orange-50: #f9c587 !default;
-$palette-color-orange-15: #ffefdc !default;
-$palette-color-orange-5: #fef9f3 !default;
-
-/// @group Tegel
-$palette-color-tegel-100: #d34503 !default;
-$palette-color-tegel-15: #f8e3d9 !default;
-
-/// @group Plommon
-$palette-color-plommon-100: #a73a64 !default;
-$palette-color-plommon-15: #f2e1e8 !default;
-
-/// @group Senap
-$palette-color-senap-100: #ba7918 !default;
-$palette-color-senap-15: #f5ebdc !default;
-
-/// @group Hav
-$palette-color-hav-100: #4c669f !default;
-$palette-color-hav-15: #e4e8f1 !default;
+$palette-color-red-900: #220506 !default;
+$palette-color-red-800: #6e1517 !default;
+$palette-color-red-700: #9f2024 !default;
+$palette-color-red-600: #bf272b !default;
+$palette-color-red-500: #df3035 !default;
+$palette-color-red-400: #e85b60 !default;
+$palette-color-red-300: #ef8a8e !default;
+$palette-color-red-200: #f4afb2 !default;
+$palette-color-red-100: #f9dcdc !default;
+$palette-color-red-50: #fdf3f3 !default;


### PR DESCRIPTION
Uppdaterar till den nya färgpaletten:

- Mappar om semantiska färgtokens i `theme-default` till nya palettfärger för light/dark.
- Uppdaterar publicerad Sass-palett och `palette.json` till nya palettnamn/färger.
- Uppdaterar `theme-desktop` med samma nya palett som `theme-default`.
- Flyttar gamla palettvärden till en intern deprecated-palett så deprecated CSS-variabler fortsatt får gamla hexvärden.
- Uppdaterar docs-temats direkta palettanvändning till nya palettnamn.

Huvuddragen av det som är gjort i nya paletten:

- Generaliserad namnsättning. fk-black -> neutral, bluebell -> blue, a-green+b-green -> green.
- Standardiserad namnsättning med 50-900 skala.
- Utökning av palettfärger för att stödja darkmode.
- Kontrastsäkring i komponenter i både ljust och mörkt läge. Behöver dock ytterligare testning.