### PR TITLE
refactor: remove default assignment of `type` button attribute in two components (refs SFKUI-6500)

### DIFF
--- a/examples/page-layout/src/views/XOverviewView.vue
+++ b/examples/page-layout/src/views/XOverviewView.vue
@@ -25,7 +25,7 @@ function openThing(): void {
 <template>
     <h1>Översikt</h1>
     <p>Lorem ipsum dolor sit amet</p>
-    <f-button type="button" variant="secondary" @click="openThing">Öppna en helt annan detaljpanel</f-button>
+    <f-button variant="secondary" @click="openThing">Öppna en helt annan detaljpanel</f-button>
 
     <f-interactive-table
         :rows="ankeborgare"

--- a/packages/vue/src/components/FWizard/examples/FWizardExampleAddStep.vue
+++ b/packages/vue/src/components/FWizard/examples/FWizardExampleAddStep.vue
@@ -121,7 +121,7 @@ export default defineComponent({
         <!-- [html-validate-disable-next no-inline-style] -->
         <p style="margin-top: 30px">
             Ett steg kan öppnas programatiskt, t.ex. man klickar 'ändra' i ett granska-steg.
-            <f-button type="button" @click="current = 'baz'">Öppna sista steget</f-button>
+            <f-button @click="current = 'baz'">Öppna sista steget</f-button>
         </p>
         <pre>v-model: {{ current }}</pre>
     </div>


### PR DESCRIPTION
Tar bort två instanser av `type="button"` som jag missade i #1065.