### PR TITLE
fix: catch keyup event  restore last value (refs SFKUI-7793)

### DIFF
--- a/packages/vue/src/components/FSelectField/FSelectField.vue
+++ b/packages/vue/src/components/FSelectField/FSelectField.vue
@@ -84,6 +84,7 @@ export default defineComponent({
         return {
             validityMode: "INITIAL" as string,
             validationMessage: "" as string,
+            lastValueBeforeUpdate: "" as unknown,
         };
     },
     computed: {
@@ -119,12 +120,17 @@ export default defineComponent({
                 return this.modelValue;
             },
             set(value: unknown) {
+                this.lastValueBeforeUpdate = this.modelValue;
                 this.$emit("update:modelValue", value);
                 this.$emit("change", value);
             },
         },
     },
     methods: {
+        onKeydownEsc(): void {
+            this.$emit("update:modelValue", this.lastValueBeforeUpdate);
+            this.$emit("change", this.lastValueBeforeUpdate);
+        },
         async onValidity({ detail }: CustomEvent<ValidityEvent>): Promise<void> {
             this.validationMessage = detail.validationMessage;
             this.validityMode = detail.validityMode;
@@ -182,7 +188,7 @@ export default defineComponent({
             </f-label>
         </div>
         <div class="select-field__icon-wrapper" :class="selectWrapperClass">
-            <select :id v-model="vModel" class="select-field__select" v-bind="attrs">
+            <select :id v-model="vModel" class="select-field__select" v-bind="attrs" @keyup.esc="onKeydownEsc">
                 <slot></slot>
             </select>
             <f-icon


### PR DESCRIPTION
select tar bort keyevent när rullgardinen trillar ner så keyup är det enda som funkar och då är redan value satt. Men en gammal rökare som behåller last value som man kan titta på vid esc återställer värdet från last value. Det blir ingen bra lösning för värdet komer blinka till om det är synligt.