### PR TITLE
test: convert `FErrorList` inline snapshots to external snapshots (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FErrorList/FErrorList.spec.ts
+++ b/packages/vue/src/components/FErrorList/FErrorList.spec.ts
@@ -37,20 +37,7 @@ describe("snapshots", () => {
                 items: [{ id: "foo", title: "No bullets" }],
             },
         });
-        /* eslint-disable-next-line jest/no-large-snapshots -- technical debt */
-        expect(wrapper.find("li").element).toMatchInlineSnapshot(`
-            <li
-              class="error-list__link"
-            >
-              <a
-                href="javascript:"
-              >
-                
-                No bullets
-                
-              </a>
-            </li>
-        `);
+        expect(wrapper.find("li").element).toMatchSnapshot();
     });
 
     it("should match snapshot when no link and no bullets (default)", () => {
@@ -59,17 +46,7 @@ describe("snapshots", () => {
                 items: [{ title: "No bullets" }],
             },
         });
-        expect(wrapper.find("li").element).toMatchInlineSnapshot(`
-            <li
-              class=""
-            >
-              
-              
-              No bullets
-              
-              
-            </li>
-        `);
+        expect(wrapper.find("li").element).toMatchSnapshot();
     });
 
     it("should match snapshot when link and bullets", () => {
@@ -79,29 +56,7 @@ describe("snapshots", () => {
                 bullets: true,
             },
         });
-        /* eslint-disable-next-line jest/no-large-snapshots -- technical debt,
-         * should add explicit tests for expected attributes or elements */
-        expect(wrapper.find("li").element).toMatchInlineSnapshot(`
-            <li
-              class=""
-            >
-              <a
-                href="javascript:"
-              >
-                
-                <span
-                  aria-hidden="true"
-                  class="error-list__bullet"
-                />
-                <span
-                  class="error-list__link"
-                >
-                  Bullet proof
-                </span>
-                
-              </a>
-            </li>
-        `);
+        expect(wrapper.find("li").element).toMatchSnapshot();
     });
 
     it("should match snapshot when no link and bullets", () => {
@@ -111,25 +66,7 @@ describe("snapshots", () => {
                 bullets: true,
             },
         });
-        /* eslint-disable-next-line jest/no-large-snapshots -- technical debt,
-         * should add explicit tests for expected attributes or elements */
-        expect(wrapper.find("li").element).toMatchInlineSnapshot(`
-            <li
-              class=""
-            >
-              
-              
-              <span
-                aria-hidden="true"
-                class="error-list__bullet"
-              />
-              <span>
-                Bullet proof
-              </span>
-              
-              
-            </li>
-        `);
+        expect(wrapper.find("li").element).toMatchSnapshot();
     });
 });
 

--- a/packages/vue/src/components/FErrorList/__snapshots__/FErrorList.spec.ts.snap
+++ b/packages/vue/src/components/FErrorList/__snapshots__/FErrorList.spec.ts.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots should match snapshot when link and bullets 1`] = `
+<li
+  class=""
+>
+  <a
+    href="javascript:"
+  >
+    
+    <span
+      aria-hidden="true"
+      class="error-list__bullet"
+    />
+    <span
+      class="error-list__link"
+    >
+      Bullet proof
+    </span>
+    
+  </a>
+</li>
+`;
+
+exports[`snapshots should match snapshot when link and no bullets (default) 1`] = `
+<li
+  class="error-list__link"
+>
+  <a
+    href="javascript:"
+  >
+    
+    No bullets
+    
+  </a>
+</li>
+`;
+
+exports[`snapshots should match snapshot when no link and bullets 1`] = `
+<li
+  class=""
+>
+  
+  
+  <span
+    aria-hidden="true"
+    class="error-list__bullet"
+  />
+  <span>
+    Bullet proof
+  </span>
+  
+  
+</li>
+`;
+
+exports[`snapshots should match snapshot when no link and no bullets (default) 1`] = `
+<li
+  class=""
+>
+  
+  
+  No bullets
+  
+  
+</li>
+`;


### PR DESCRIPTION
### Bakgrund
Jag har problem i #1218 med att Lint försör inline snapshots genom att ta bort whitespace.

Denna commit har fungerande snapshots och varnar om lint-fel: https://github.com/Forsakringskassan/designsystem/pull/1218/changes/26e13586acb6121b220b8fdd0e0fc2c58b109a0c

Denna commit har åtgärdat lint-felen och förstört snapshots (genom att ta bort whitespace): https://github.com/Forsakringskassan/designsystem/pull/1218/changes/d542637341625661aba905fba91a5a30e221c64f

### Förslag till lösning
Jag föreslår att konvertera till externa snapshots genom att byta från `toMatchInlineSnapshot()` till `toMatchSnapshot()`.
Det lägger koden i en fil som inte berörs av lint-regler.