### PR TITLE
fix(deps): raised the allowed version of sass to 1.92 (refs SFKUI-7836)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28777,7 +28777,7 @@
       },
       "peerDependencies": {
         "@fkui/theme-default": "^6.43.1",
-        "sass": "^1.40.0",
+        "sass": "^1.92.0",
         "stylelint": ">= 14"
       },
       "peerDependenciesMeta": {

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "@fkui/theme-default": "^6.43.1",
-    "sass": "^1.40.0",
+    "sass": "^1.92.0",
     "stylelint": ">= 14"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
1.92 Breaking change: Emit declarations, childless at-rules, and comments in the order they appear in the source even when they're interleaved with nested rules. This obsoletes the mixed-decls deprecation.

https://github.com/sass/dart-sass/blob/main/CHANGELOG.md