### PR TITLE
refactor(eslint): restrict usage of options api (refs SFKUI-6500)

### DIFF
--- a/docs/components/input/examples/ComboboxExample.vue
+++ b/docs/components/input/examples/ComboboxExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset, FTextField, FTooltip } from "@fkui/vue";

--- a/docs/components/page-layout/examples/FLayoutApplicationTemplateExample.vue
+++ b/docs/components/page-layout/examples/FLayoutApplicationTemplateExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/docs/components/page-layout/examples/FLayoutApplicationTemplateParts.vue
+++ b/docs/components/page-layout/examples/FLayoutApplicationTemplateParts.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FLayoutApplicationTemplate } from "@fkui/vue";

--- a/docs/components/validation/examples/BankAccountNumberExample.vue
+++ b/docs/components/validation/examples/BankAccountNumberExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/BankgiroExample.vue
+++ b/docs/components/validation/examples/BankgiroExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/ClearingNumberExample.vue
+++ b/docs/components/validation/examples/ClearingNumberExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/CurrencyExample.vue
+++ b/docs/components/validation/examples/CurrencyExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/DateExample.vue
+++ b/docs/components/validation/examples/DateExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/DateFormatExample.vue
+++ b/docs/components/validation/examples/DateFormatExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/DecimalExample.vue
+++ b/docs/components/validation/examples/DecimalExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/EmailExample.vue
+++ b/docs/components/validation/examples/EmailExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/GreaterThanExample.vue
+++ b/docs/components/validation/examples/GreaterThanExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/IntegerExample.vue
+++ b/docs/components/validation/examples/IntegerExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/InvalidDatesExample.vue
+++ b/docs/components/validation/examples/InvalidDatesExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/InvalidWeekdaysExample.vue
+++ b/docs/components/validation/examples/InvalidWeekdaysExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/LessThanExample.vue
+++ b/docs/components/validation/examples/LessThanExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/MatchesExample.vue
+++ b/docs/components/validation/examples/MatchesExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/MaxDateExample.vue
+++ b/docs/components/validation/examples/MaxDateExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/MaxLengthExample.vue
+++ b/docs/components/validation/examples/MaxLengthExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/MaxValueExample.vue
+++ b/docs/components/validation/examples/MaxValueExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/MinDateExample.vue
+++ b/docs/components/validation/examples/MinDateExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/MinLengthExample.vue
+++ b/docs/components/validation/examples/MinLengthExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/MinValueExample.vue
+++ b/docs/components/validation/examples/MinValueExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/NumberExample.vue
+++ b/docs/components/validation/examples/NumberExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/OrganisationsnummerExample.vue
+++ b/docs/components/validation/examples/OrganisationsnummerExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/PercentExample.vue
+++ b/docs/components/validation/examples/PercentExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/PersonnummerFormatExample.vue
+++ b/docs/components/validation/examples/PersonnummerFormatExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/PersonnummerLuhnExample.vue
+++ b/docs/components/validation/examples/PersonnummerLuhnExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/PersonnummerNotSameExample.vue
+++ b/docs/components/validation/examples/PersonnummerNotSameExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/PersonnummerOlderExample.vue
+++ b/docs/components/validation/examples/PersonnummerOlderExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/PersonnummerYoungerExample.vue
+++ b/docs/components/validation/examples/PersonnummerYoungerExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/PhoneNumberExample.vue
+++ b/docs/components/validation/examples/PhoneNumberExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/PlusgiroExample.vue
+++ b/docs/components/validation/examples/PlusgiroExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/PostalCodeExample.vue
+++ b/docs/components/validation/examples/PostalCodeExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/components/validation/examples/RequiredExample.vue
+++ b/docs/components/validation/examples/RequiredExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FTextField, FValidationForm } from "@fkui/vue";

--- a/docs/components/validation/examples/WhitelistExample.vue
+++ b/docs/components/validation/examples/WhitelistExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/docs/guides/validation/examples/CombinedFormatterParserExample.vue
+++ b/docs/guides/validation/examples/CombinedFormatterParserExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { formatNumber, parseNumber } from "@fkui/logic";

--- a/docs/guides/validation/examples/CrossValidateDates.vue
+++ b/docs/guides/validation/examples/CrossValidateDates.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FDate, Weekday } from "@fkui/date";

--- a/docs/guides/validation/examples/CustomValidatorExample.vue
+++ b/docs/guides/validation/examples/CustomValidatorExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/docs/guides/validation/examples/FormatterExample.vue
+++ b/docs/guides/validation/examples/FormatterExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { formatNumber } from "@fkui/logic";

--- a/docs/guides/validation/examples/ParserExample.vue
+++ b/docs/guides/validation/examples/ParserExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { parseNumber } from "@fkui/logic";

--- a/docs/guides/validation/examples/WithFormatterExample.vue
+++ b/docs/guides/validation/examples/WithFormatterExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FOutputField, FTextField } from "@fkui/vue";

--- a/docs/guides/validation/examples/WithParserExample.vue
+++ b/docs/guides/validation/examples/WithParserExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FOutputField, FTextField } from "@fkui/vue";

--- a/docs/guides/validation/examples/WithParserFormatterExample.vue
+++ b/docs/guides/validation/examples/WithParserFormatterExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FOutputField, FTextField } from "@fkui/vue";

--- a/docs/styles/examples/ColorTable.vue
+++ b/docs/styles/examples/ColorTable.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type SassVariable } from "@fkui/theme-default/dist/palette.json";

--- a/docs/styles/examples/CompareDensity.vue
+++ b/docs/styles/examples/CompareDensity.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/docs/styles/examples/DensityExample.vue
+++ b/docs/styles/examples/DensityExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FDataTable, FTableColumn } from "@fkui/vue";

--- a/docs/styles/examples/PaletteList.vue
+++ b/docs/styles/examples/PaletteList.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import palette from "@fkui/theme-default/dist/palette.json";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,6 +89,10 @@ export default [
         name: "local/stricter-rules/vue",
         files: ["**/*.vue"],
         rules: {
+            "vue/component-api-style": [
+                "error",
+                ["script-setup", "composition"], // "script-setup", "composition", "composition-vue2", or "options"
+            ],
             "vue/no-unsupported-features": [
                 "error",
                 {

--- a/internal/vue-sandbox/src/views/DefaultView.vue
+++ b/internal/vue-sandbox/src/views/DefaultView.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/packages/vue-labs/src/components/FTable/examples/FTableColumnLiveExample.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableColumnLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, h } from "vue";
 import { FDate } from "@fkui/date";

--- a/packages/vue-labs/src/components/FTable/examples/FTableLiveExample.vue
+++ b/packages/vue-labs/src/components/FTable/examples/FTableLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, h } from "vue";
 import { formatNumber } from "@fkui/logic";

--- a/packages/vue-labs/src/components/XTimeTextField/XTimeTextField.vue
+++ b/packages/vue-labs/src/components/XTimeTextField/XTimeTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { ValidationService, isSet } from "@fkui/logic";

--- a/packages/vue-labs/src/components/XTimeTextField/examples/ForgivingInput.vue
+++ b/packages/vue-labs/src/components/XTimeTextField/examples/ForgivingInput.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue-labs/src/components/XTimeTextField/examples/XTimeTextFieldExample.vue
+++ b/packages/vue-labs/src/components/XTimeTextField/examples/XTimeTextFieldExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue-labs/src/vite-dev/app.vue
+++ b/packages/vue-labs/src/vite-dev/app.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/packages/vue/src/components/FBadge/examples/FBadgeLiveExample.vue
+++ b/packages/vue/src/components/FBadge/examples/FBadgeLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FBadge, FCheckboxField, FSelectField } from "@fkui/vue";

--- a/packages/vue/src/components/FButton/examples/FButtonLiveExample.vue
+++ b/packages/vue/src/components/FButton/examples/FButtonLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FCheckboxField, FFieldset, FIcon, FRadioField, FSelectField } from "@fkui/vue";

--- a/packages/vue/src/components/FCalendar/FCalendar.vue
+++ b/packages/vue/src/components/FCalendar/FCalendar.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, computed, defineComponent, shallowRef, useTemplateRef, watch } from "vue";
 import { type FDate, type FYear } from "@fkui/date";

--- a/packages/vue/src/components/FCalendar/FCalendarDay.vue
+++ b/packages/vue/src/components/FCalendar/FCalendarDay.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type FDate } from "@fkui/date";

--- a/packages/vue/src/components/FCalendar/examples/FCalendarCustom.vue
+++ b/packages/vue/src/components/FCalendar/examples/FCalendarCustom.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, shallowRef } from "vue";
 import { FDate } from "@fkui/date";

--- a/packages/vue/src/components/FCalendar/examples/FCalendarLiveExample.vue
+++ b/packages/vue/src/components/FCalendar/examples/FCalendarLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FDate } from "@fkui/date";

--- a/packages/vue/src/components/FCalendar/examples/FCalendarSelectDays.vue
+++ b/packages/vue/src/components/FCalendar/examples/FCalendarSelectDays.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, shallowRef } from "vue";
 import { FDate } from "@fkui/date";

--- a/packages/vue/src/components/FCalendar/examples/ICalendarNavbarExample.vue
+++ b/packages/vue/src/components/FCalendar/examples/ICalendarNavbarExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, shallowRef } from "vue";
 import { FDate } from "@fkui/date";

--- a/packages/vue/src/components/FCard/examples/FCardExample.vue
+++ b/packages/vue/src/components/FCard/examples/FCardExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FCard } from "@fkui/vue";

--- a/packages/vue/src/components/FCheckboxField/FCheckboxField.vue
+++ b/packages/vue/src/components/FCheckboxField/FCheckboxField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, toValue } from "vue";
 import { type ValidityEvent, ElementIdService } from "@fkui/logic";

--- a/packages/vue/src/components/FCheckboxField/examples/FCheckboxFieldLiveExample.vue
+++ b/packages/vue/src/components/FCheckboxField/examples/FCheckboxFieldLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset, FSelectField, FTooltip } from "@fkui/vue";

--- a/packages/vue/src/components/FCheckboxField/examples/FCheckboxGroupSingle.vue
+++ b/packages/vue/src/components/FCheckboxField/examples/FCheckboxGroupSingle.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset } from "@fkui/vue";

--- a/packages/vue/src/components/FCheckboxField/examples/FCheckboxGroupValues.vue
+++ b/packages/vue/src/components/FCheckboxField/examples/FCheckboxGroupValues.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset } from "@fkui/vue";

--- a/packages/vue/src/components/FContextMenu/examples/FContextMenuExample.vue
+++ b/packages/vue/src/components/FContextMenu/examples/FContextMenuExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { type ContextMenuItem, FButton, FContextMenu, getHTMLElementFromVueRef } from "@fkui/vue";

--- a/packages/vue/src/components/FContextMenu/examples/FContextMenuExampleTextOnly.vue
+++ b/packages/vue/src/components/FContextMenu/examples/FContextMenuExampleTextOnly.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { type ContextMenuItem, FButton, FContextMenu, getHTMLElementFromVueRef } from "@fkui/vue";

--- a/packages/vue/src/components/FCrudDataset/FCrudButton.vue
+++ b/packages/vue/src/components/FCrudDataset/FCrudButton.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 /**
  * @deprecated for table replace with <f-table-button> or <button> in other cases

--- a/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetCustomTextExample.vue
+++ b/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetCustomTextExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FCrudDataset, FList, FStaticField, FTextField, FTextareaField } from "@fkui/vue";

--- a/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetListExample.vue
+++ b/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetListExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FCrudDataset, FList, FStaticField, FTextField, FTextareaField } from "@fkui/vue";

--- a/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetSortListExample.vue
+++ b/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetSortListExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetTableCreateExample.vue
+++ b/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetTableCreateExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCrudDataset, FDataTable, FTableColumn, FTextField, FTextareaField } from "@fkui/vue";

--- a/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetTableExample.vue
+++ b/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetTableExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetTableUpdateExample.vue
+++ b/packages/vue/src/components/FCrudDataset/examples/FCrudDatasetTableUpdateExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCrudDataset, FInteractiveTable, FTableButton, FTableColumn, FTextField } from "@fkui/vue";

--- a/packages/vue/src/components/FDataTable/examples/FDataTableLiveExample.vue
+++ b/packages/vue/src/components/FDataTable/examples/FDataTableLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FDataTable, FFieldset, FRadioField, FTableColumn } from "@fkui/vue";

--- a/packages/vue/src/components/FDatepickerField/FDatepickerField.vue
+++ b/packages/vue/src/components/FDatepickerField/FDatepickerField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent, inject, ref, shallowRef } from "vue";
 import { DateFormat, FDate } from "@fkui/date";

--- a/packages/vue/src/components/FDatepickerField/examples/FDatepickerFieldLiveExample.vue
+++ b/packages/vue/src/components/FDatepickerField/examples/FDatepickerFieldLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { DateFormat, FDate, Weekday } from "@fkui/date";

--- a/packages/vue/src/components/FDialogueTree/FDialogueTree.vue
+++ b/packages/vue/src/components/FDialogueTree/FDialogueTree.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { focus, focusFirst } from "@fkui/logic";

--- a/packages/vue/src/components/FDialogueTree/examples/ExampleFDialogueTree.vue
+++ b/packages/vue/src/components/FDialogueTree/examples/ExampleFDialogueTree.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FDialogueTree/examples/FlerstegsModalExample.vue
+++ b/packages/vue/src/components/FDialogueTree/examples/FlerstegsModalExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, formModal } from "@fkui/vue";

--- a/packages/vue/src/components/FErrorList/FErrorList.vue
+++ b/packages/vue/src/components/FErrorList/FErrorList.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { IFlex, IFlexItem } from "../../internal-components/IFlex";

--- a/packages/vue/src/components/FErrorList/examples/FErrorListBeforeNavigate.vue
+++ b/packages/vue/src/components/FErrorList/examples/FErrorListBeforeNavigate.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FErrorList, FExpandablePanel, FTextField } from "@fkui/vue";

--- a/packages/vue/src/components/FErrorList/examples/FErrorListDefault.vue
+++ b/packages/vue/src/components/FErrorList/examples/FErrorListDefault.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FErrorList, FTextField } from "@fkui/vue";

--- a/packages/vue/src/components/FErrorList/examples/FErrorListNoLinks.vue
+++ b/packages/vue/src/components/FErrorList/examples/FErrorListNoLinks.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FErrorList } from "@fkui/vue";

--- a/packages/vue/src/components/FErrorList/examples/FErrorListNoTitle.vue
+++ b/packages/vue/src/components/FErrorList/examples/FErrorListNoTitle.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FErrorList, FTextField } from "@fkui/vue";

--- a/packages/vue/src/components/FExpand/FExpand.vue
+++ b/packages/vue/src/components/FExpand/FExpand.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { afterEnterTransition } from "./after-enter";

--- a/packages/vue/src/components/FExpand/examples/FExpandExample.vue
+++ b/packages/vue/src/components/FExpand/examples/FExpandExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FExpand } from "@fkui/vue";

--- a/packages/vue/src/components/FExpandablePanel/FExpandablePanel.vue
+++ b/packages/vue/src/components/FExpandablePanel/FExpandablePanel.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ElementIdService } from "@fkui/logic";

--- a/packages/vue/src/components/FExpandablePanel/examples/FExpandablePanelExample.vue
+++ b/packages/vue/src/components/FExpandablePanel/examples/FExpandablePanelExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FExpandablePanel } from "@fkui/vue";

--- a/packages/vue/src/components/FExpandablePanel/examples/FExpandablePanelNotificationExample.vue
+++ b/packages/vue/src/components/FExpandablePanel/examples/FExpandablePanelNotificationExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FExpandablePanel } from "@fkui/vue";

--- a/packages/vue/src/components/FExpandablePanel/examples/FExpandablePanelRelatedExample.vue
+++ b/packages/vue/src/components/FExpandablePanel/examples/FExpandablePanelRelatedExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FExpandablePanel } from "@fkui/vue";

--- a/packages/vue/src/components/FExpandableParagraph/FExpandableParagraph.vue
+++ b/packages/vue/src/components/FExpandableParagraph/FExpandableParagraph.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ElementIdService } from "@fkui/logic";

--- a/packages/vue/src/components/FExpandableParagraph/examples/FExpandableParagraphExample.vue
+++ b/packages/vue/src/components/FExpandableParagraph/examples/FExpandableParagraphExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FExpandableParagraph } from "@fkui/vue";

--- a/packages/vue/src/components/FExpandableParagraph/examples/FExpandableParagraphListExample.vue
+++ b/packages/vue/src/components/FExpandableParagraph/examples/FExpandableParagraphListExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FExpandableParagraph } from "@fkui/vue";

--- a/packages/vue/src/components/FExpandableParagraph/examples/FExpandableParagraphMultipleExample.vue
+++ b/packages/vue/src/components/FExpandableParagraph/examples/FExpandableParagraphMultipleExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FExpandableParagraph } from "@fkui/vue";

--- a/packages/vue/src/components/FFieldset/FFieldset.vue
+++ b/packages/vue/src/components/FFieldset/FFieldset.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent, provide, useSlots, useTemplateRef } from "vue";
 import { type ValidityEvent, ElementIdService, debounce } from "@fkui/logic";

--- a/packages/vue/src/components/FFieldset/examples/FFieldsetCheckbox.vue
+++ b/packages/vue/src/components/FFieldset/examples/FFieldsetCheckbox.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset } from "@fkui/vue";

--- a/packages/vue/src/components/FFieldset/examples/FFieldsetChipLiveExample.vue
+++ b/packages/vue/src/components/FFieldset/examples/FFieldsetChipLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset, FRadioField, FTooltip } from "@fkui/vue";

--- a/packages/vue/src/components/FFieldset/examples/FFieldsetDefault.vue
+++ b/packages/vue/src/components/FFieldset/examples/FFieldsetDefault.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FFieldset, FRadioField, FTooltip } from "@fkui/vue";

--- a/packages/vue/src/components/FFieldset/examples/FFieldsetRadioButtons.vue
+++ b/packages/vue/src/components/FFieldset/examples/FFieldsetRadioButtons.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FFieldset, FRadioField } from "@fkui/vue";

--- a/packages/vue/src/components/FFieldset/examples/FFieldsetRadioButtonsHorizontal.vue
+++ b/packages/vue/src/components/FFieldset/examples/FFieldsetRadioButtonsHorizontal.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FFieldset, FRadioField } from "@fkui/vue";

--- a/packages/vue/src/components/FFileItem/FFileItem.vue
+++ b/packages/vue/src/components/FFileItem/FFileItem.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ElementIdService, isSet } from "@fkui/logic";

--- a/packages/vue/src/components/FFileItem/examples/FFileItemButtonProgress.vue
+++ b/packages/vue/src/components/FFileItem/examples/FFileItemButtonProgress.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FFileItem, FIcon, FProgressbar } from "@fkui/vue";

--- a/packages/vue/src/components/FFileItem/examples/FFileItemDefault.vue
+++ b/packages/vue/src/components/FFileItem/examples/FFileItemDefault.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FFileItem } from "@fkui/vue";

--- a/packages/vue/src/components/FFileItem/examples/FFileItemIcons.vue
+++ b/packages/vue/src/components/FFileItem/examples/FFileItemIcons.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FFileItem } from "@fkui/vue";

--- a/packages/vue/src/components/FFileSelector/FFileSelector.vue
+++ b/packages/vue/src/components/FFileSelector/FFileSelector.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { ElementIdService } from "@fkui/logic";

--- a/packages/vue/src/components/FIcon/FIcon.vue
+++ b/packages/vue/src/components/FIcon/FIcon.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 

--- a/packages/vue/src/components/FIcon/examples/FIconAll.vue
+++ b/packages/vue/src/components/FIcon/examples/FIconAll.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { type IconPackage } from "@fkui/icon-lib-default";

--- a/packages/vue/src/components/FIcon/examples/FIconCircleBackground.vue
+++ b/packages/vue/src/components/FIcon/examples/FIconCircleBackground.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FIcon } from "@fkui/vue";

--- a/packages/vue/src/components/FIcon/examples/FIconDefault.vue
+++ b/packages/vue/src/components/FIcon/examples/FIconDefault.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FIcon } from "@fkui/vue";

--- a/packages/vue/src/components/FIcon/examples/FIconError.vue
+++ b/packages/vue/src/components/FIcon/examples/FIconError.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FIcon } from "@fkui/vue";

--- a/packages/vue/src/components/FIcon/examples/FIconFlip.vue
+++ b/packages/vue/src/components/FIcon/examples/FIconFlip.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FIcon } from "@fkui/vue";

--- a/packages/vue/src/components/FIcon/examples/FIconInfo.vue
+++ b/packages/vue/src/components/FIcon/examples/FIconInfo.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FIcon } from "@fkui/vue";

--- a/packages/vue/src/components/FIcon/examples/FIconLibrary.vue
+++ b/packages/vue/src/components/FIcon/examples/FIconLibrary.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FIcon } from "@fkui/vue";

--- a/packages/vue/src/components/FIcon/examples/FIconRotate.vue
+++ b/packages/vue/src/components/FIcon/examples/FIconRotate.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FIcon } from "@fkui/vue";

--- a/packages/vue/src/components/FIcon/examples/FIconStack.vue
+++ b/packages/vue/src/components/FIcon/examples/FIconStack.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FIcon } from "@fkui/vue";

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any -- this is needed to ensure any array is allowed, not only an array of literal unknown */
 type IsArray<T, U> = T extends any[] | undefined ? U : never;

--- a/packages/vue/src/components/FInteractiveTable/examples/FInteractiveTableInputExample.vue
+++ b/packages/vue/src/components/FInteractiveTable/examples/FInteractiveTableInputExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FDatepickerField, FInteractiveTable, FNumericTextField, FTableColumn } from "@fkui/vue";

--- a/packages/vue/src/components/FInteractiveTable/examples/FInteractiveTableLiveExample.vue
+++ b/packages/vue/src/components/FInteractiveTable/examples/FInteractiveTableLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FLabel/FLabel.vue
+++ b/packages/vue/src/components/FLabel/FLabel.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent, provide, useTemplateRef } from "vue";
 import { hasSlot } from "../../utils";

--- a/packages/vue/src/components/FLabel/examples/FLabelLiveExample.vue
+++ b/packages/vue/src/components/FLabel/examples/FLabelLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset, FLabel, FTooltip } from "@fkui/vue";

--- a/packages/vue/src/components/FLayoutApplicationTemplate/FLayoutApplicationTemplate.vue
+++ b/packages/vue/src/components/FLayoutApplicationTemplate/FLayoutApplicationTemplate.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { isSet } from "@fkui/logic";

--- a/packages/vue/src/components/FLayoutLeftPanel/FLayoutLeftPanel.vue
+++ b/packages/vue/src/components/FLayoutLeftPanel/FLayoutLeftPanel.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, toRefs } from "vue";
 import { focus } from "@fkui/logic";

--- a/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.vue
+++ b/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, toRefs } from "vue";
 import { focus } from "@fkui/logic";

--- a/packages/vue/src/components/FLayoutRightPanel/examples/FLayoutRightPanelVisualExample.vue
+++ b/packages/vue/src/components/FLayoutRightPanel/examples/FLayoutRightPanelVisualExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FList/examples/FListLiveExample.vue
+++ b/packages/vue/src/components/FList/examples/FListLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset, FList, FRadioField, FSelectField } from "@fkui/vue";

--- a/packages/vue/src/components/FLoader/FLoader.vue
+++ b/packages/vue/src/components/FLoader/FLoader.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { addFocusListener, findTabbableElements, removeFocusListener, restoreFocus, saveFocus } from "@fkui/logic";

--- a/packages/vue/src/components/FLoader/examples/FLoaderLiveExample.vue
+++ b/packages/vue/src/components/FLoader/examples/FLoaderLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FCheckboxField, FLoader } from "@fkui/vue";

--- a/packages/vue/src/components/FLogo/FLogo.vue
+++ b/packages/vue/src/components/FLogo/FLogo.vue
@@ -19,6 +19,7 @@ const props = defineProps({
 });
 </script>
 
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 /* technical debt: `cy.mount()` doesn't work with slots defined with composition API */
 export default defineComponent({

--- a/packages/vue/src/components/FMessageBox/FMessageBox.vue
+++ b/packages/vue/src/components/FMessageBox/FMessageBox.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { TranslationService } from "@fkui/logic";

--- a/packages/vue/src/components/FMessageBox/examples/FMessageBoxBanner.vue
+++ b/packages/vue/src/components/FMessageBox/examples/FMessageBoxBanner.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FMessageBox } from "@fkui/vue";

--- a/packages/vue/src/components/FMessageBox/examples/FMessageBoxContext.vue
+++ b/packages/vue/src/components/FMessageBox/examples/FMessageBoxContext.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FMessageBox } from "@fkui/vue";

--- a/packages/vue/src/components/FMessageBox/examples/FMessageBoxContextPartial.vue
+++ b/packages/vue/src/components/FMessageBox/examples/FMessageBoxContextPartial.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FMessageBox } from "@fkui/vue";

--- a/packages/vue/src/components/FMessageBox/examples/FMessageBoxContextSeparate.vue
+++ b/packages/vue/src/components/FMessageBox/examples/FMessageBoxContextSeparate.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FMessageBox } from "@fkui/vue";

--- a/packages/vue/src/components/FMessageBox/examples/FMessageBoxIconLink.vue
+++ b/packages/vue/src/components/FMessageBox/examples/FMessageBoxIconLink.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FIcon, FMessageBox } from "@fkui/vue";

--- a/packages/vue/src/components/FMessageBox/examples/FMessageBoxLiveExample.vue
+++ b/packages/vue/src/components/FMessageBox/examples/FMessageBoxLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset, FMessageBox, FRadioField } from "@fkui/vue";

--- a/packages/vue/src/components/FModal/FConfirmModal/FConfirmModal.vue
+++ b/packages/vue/src/components/FModal/FConfirmModal/FConfirmModal.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { FKUIConfigButtonOrder, config } from "../../../config";

--- a/packages/vue/src/components/FModal/FFormModal/FFormModal.vue
+++ b/packages/vue/src/components/FModal/FFormModal/FFormModal.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { ElementIdService, TranslationService, ValidationService } from "@fkui/logic";

--- a/packages/vue/src/components/FModal/FModal.vue
+++ b/packages/vue/src/components/FModal/FModal.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { ElementIdService, findTabbableElements, focus, popFocus, pushFocus } from "@fkui/logic";

--- a/packages/vue/src/components/FModal/examples/ExampleModal.vue
+++ b/packages/vue/src/components/FModal/examples/ExampleModal.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FModal/examples/FConfirmModalApiExample.vue
+++ b/packages/vue/src/components/FModal/examples/FConfirmModalApiExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, confirmModal } from "@fkui/vue";

--- a/packages/vue/src/components/FModal/examples/FConfirmModalCustomButtons.vue
+++ b/packages/vue/src/components/FModal/examples/FConfirmModalCustomButtons.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { type ModalResult, FButton, FConfirmModal, openModal } from "@fkui/vue";

--- a/packages/vue/src/components/FModal/examples/FFormModalApiExample.vue
+++ b/packages/vue/src/components/FModal/examples/FFormModalApiExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, formModal } from "@fkui/vue";

--- a/packages/vue/src/components/FModal/examples/FModalLiveExample.vue
+++ b/packages/vue/src/components/FModal/examples/FModalLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FCheckboxField, FModal, FSelectField } from "@fkui/vue";

--- a/packages/vue/src/components/FNavigationMenu/FNavigationMenu.vue
+++ b/packages/vue/src/components/FNavigationMenu/FNavigationMenu.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent, ref } from "vue";
 import { debounce } from "@fkui/logic";

--- a/packages/vue/src/components/FNavigationMenu/examples/FNavigationMenuLiveExample.vue
+++ b/packages/vue/src/components/FNavigationMenu/examples/FNavigationMenuLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FNavigationMenu } from "@fkui/vue";

--- a/packages/vue/src/components/FOffline/FOffline.vue
+++ b/packages/vue/src/components/FOffline/FOffline.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { IFlex, IFlexItem } from "../../internal-components/IFlex";

--- a/packages/vue/src/components/FOffline/examples/FOfflineExample.vue
+++ b/packages/vue/src/components/FOffline/examples/FOfflineExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FOffline } from "@fkui/vue";

--- a/packages/vue/src/components/FOutputField/FOutputField.vue
+++ b/packages/vue/src/components/FOutputField/FOutputField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ElementIdService } from "@fkui/logic";

--- a/packages/vue/src/components/FOutputField/examples/FOutputFieldExample.vue
+++ b/packages/vue/src/components/FOutputField/examples/FOutputFieldExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FOutputField, FTextField, FTooltip } from "@fkui/vue";

--- a/packages/vue/src/components/FPageHeader/FPageHeader.vue
+++ b/packages/vue/src/components/FPageHeader/FPageHeader.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { ISkipLink } from "../../internal-components/ISkipLink";

--- a/packages/vue/src/components/FPageHeader/examples/FPageHeaderCustomLogo.vue
+++ b/packages/vue/src/components/FPageHeader/examples/FPageHeaderCustomLogo.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FPageHeader } from "@fkui/vue";

--- a/packages/vue/src/components/FPageHeader/examples/FPageHeaderDefault.vue
+++ b/packages/vue/src/components/FPageHeader/examples/FPageHeaderDefault.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FLogo, FPageHeader } from "@fkui/vue";

--- a/packages/vue/src/components/FPaginator/examples/PaginationExample.vue
+++ b/packages/vue/src/components/FPaginator/examples/PaginationExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FProgressbar/examples/FProgressbarExample.vue
+++ b/packages/vue/src/components/FProgressbar/examples/FProgressbarExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FProgressbar } from "@fkui/vue";

--- a/packages/vue/src/components/FRadioField/FRadioField.vue
+++ b/packages/vue/src/components/FRadioField/FRadioField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { type ValidityEvent, ElementIdService } from "@fkui/logic";

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.vue
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { DateFormat, FDate } from "@fkui/date";

--- a/packages/vue/src/components/FSelectField/FSelectField.vue
+++ b/packages/vue/src/components/FSelectField/FSelectField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, inject } from "vue";
 import { type ValidityEvent, ElementIdService } from "@fkui/logic";

--- a/packages/vue/src/components/FSelectField/examples/FSelectFieldLiveExample.vue
+++ b/packages/vue/src/components/FSelectField/examples/FSelectFieldLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset, FSelectField, FTooltip } from "@fkui/vue";

--- a/packages/vue/src/components/FSelectField/examples/FSelectFieldWidths.vue
+++ b/packages/vue/src/components/FSelectField/examples/FSelectFieldWidths.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FSelectField } from "@fkui/vue";

--- a/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetCustomExample.vue
+++ b/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetCustomExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FSortFilterDataset } from "@fkui/vue";

--- a/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetEmptySlot.vue
+++ b/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetEmptySlot.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FDataTable, FSelectField, FSortFilterDataset, FTableColumn } from "@fkui/vue";

--- a/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetHeader.vue
+++ b/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetHeader.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FSortFilterDataset } from "@fkui/vue";

--- a/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetListExample.vue
+++ b/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetListExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FList, FSortFilterDataset } from "@fkui/vue";

--- a/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetTableExample.vue
+++ b/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetTableExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FInteractiveTable, FSortFilterDataset, FTableColumn } from "@fkui/vue";

--- a/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetTableExampleToolbar.vue
+++ b/packages/vue/src/components/FSortFilterDataset/examples/FSortFilterDatasetTableExampleToolbar.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FInteractiveTable, FSortFilterDataset, FTableColumn } from "@fkui/vue";

--- a/packages/vue/src/components/FStaticField/FStaticField.vue
+++ b/packages/vue/src/components/FStaticField/FStaticField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FLabel } from "../FLabel";

--- a/packages/vue/src/components/FStaticField/examples/FStaticFieldInput.vue
+++ b/packages/vue/src/components/FStaticField/examples/FStaticFieldInput.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FStaticField, FTextField } from "@fkui/vue";

--- a/packages/vue/src/components/FStaticField/examples/FStaticFieldTooltipDescription.vue
+++ b/packages/vue/src/components/FStaticField/examples/FStaticFieldTooltipDescription.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FStaticField, FTooltip } from "@fkui/vue";

--- a/packages/vue/src/components/FTextField/FTextField.vue
+++ b/packages/vue/src/components/FTextField/FTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type ValidityEvent, ElementIdService, ValidationService, isSet } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/examples/FEmailTextFieldExtended.vue
+++ b/packages/vue/src/components/FTextField/examples/FEmailTextFieldExtended.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FEmailTextField } from "@fkui/vue";

--- a/packages/vue/src/components/FTextField/examples/FEmailTextFieldSimple.vue
+++ b/packages/vue/src/components/FTextField/examples/FEmailTextFieldSimple.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FEmailTextField } from "@fkui/vue";

--- a/packages/vue/src/components/FTextField/examples/FPhoneTextFieldExtended.vue
+++ b/packages/vue/src/components/FTextField/examples/FPhoneTextFieldExtended.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FPhoneTextField } from "@fkui/vue";

--- a/packages/vue/src/components/FTextField/examples/FPhoneTextFieldSimple.vue
+++ b/packages/vue/src/components/FTextField/examples/FPhoneTextFieldSimple.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FPhoneTextField } from "@fkui/vue";

--- a/packages/vue/src/components/FTextField/examples/FTextFieldGrid.vue
+++ b/packages/vue/src/components/FTextField/examples/FTextFieldGrid.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/packages/vue/src/components/FTextField/examples/FTextFieldLiveExample.vue
+++ b/packages/vue/src/components/FTextField/examples/FTextFieldLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FTextField/extendedTextFields/FBankAccountNumberTextField/FBankAccountNumberTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FBankAccountNumberTextField/FBankAccountNumberTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type BankAccountNumberString, ValidationService, parseBankAccountNumber } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FBankgiroTextField/FBankgiroTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FBankgiroTextField/FBankgiroTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type BankgiroString, ValidationService, parseBankgiro } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FClearingnumberTextField/FClearingnumberTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FClearingnumberTextField/FClearingnumberTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type ClearingnumberString, ValidationService, parseClearingNumber } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FCurrencyTextField/FCurrencyTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FCurrencyTextField/FCurrencyTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { ValidationService, formatNumber, parseNumber } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FTextField/extendedTextFields/FNumericTextField/FNumericTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FNumericTextField/FNumericTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { ValidationService, formatNumber, parseNumber } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FOrganisationsnummerTextField/FOrganisationsnummerTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FOrganisationsnummerTextField/FOrganisationsnummerTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type OrganisationsnummerString, ValidationService, parseOrganisationsnummer } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPercentTextField/FPercentTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPercentTextField/FPercentTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { ValidationService, formatPercent, parsePercent } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPersonnummerTextField/FPersonnummerTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPersonnummerTextField/FPersonnummerTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type PersonnummerString, ValidationService, formatPersonnummer, parsePersonnummer } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { type ValidatorConfigs, type ValidityEvent, ElementIdService, ValidationService } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPlusgiroTextField/FPlusgiroTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPlusgiroTextField/FPlusgiroTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type PlusgiroString, ValidationService, parsePlusgiro } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPostalCodeTextField/FPostalCodeTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPostalCodeTextField/FPostalCodeTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type PostalCodeString, ValidationService, formatPostalCode } from "@fkui/logic";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FSearchTextField/FSearchTextField.vue
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FSearchTextField/FSearchTextField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ElementIdService, TranslationService, alertScreenReader } from "@fkui/logic";

--- a/packages/vue/src/components/FTextareaField/FTextareaField.vue
+++ b/packages/vue/src/components/FTextareaField/FTextareaField.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { type ValidityEvent, ElementIdService, isSet } from "@fkui/logic";

--- a/packages/vue/src/components/FTextareaField/examples/FTextareaFieldLiveExample.vue
+++ b/packages/vue/src/components/FTextareaField/examples/FTextareaFieldLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset, FSelectField, FTextareaField, FTooltip } from "@fkui/vue";

--- a/packages/vue/src/components/FTooltip/FTooltip.vue
+++ b/packages/vue/src/components/FTooltip/FTooltip.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import {
     type PropType,

--- a/packages/vue/src/components/FTooltip/examples/FTooltipHeadingExample.vue
+++ b/packages/vue/src/components/FTooltip/examples/FTooltipHeadingExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, useTemplateRef } from "vue";
 import { FTooltip } from "@fkui/vue";

--- a/packages/vue/src/components/FTooltip/examples/FTooltipLiveExample.vue
+++ b/packages/vue/src/components/FTooltip/examples/FTooltipLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FLabel, FTooltip } from "@fkui/vue";

--- a/packages/vue/src/components/FValidationForm/FValidationForm.vue
+++ b/packages/vue/src/components/FValidationForm/FValidationForm.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { ElementIdService, ValidationService, focus } from "@fkui/logic";

--- a/packages/vue/src/components/FValidationForm/examples/FValidationFormDefault.vue
+++ b/packages/vue/src/components/FValidationForm/examples/FValidationFormDefault.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FValidationForm/examples/FValidationFormServerError.vue
+++ b/packages/vue/src/components/FValidationForm/examples/FValidationFormServerError.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ValidationService } from "@fkui/logic";

--- a/packages/vue/src/components/FValidationForm/examples/NoErrorList.vue
+++ b/packages/vue/src/components/FValidationForm/examples/NoErrorList.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FTextField, FValidationForm } from "@fkui/vue";

--- a/packages/vue/src/components/FValidationForm/examples/WithErrorList.vue
+++ b/packages/vue/src/components/FValidationForm/examples/WithErrorList.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FTextField, FValidationForm } from "@fkui/vue";

--- a/packages/vue/src/components/FValidationForm/examples/WithErrorListAndCbFunction.vue
+++ b/packages/vue/src/components/FValidationForm/examples/WithErrorListAndCbFunction.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FExpandablePanel, FTextField, FValidationForm } from "@fkui/vue";

--- a/packages/vue/src/components/FValidationGroup/FValidationGroup.vue
+++ b/packages/vue/src/components/FValidationGroup/FValidationGroup.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { documentOrderComparator } from "@fkui/logic";

--- a/packages/vue/src/components/FValidationGroup/examples/FValidationGroupExample.vue
+++ b/packages/vue/src/components/FValidationGroup/examples/FValidationGroupExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { type GroupValidityEvent, FTextField, FValidationGroup } from "@fkui/vue";

--- a/packages/vue/src/components/FValidationGroup/examples/OptimizationExample.vue
+++ b/packages/vue/src/components/FValidationGroup/examples/OptimizationExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FWizard/FWizard.vue
+++ b/packages/vue/src/components/FWizard/FWizard.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import {

--- a/packages/vue/src/components/FWizard/FWizardStep.vue
+++ b/packages/vue/src/components/FWizard/FWizardStep.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent, getCurrentInstance } from "vue";
 import { DomUtils, isSet } from "@fkui/logic";

--- a/packages/vue/src/components/FWizard/examples/FWizardExampleAddStep.vue
+++ b/packages/vue/src/components/FWizard/examples/FWizardExampleAddStep.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FCheckboxField, FFieldset, FTextField, FWizard, FWizardStep } from "@fkui/vue";

--- a/packages/vue/src/components/FWizard/examples/FWizardExampleDefault.vue
+++ b/packages/vue/src/components/FWizard/examples/FWizardExampleDefault.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FDatepickerField, FSelectField, FTextField, FWizard, FWizardStep } from "@fkui/vue";

--- a/packages/vue/src/components/FWizard/examples/FWizardTestComponent.vue
+++ b/packages/vue/src/components/FWizard/examples/FWizardTestComponent.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { FWizard, FWizardStep } from "..";

--- a/packages/vue/src/design-component-tests/Anchor/examples/AnchorLiveExample.vue
+++ b/packages/vue/src/design-component-tests/Anchor/examples/AnchorLiveExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FCheckboxField, FFieldset, FIcon, FRadioField, FSelectField } from "@fkui/vue";

--- a/packages/vue/src/design-component-tests/Button/examples/ButtonButtonGroupFullWidthExample.vue
+++ b/packages/vue/src/design-component-tests/Button/examples/ButtonButtonGroupFullWidthExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton } from "@fkui/vue";

--- a/packages/vue/src/design-component-tests/Button/examples/ButtonDiscreteExample.vue
+++ b/packages/vue/src/design-component-tests/Button/examples/ButtonDiscreteExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FIcon } from "@fkui/vue";

--- a/packages/vue/src/internal-components/IAnimateExpand/IAnimateExpand.vue
+++ b/packages/vue/src/internal-components/IAnimateExpand/IAnimateExpand.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type AnimationCallback } from "./animation-callback";

--- a/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandRadioGroup.vue
+++ b/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandRadioGroup.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FFieldset, FRadioField, FTextField, IAnimateExpand } from "@fkui/vue";

--- a/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandRecommended.vue
+++ b/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandRecommended.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, IAnimateExpand } from "@fkui/vue";

--- a/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandTestComponent.vue
+++ b/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandTestComponent.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, IAnimateExpand } from "@fkui/vue";

--- a/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandToggleTwo.vue
+++ b/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandToggleTwo.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, IAnimateExpand } from "@fkui/vue";

--- a/packages/vue/src/internal-components/IFlex/IFlex.vue
+++ b/packages/vue/src/internal-components/IFlex/IFlex.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FLOAT, GAP } from "./constants";

--- a/packages/vue/src/internal-components/IFlex/IFlexItem.vue
+++ b/packages/vue/src/internal-components/IFlex/IFlexItem.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ALIGNMENT } from "./constants";

--- a/packages/vue/src/internal-components/IFlex/examples/IFlexExample.vue
+++ b/packages/vue/src/internal-components/IFlex/examples/IFlexExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FIcon, IFlex, IFlexItem } from "@fkui/vue";

--- a/packages/vue/src/internal-components/IPopup/IPopup.vue
+++ b/packages/vue/src/internal-components/IPopup/IPopup.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { debounce, handleTab, popFocus, pushFocus } from "@fkui/logic";

--- a/packages/vue/src/internal-components/IPopup/examples/IPopupExample.vue
+++ b/packages/vue/src/internal-components/IPopup/examples/IPopupExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { IPopup } from "@fkui/vue";

--- a/packages/vue/src/internal-components/IPopup/examples/IPopupPositioning.vue
+++ b/packages/vue/src/internal-components/IPopup/examples/IPopupPositioning.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { CandidateOrder, Placement, clamp, fitInsideArea } from "../i-popup-utils";

--- a/packages/vue/src/internal-components/IPopupError/IPopupError.vue
+++ b/packages/vue/src/internal-components/IPopupError/IPopupError.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { FIcon } from "../../components/FIcon";

--- a/packages/vue/src/internal-components/IPopupError/examples/IPopupErrorExample.vue
+++ b/packages/vue/src/internal-components/IPopupError/examples/IPopupErrorExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import {

--- a/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.vue
+++ b/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { focus } from "@fkui/logic";

--- a/packages/vue/src/internal-components/IPopupMenu/examples/IPopupMenuExample.vue
+++ b/packages/vue/src/internal-components/IPopupMenu/examples/IPopupMenuExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { IPopupMenu } from "..";

--- a/packages/vue/src/internal-components/ISkipLink/ISkipLink.vue
+++ b/packages/vue/src/internal-components/ISkipLink/ISkipLink.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { TranslationMixin } from "../../plugins/translation";

--- a/packages/vue/src/internal-components/calendar/ICalendarMonth.vue
+++ b/packages/vue/src/internal-components/calendar/ICalendarMonth.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { FDate } from "@fkui/date";

--- a/packages/vue/src/internal-components/calendar/ICalendarMonthGrid.vue
+++ b/packages/vue/src/internal-components/calendar/ICalendarMonthGrid.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type FDate, getWeekdayNamings, groupByWeek } from "@fkui/date";

--- a/packages/vue/src/internal-components/calendar/ICalendarNavbar.vue
+++ b/packages/vue/src/internal-components/calendar/ICalendarNavbar.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, capitalize, defineComponent } from "vue";
 import { type FDate } from "@fkui/date";

--- a/packages/vue/src/internal-components/calendar/examples/ICalendarMonthDefault.vue
+++ b/packages/vue/src/internal-components/calendar/examples/ICalendarMonthDefault.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, shallowRef } from "vue";
 import { FDate } from "@fkui/date";

--- a/packages/vue/src/internal-components/calendar/examples/ICalendarMonthGridDagnummer.vue
+++ b/packages/vue/src/internal-components/calendar/examples/ICalendarMonthGridDagnummer.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, shallowRef } from "vue";
 import { FDate } from "@fkui/date";

--- a/packages/vue/src/internal-components/calendar/examples/ICalendarMonthGridDefault.vue
+++ b/packages/vue/src/internal-components/calendar/examples/ICalendarMonthGridDefault.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, shallowRef } from "vue";
 import { FDate } from "@fkui/date";

--- a/packages/vue/src/internal-components/calendar/examples/ICalendarMonthWithFCalendarDay.vue
+++ b/packages/vue/src/internal-components/calendar/examples/ICalendarMonthWithFCalendarDay.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, shallowRef } from "vue";
 import { FDate } from "@fkui/date";

--- a/packages/vue/src/internal-components/calendar/examples/ICalendarNavbarDefault.vue
+++ b/packages/vue/src/internal-components/calendar/examples/ICalendarNavbarDefault.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, shallowRef } from "vue";
 import { FDate } from "@fkui/date";

--- a/packages/vue/src/plugins/error/FErrorHandlingApp.vue
+++ b/packages/vue/src/plugins/error/FErrorHandlingApp.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type Component, type PropType, defineComponent } from "vue";
 import { ErrorViewData } from "../../types";

--- a/packages/vue/src/plugins/error/FErrorPage.vue
+++ b/packages/vue/src/plugins/error/FErrorPage.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
 import { type ErrorData } from "../../types";

--- a/packages/vue/src/plugins/error/examples/ErrorPluginExample.vue
+++ b/packages/vue/src/plugins/error/examples/ErrorPluginExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent, getCurrentInstance } from "vue";
 import { FButton } from "@fkui/vue";

--- a/packages/vue/src/plugins/test/examples/TestPluginExample.vue
+++ b/packages/vue/src/plugins/test/examples/TestPluginExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/packages/vue/src/plugins/test/examples/TestPluginHidden.vue
+++ b/packages/vue/src/plugins/test/examples/TestPluginHidden.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FTextField } from "@fkui/vue";

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginDynamicValidation.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginDynamicValidation.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ValidationService } from "@fkui/logic";

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginErrorMessage.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginErrorMessage.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginExample.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginFormValidation.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginFormValidation.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton, FTextField, FValidationForm } from "@fkui/vue";

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginRevalidate.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginRevalidate.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ValidationService } from "@fkui/logic";

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginToggleDisable.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginToggleDisable.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ValidationService } from "@fkui/logic";

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginToggleEnabled.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginToggleEnabled.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ValidationService } from "@fkui/logic";

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginValidateAll.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginValidateAll.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ValidationService } from "@fkui/logic";

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginValidityEvent.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginValidityEvent.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginVariables.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginVariables.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FTextField } from "@fkui/vue";

--- a/packages/vue/src/utils/mount-component/examples/MountOptionsExample.vue
+++ b/packages/vue/src/utils/mount-component/examples/MountOptionsExample.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { mountComponent } from "@fkui/vue";

--- a/packages/vue/src/utils/mount-component/examples/MyAwesomeComponent.vue
+++ b/packages/vue/src/utils/mount-component/examples/MyAwesomeComponent.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
 import { FButton } from "@fkui/vue";


### PR DESCRIPTION
Blev trött på att vi fortfarande inför nya komponenter med options api (framförallt live-exempel), nu kommer eslint klaga om man använder det.