### PR TITLE
feat: set f-table nested aria attributes (refs SFKUI-7436)

### DIFF
--- a/packages/vue/src/components/FTable/FTable.spec.ts
+++ b/packages/vue/src/components/FTable/FTable.spec.ts
@@ -606,7 +606,7 @@ describe("6 Expandable table", () => {
         expect(expandButtons[1].attributes("aria-expanded")).toBe("false");
     });
 
-    it("6.4 should set correct aria-level on rows", async () => {
+    it("6.4 should set correct aria-level, aria-setsize, aria-posinset on rows", async () => {
         const wrapper = mount(FTable<ExpandableRow>, {
             props: {
                 rows: useDatasetRef(rows, expandableAttribute).value,
@@ -619,12 +619,39 @@ describe("6 Expandable table", () => {
         await expandButtons[1].trigger("click");
 
         const bodyRows = wrapper.findAll("tbody tr");
-        expect(bodyRows[0].attributes("aria-level")).toBe("1");
-        expect(bodyRows[1].attributes("aria-level")).toBe("2");
-        expect(bodyRows[2].attributes("aria-level")).toBe("2");
-        expect(bodyRows[3].attributes("aria-level")).toBe("1");
-        expect(bodyRows[4].attributes("aria-level")).toBe("2");
-        expect(bodyRows[5].attributes("aria-level")).toBe("2");
+
+        expect(bodyRows.map((it) => it.attributes())).toMatchObject([
+            {
+                "aria-level": "1",
+                "aria-posinset": "1",
+                "aria-setsize": "2",
+            },
+            {
+                "aria-level": "2",
+                "aria-posinset": "1",
+                "aria-setsize": "2",
+            },
+            {
+                "aria-level": "2",
+                "aria-posinset": "2",
+                "aria-setsize": "2",
+            },
+            {
+                "aria-level": "1",
+                "aria-posinset": "2",
+                "aria-setsize": "2",
+            },
+            {
+                "aria-level": "2",
+                "aria-posinset": "1",
+                "aria-setsize": "2",
+            },
+            {
+                "aria-level": "2",
+                "aria-posinset": "2",
+                "aria-setsize": "2",
+            },
+        ]);
     });
 
     it("6.6 should render custom expanded row with colspan spanning all columns", async () => {
@@ -1181,7 +1208,9 @@ describe("7.6 aria-selected", () => {
         expect(
             trs.map(
                 (tr, index) =>
-                    `Row ${index + 1} aria-selected: ${tr.attributes("aria-selected")}`,
+                    `Row ${index + 1} aria-selected: ${tr.attributes(
+                        "aria-selected",
+                    )}`,
             ),
         ).toMatchObject([
             "Row 1 aria-selected: true",

--- a/packages/vue/src/components/FTable/ITableTextInputFields.cy.ts
+++ b/packages/vue/src/components/FTable/ITableTextInputFields.cy.ts
@@ -1,5 +1,6 @@
 import { defineComponent } from "vue";
 import { FTablePageObject } from "../../cypress/FTable.pageobject";
+import { useDatasetRef } from "../../utils";
 import FTable from "./FTable.vue";
 import { type TableColumn, defineTableColumns } from "./table-column";
 
@@ -28,7 +29,7 @@ function mountTable(row: Row, columns: TableColumn<Row, keyof Row>): void {
             components: { FTable },
             data() {
                 return {
-                    rows: [row],
+                    rows: useDatasetRef([row]),
                     columns: cols,
                 };
             },

--- a/packages/vue/src/components/FTable/examples/FTableColumnLiveExample.vue
+++ b/packages/vue/src/components/FTable/examples/FTableColumnLiveExample.vue
@@ -1,16 +1,19 @@
 <!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
-import { defineComponent, h } from "vue";
+import { defineComponent } from "vue";
 import { FDate } from "@fkui/date";
 import {
+    type TableColumn,
     FCheckboxField,
     FFieldset,
     FRadioField,
     FSelectField,
+    FTable,
+    defineTableColumns as defineTableColumnsFunc,
     getHTMLElementFromVueRef,
+    useDatasetRef,
 } from "@fkui/vue";
-import { type TableColumn, FTable, defineTableColumns as defineTableColumnsFunc } from "@fkui/vue";
-import { LiveExample } from "@forsakringskassan/docs-live-example";
+import { LiveExample, createElement } from "@forsakringskassan/docs-live-example";
 import { defaultTnumValue } from "../columns/helpers";
 import { type InputType } from "../input-fields-config";
 import { isEditableColumn } from "../is-editable-column";
@@ -262,12 +265,6 @@ function getColumn(options: {
     return column;
 }
 
-function getRows(options: { columnType: TableColumnType }): Row[] {
-    const { columnType } = options;
-
-    return rowData[columnType].map((it, index) => ({ id: index + 1, value: it }));
-}
-
 export default defineComponent({
     name: "FTableColumnLiveExample",
     components: { LiveExample, FSelectField, FFieldset, FCheckboxField, FRadioField },
@@ -291,6 +288,15 @@ export default defineComponent({
         };
     },
     computed: {
+        livedata(): object {
+            const rows = useDatasetRef(
+                rowData[this.columnType].map((it, index) => ({ id: index + 1, value: it })),
+            );
+
+            return {
+                rows,
+            };
+        },
         livemethods(): object {
             return {
                 defineTableColumns: defineTableColumnsFunc,
@@ -351,16 +357,9 @@ export default defineComponent({
 
             return `defineTableColumns([${stringifyObject(column as unknown as Record<string, unknown>)}])`;
         },
-        rows(): string {
-            const rows = getRows({ columnType: this.normalizedKey });
-            const stringified = rows
-                .map((it) => stringifyObject(it as unknown as Record<string, unknown>))
-                .join(", ");
 
-            return `[${stringified}]`;
-        },
         template(): string {
-            return `<f-table :columns="${this.columns}" :rows="${this.rows}"></f-table>`;
+            return createElement("f-table", { ":columns": this.columns, ":rows": "rows" });
         },
     },
     mounted() {
@@ -387,7 +386,7 @@ export default defineComponent({
 </script>
 
 <template>
-    <live-example :components :template :livemethods>
+    <live-example :components :template :livemethods :livedata>
         <f-select-field v-model="columnType">
             <template #label> Kolumntyp </template>
             <option value="text">Text</option>

--- a/packages/vue/src/components/FTable/get-meta-rows.spec.ts
+++ b/packages/vue/src/components/FTable/get-meta-rows.spec.ts
@@ -1,4 +1,4 @@
-import { setItemIdentifiers } from "../../utils";
+import { setItemIdentifiers, useDatasetRef } from "../../utils";
 import { getMetaRows } from "./get-meta-rows";
 
 const rows = [
@@ -18,6 +18,28 @@ const rows = [
         ],
     },
 ];
+
+it("should not add nested metadata when not expandable", () => {
+    const dataset = useDatasetRef(rows);
+    const keyedRows = setItemIdentifiers(dataset.value, "name");
+    const result = getMetaRows(keyedRows, new Set());
+
+    expect(result[0].rowIndex).toBe(2);
+    expect(result[0].level).toBeUndefined();
+    expect(result[0].setsize).toBeUndefined();
+    expect(result[0].posinset).toBeUndefined();
+});
+
+it("should add nested metadata when expandable", () => {
+    const dataset = useDatasetRef(rows, "expandable");
+    const keyedRows = setItemIdentifiers(dataset.value, "name", "expandable");
+    const result = getMetaRows(keyedRows, new Set(), "expandable");
+
+    expect(result[0].rowIndex).toBe(2);
+    expect(result[0].level).toBe(1);
+    expect(result[0].setsize).toBe(3);
+    expect(result[0].posinset).toBe(1);
+});
 
 it("should only mark rows with non-empty children as expandable", () => {
     const keyedRows = setItemIdentifiers(rows, "name", "expandable");

--- a/packages/vue/src/components/FTable/get-meta-rows.ts
+++ b/packages/vue/src/components/FTable/get-meta-rows.ts
@@ -1,52 +1,52 @@
-import { type ItemIdentifier, getItemIdentifier } from "../../utils";
+import {
+    type ItemIdentifier,
+    getDatasetMetadata,
+    getItemIdentifier,
+} from "../../utils";
 import { type MetaRow } from "./meta-row";
 import { walk } from "./walk";
-
-function getRowIndexes<T>(
-    rows: T[],
-    expandableAttribute: keyof T | undefined,
-): ItemIdentifier[] {
-    const array: ItemIdentifier[] = [];
-
-    walk(rows, expandableAttribute, (row) => {
-        array.push(getItemIdentifier(row));
-        return true;
-    });
-
-    return array;
-}
 
 /**
  * @internal
  */
-export function getMetaRows<T>(
+export function getMetaRows<T extends object>(
     keyedRows: T[],
     expandedKeys: Set<ItemIdentifier>,
     expandableAttribute?: keyof T,
 ): Array<MetaRow<T>> {
-    const rowIndexes = getRowIndexes(keyedRows, expandableAttribute);
     const array: Array<MetaRow<T>> = [];
 
-    walk(keyedRows, expandableAttribute, (row, level) => {
+    walk(keyedRows, expandableAttribute, (row) => {
         const key = getItemIdentifier(row);
         const isExpandable = Boolean(
             expandableAttribute &&
             Array.isArray(row[expandableAttribute]) &&
             row[expandableAttribute].length > 0,
         );
+
+        const { ariaLevel, ariaPosInSet, ariaRowIndex, ariaSetSize } =
+            getDatasetMetadata(row);
+        const rowIndex = ariaRowIndex + 1; // +1 to include header row
         const isExpanded = isExpandable && expandedKeys.has(key);
 
-        // +2 since header row has rowindex 1.
-        const rowIndex = rowIndexes.indexOf(key) + 2;
-
-        array.push({
+        let metarow: MetaRow<T> = {
             key,
             row,
             rowIndex,
-            level: expandableAttribute ? level : undefined,
             isExpandable,
             isExpanded,
-        });
+        };
+
+        if (expandableAttribute) {
+            metarow = {
+                level: ariaLevel,
+                posinset: ariaPosInSet,
+                setsize: ariaSetSize,
+                ...metarow,
+            };
+        }
+
+        array.push(metarow);
 
         return isExpanded;
     });


### PR DESCRIPTION
`aria-level`, `aria-setsize` and `aria-posinset` are now set on rows in expandable table.