### PR TITLE
fix: `disabled` attribute not set for disabled `FButton` (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FButton/FButton.spec.ts
+++ b/packages/vue/src/components/FButton/FButton.spec.ts
@@ -36,6 +36,24 @@ describe("props", () => {
             const button = wrapper.get("button");
             expect(button.attributes("aria-disabled")).toBe("false");
         });
+
+        it("should set `disabled` on the button element when true", () => {
+            expect.assertions(1);
+            const wrapper = shallowMount(FButton, {
+                props: {
+                    disabled: true,
+                },
+            });
+            const button = wrapper.get("button");
+            expect(button.element.disabled).toBe(true);
+        });
+
+        it("should not set `disabled` on the button as default", () => {
+            expect.assertions(1);
+            const wrapper = shallowMount(FButton);
+            const button = wrapper.get("button");
+            expect(button.element.disabled).toBe(false);
+        });
     });
 
     it("type prop should set type attribute on button element", () => {

--- a/packages/vue/src/components/FButton/FButton.vue
+++ b/packages/vue/src/components/FButton/FButton.vue
@@ -162,7 +162,7 @@ const buttonClass = computed((): string[] => {
 </script>
 
 <template>
-    <button :type :class="buttonClass" :aria-disabled="disabled" v-bind="attrs">
+    <button :type :class="buttonClass" :aria-disabled="disabled" :disabled v-bind="attrs">
         <template v-if="hasIconLeft">
             <f-icon v-if="inflight" name="circle-notch-solid" class="button__icon button__spinner"></f-icon>
             <f-icon


### PR DESCRIPTION
Denna bugg har lyfts i en diskussion mellan två utvecklare i vår chattkanal för frågor angående designsystemet.

> @jgrundh: Stegar fkui/vue från 6.27 -> 6.44 och stöter på ett problem som verkar ha introducerats vid 6.35 (cfe25ec). På grund av implementationen av den nya proppen för disabled och användandet av en computed
> 
> ```js
> const disabled = computed((): boolean => {
>     return props.disabled || inflight.value;
> });
> ```
> 
> så verkar bara `aria-disabled` sättas på elementet. Inte native attributet `disabled`. Jag upptäcker det eftersom Seleniums funktion isEnabled() bara kollar på nativ-attributet och därmed failar mina tester efter stegning.
> 
> Den här lösningen har ju också andra implikationer. I och med att native disabled nu inte sätts, så går det att tabba till en inaktiv knapp. Den går ju fortfarande inte att klicka på eftersom useInflight guarden gör att click-eventet ignoreras. Det stör i och för sig inte mig, men kanske har nån bäring på användarvänligheten? Är det rätt att man kan fokusera på inaktiva knappar?

> @ext: en fördel är just att du kan tangentbordsnavigera till den, annars så kan det bli svårt för hjälpmedel att ta sig till knappen, vanligtvis så använder vi inte oss av `disabled`

> @jgrundh: Så kan det vara om man vill att hjälpmedel ska navigera till inaktiva element (det vet inte jag om det är önskat beteende). Beetendet förut var att den satte nativ-attributet disabled, men efter ändringen så blev det "aria-disabled"=true istället. Jag har justerat mina tester, så det är inget problem för mig längre. Jag ville bara uppmärksamma er på det utifall det var en oönskad effekt från er sida.