### PR TITLE
refactor: remove `button__icon--end` class (refs SFKUI-7315)

### DIFF
--- a/packages/design/src/components/button/_button.scss
+++ b/packages/design/src/components/button/_button.scss
@@ -319,11 +319,6 @@ $button--tertiary: (
         }
     }
 
-    & > .button__icon--end {
-        position: absolute;
-        right: size.$padding-125;
-    }
-
     &.disabled,
     &.disabled:hover,
     &:disabled,

--- a/packages/vue/htmlvalidate/rules/classdeprecated.rule.js
+++ b/packages/vue/htmlvalidate/rules/classdeprecated.rule.js
@@ -32,6 +32,11 @@ const deprecatedClasses = [
         url: "/components/button.html",
     },
     {
+        name: "button__icon--end",
+        additionalMessage: "The class does nothing and has no replacement.",
+        url: "/components/button.html",
+    },
+    {
         name: "icon-stack--new-window",
         additionalMessage:
             "Stacked icons are no longer used for file item links.",

--- a/packages/vue/htmlvalidate/rules/classdeprecated.spec.ts
+++ b/packages/vue/htmlvalidate/rules/classdeprecated.spec.ts
@@ -88,6 +88,34 @@ it("should report error when `.button--discrete` is used", async () => {
     );
 });
 
+it("should report error when `.button__icon--end` is used", async () => {
+    expect.assertions(3);
+    const markup = /* HTML */ `
+        <button type="button" class="button button--primary button--large">
+            <f-icon name="pen" class="button__icon button__icon--end"></f-icon>
+        </button>
+    `;
+    const report = await htmlvalidate.validateString(markup);
+    expect(report).toBeInvalid();
+    expect(report).toMatchInlineCodeframe(`
+        "error: class "button__icon--end" is deprecated (fkui/class-deprecated)
+          1 |
+          2 |         <button type="button" class="button button--primary button--large">
+        > 3 |             <f-icon name="pen" class="button__icon button__icon--end"></f-icon>
+            |                                                    ^^^^^^^^^^^^^^^^^
+          4 |         </button>
+          5 |
+        Selector: button > f-icon"
+    `);
+    const error = report.results[0].messages[0];
+    const docs = await htmlvalidate.getContextualDocumentation(error);
+    expect(docs?.description).toMatchInlineSnapshot(`
+        "Class \`button__icon--end\` is deprecated.
+
+        The class does nothing and has no replacement."
+    `);
+});
+
 it("should report error when `.navbar` is used", async () => {
     expect.assertions(3);
     const markup = /* HTML */ ` <div class="custom-navbar navbar"></div> `;


### PR DESCRIPTION
Hittade tidigare en klass för knappikon som vi själva inte använder eller dokumenterar. Tanken för den verkar vara att den sätts på knappens ikon för att lägga den till höger och inte påverka position av text, se nedan för exempel.

```
<button type="button" class="button button--primary button--large">
    <f-icon name="pen" class="button__icon button__icon--end"></f-icon>
    Knapp
</button>
```

<img width="389" height="255" alt="Skärmbild 2026-05-08 101529" src="https://github.com/user-attachments/assets/cc23b8f5-f2f0-4c74-882c-1d15c8e8b994" />

Som kan ses så fungerar det inte så bra out-of-the-box om man har lite längre text. Ser inte nåt specifikt användningsområde för vår knapp med den här klassen, men tar gärna input.

Lösningsalternativ:
- Ta bort den direkt då den har så begränsad användning (1 som jag hittat) och troligen ingen känner till att den existerar (min valda lösning).
- Deprekera och ta bort den efter sedvanlig tid.