### PR TITLE
ci: retry docs gh-pages subtree push (refs SFKUI-7902)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,5 +85,20 @@ jobs:
                       --message "chore(release): [skip ci] deploy ${VERSION} documentation" \
                       --no-verify \
                       --allow-empty
-            - name: Push subtree
-              run: git subtree push --prefix pages ${DST_REMOTE} ${DST_BRANCH}
+            - name: Refresh and push subtree (retry)
+              run: |
+                  for attempt in 1 2 3; do
+                      echo "Attempt ${attempt}/3: refresh and push subtree"
+                      if git subtree pull --prefix pages ${DST_REMOTE} ${DST_BRANCH} && git subtree push --prefix pages ${DST_REMOTE} ${DST_BRANCH}; then
+                          echo "Subtree push succeeded"
+                          exit 0
+                      fi
+
+                      if [[ ${attempt} -lt 3 ]]; then
+                          echo "Subtree push failed, retrying in 5 sec"
+                          sleep 5
+                      fi
+                  done
+
+                  echo "Subtree push failed after 3 attempts"
+                  exit 1


### PR DESCRIPTION
Den nya loopen löser främst en tillfälligt push-reject då någon annan precis hann skriva till gh-pages. 
Nästa försök gör en ny subtree pull och försöker igen.

Så ingen perfekt lösning men lite hängslen som förhoppningsvis gör det lite bättre.

Deploy/push från PR och main har vi inte lika stor kontroll på då de använder `JamesIves/github-pages-deploy-action` och `rossjrw/pr-preview-action`. Men samtidigt så är det release-bygget som är det viktiga, de andra kan vi trigga om vid behov.