### PR TITLE
feat: add node & vite/client to types field for @fkui/tsconfig/vue

### DIFF
--- a/packages/tsconfig/presets/tsconfig-vue.json
+++ b/packages/tsconfig/presets/tsconfig-vue.json
@@ -6,7 +6,17 @@
         "module": "esnext",
         "moduleResolution": "bundler",
         "emitDeclarationOnly": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "types": [
+            /* Consumers use process.env to pass environmental variables into the compiled source */
+            "node",
+
+            /*
+            To handle importing static assets, raw/encoded urls, working with Vite, and other common patterns in Vue projects
+            https://vite.dev/guide/assets
+             */
+            "vite/client"
+        ]
     },
 
     "vueCompilerOptions": {


### PR DESCRIPTION
Preppar för Typescript 6 internt och inser att vi behöver duplicera `types` en hel del då det saknas i både den rekommenderade filen men också vue.

* Node behövs för att kunna nyttja `process.env` vilket vi verkar göra en del.
* Vite/client för att exempelvis kunna importera en sass-fil utan att få varningar.

Om detta bör lösas på annat sätt så tar jag gärna emot feedback. Det känns lite fel att definera upp vite, men känns ändå som det är det absolut vanligaste ramverket när du jobbar med Vue just nu.