### PR TITLE
fix: use semantic tokens for focus indicator

### DIFF
--- a/packages/design/src/core/mixins/_focus.scss
+++ b/packages/design/src/core/mixins/_focus.scss
@@ -1,5 +1,10 @@
+$focus-box-shadow:
+    0 0 0 2px var(--fkds-focus-indicator-color-background),
+    0 0 0 4px var(--fkds-focus-indicator-color),
+    0 0 0 6px var(--fkds-focus-indicator-color-background) !default;
+
 @mixin focus-indicator() {
     border-radius: 0;
-    box-shadow: var(--f-focus-box-shadow);
+    box-shadow: $focus-box-shadow;
     outline: 3px solid transparent; // Windows high contrast
 }

--- a/packages/design/src/internal-components/calendar-month/_calendar-month.scss
+++ b/packages/design/src/internal-components/calendar-month/_calendar-month.scss
@@ -1,4 +1,5 @@
 @use "../../components/z-index";
+@use "../../core/mixins/focus";
 @use "variables" as *;
 
 $days: 7;
@@ -66,7 +67,7 @@ $day-width: calc((100% - $week-width) / $days);
             z-index: z-index.$CALENDAR_MONTH;
 
             &[tabindex="-1"] {
-                box-shadow: var(--f-focus-box-shadow);
+                box-shadow: focus.$focus-box-shadow;
             }
         }
     }

--- a/packages/theme-default/src/dark/_variables.scss
+++ b/packages/theme-default/src/dark/_variables.scss
@@ -103,4 +103,8 @@
 
     // HEADER - TEXT
     --fkds-color-header-text-primary: #{$palette-color-white-100};
+
+    // FOCUS INDICATOR
+    --fkds-focus-indicator-color: #{$palette-color-white-100};
+    --fkds-focus-indicator-color-background: #{$palette-color-fk-black-100};
 }

--- a/packages/theme-default/src/light/_variables.scss
+++ b/packages/theme-default/src/light/_variables.scss
@@ -103,4 +103,8 @@
 
     // HEADER - TEXT
     --fkds-color-header-text-primary: #{$palette-color-white-100};
+
+    // FOCUS INDICATOR
+    --fkds-focus-indicator-color: #{$palette-color-fk-black-100};
+    --fkds-focus-indicator-color-background: #{$palette-color-white-100};
 }

--- a/packages/theme-default/src/shared/_index.scss
+++ b/packages/theme-default/src/shared/_index.scss
@@ -95,9 +95,10 @@
     --padding-input-fields: 0 2.25rem 0 0.75rem;
 
     /// Focus related
-    $_f-color-focus: $palette-color-fk-black-100;
-    --f-color-focus: #{$_f-color-focus};
-    --f-focus-box-shadow: 0 0 0 2px #{$palette-color-white-100}, 0 0 0 4px #{$_f-color-focus}, 0 0 0 6px #{$palette-color-white-100};
+    --f-color-focus: var(--fkds-focus-indicator-color);
+    --f-focus-box-shadow:
+        0 0 0 2px var(--fkds-focus-indicator-color-background), 0 0 0 4px var(--fkds-focus-indicator-color),
+        0 0 0 6px var(--fkds-focus-indicator-color-background);
 
     // Effect related variables
     --f-animation-duration-short: 150ms;


### PR DESCRIPTION
Lägger till semantiska färgtokens för fokusram:
- Specifika tokens för fokusramen så att den enkelt kan stylas om per tema
- Mappar om gamla globala tokens i /shared/_index.scss (kan antagligen deprekeras senare)
- Själva `box-shadow`-värdet återanvänds via en Sass-variabel i fokusmixinen, så formen på fokusramen bara
  definieras på ett ställe. Temat styr endast färgerna via CSS-variabler.