### PR TITLE
fix: use semantic tokens for layout panels

### DIFF
--- a/packages/design/src/components/layout-navigation/_layout-navigation.scss
+++ b/packages/design/src/components/layout-navigation/_layout-navigation.scss
@@ -1,4 +1,5 @@
 @use "../z-index";
+@use "variables" as *;
 
 $ZINDEX: z-index.$MODAL_ZINDEX - 1 !default;
 
@@ -9,15 +10,6 @@ $layout-navigation-inner-margin: 20px !default;
 $layout-navigation-content-padding: 4px !default;
 $layout-navigation-dot-diameter: 4px !default;
 $layout-navigation-dot-spacing: 4px !default;
-
-// Colors
-$palette-color-fk-black-5: #f4f4f4 !default;
-$palette-color-fk-black-50: #8d8e91 !default;
-$palette-color-bluebell-15: #e5e5f5 !default;
-$background-navigation: #{$palette-color-fk-black-5};
-$border-hover-navigation: #{$palette-color-bluebell-15};
-$border-dots-navigation: #{$palette-color-fk-black-50};
-$scrollbar-navigation: #{$palette-color-fk-black-50};
 
 .layout-navigation {
     min-height: 100%;
@@ -36,7 +28,7 @@ $scrollbar-navigation: #{$palette-color-fk-black-50};
     }
 
     &__navigation {
-        background-color: #{$background-navigation};
+        background-color: $layout-navigation-color-background;
         display: flex;
         position: fixed;
         z-index: $ZINDEX;
@@ -45,12 +37,12 @@ $scrollbar-navigation: #{$palette-color-fk-black-50};
     }
 
     &__navigation .button.button--tertiary:hover {
-        background-color: var(--f-background-sidepanel-button-tertiary-hover);
+        background-color: $layout-navigation-button-tertiary-color-background-hover;
     }
 
     &__navigation__border {
         width: #{$layout-navigation-border-width};
-        background-color: #{$background-navigation};
+        background-color: $layout-navigation-resize-handle-color-background-default;
         cursor: w-resize;
         flex-shrink: 0;
         display: flex;
@@ -59,7 +51,7 @@ $scrollbar-navigation: #{$palette-color-fk-black-50};
         flex-direction: column;
 
         &__dot {
-            background-color: #{$border-dots-navigation};
+            background-color: $layout-navigation-resize-handle-dot-color-background;
             width: #{$layout-navigation-dot-diameter};
             height: #{$layout-navigation-dot-diameter};
             border-radius: 2px;
@@ -68,7 +60,7 @@ $scrollbar-navigation: #{$palette-color-fk-black-50};
     }
 
     &__navigation__border:hover {
-        background-color: #{$border-hover-navigation};
+        background-color: $layout-navigation-resize-handle-color-background-hover;
     }
 
     &__navigation__inner {
@@ -107,8 +99,8 @@ $scrollbar-navigation: #{$palette-color-fk-black-50};
             }
 
             &::-webkit-scrollbar-thumb {
-                background: #{$scrollbar-navigation};
-                border: 1px solid #{$scrollbar-navigation};
+                background: $layout-navigation-scrollbar-thumb-color-background;
+                border: 1px solid $layout-navigation-scrollbar-thumb-color-background;
                 box-sizing: border-box;
                 border-radius: 33px;
             }

--- a/packages/design/src/components/layout-navigation/_variables.scss
+++ b/packages/design/src/components/layout-navigation/_variables.scss
@@ -1,1 +1,6 @@
-// stylelint-disable no-empty-source -- placeholder file
+$layout-navigation-color-background: var(--fkds-color-background-secondary) !default;
+$layout-navigation-resize-handle-color-background-default: var(--fkds-color-background-secondary) !default;
+$layout-navigation-resize-handle-color-background-hover: var(--fkds-color-action-background-secondary-hover) !default;
+$layout-navigation-resize-handle-dot-color-background: var(--fkds-color-action-text-secondary-default) !default;
+$layout-navigation-scrollbar-thumb-color-background: var(--fkds-color-border-primary) !default;
+$layout-navigation-button-tertiary-color-background-hover: var(--fkds-color-action-background-secondary-hover) !default;

--- a/packages/design/src/components/layout-secondary/_layout-secondary.scss
+++ b/packages/design/src/components/layout-secondary/_layout-secondary.scss
@@ -1,4 +1,5 @@
 @use "../z-index";
+@use "variables" as *;
 
 $ZINDEX: z-index.$MODAL_ZINDEX - 1 !default;
 
@@ -9,15 +10,6 @@ $layout-secondary-inner-margin: 20px !default;
 $layout-secondary-content-padding: 4px !default;
 $layout-secondary-dot-diameter: 4px !default;
 $layout-secondary-dot-spacing: 4px !default;
-
-// Colors
-$palette-color-fk-black-5: #f4f4f4 !default;
-$palette-color-fk-black-50: #8d8e91 !default;
-$palette-color-bluebell-15: #e5e5f5 !default;
-$background-secondary: #{$palette-color-fk-black-5};
-$border-hover-secondary: #{$palette-color-bluebell-15};
-$border-dots-secondary: #{$palette-color-fk-black-50};
-$scrollbar-secondary: #{$palette-color-fk-black-50};
 
 .layout-secondary {
     width: 100%;
@@ -36,7 +28,7 @@ $scrollbar-secondary: #{$palette-color-fk-black-50};
     }
 
     &__secondary {
-        background-color: #{$background-secondary};
+        background-color: $layout-secondary-color-background;
         position: fixed;
         display: flex;
         right: 0;
@@ -44,12 +36,12 @@ $scrollbar-secondary: #{$palette-color-fk-black-50};
         z-index: $ZINDEX;
 
         .button.button--tertiary:hover {
-            background-color: var(--f-background-sidepanel-button-tertiary-hover);
+            background-color: $layout-secondary-button-tertiary-color-background-hover;
         }
 
         &__border {
             width: #{$layout-secondary-border-width};
-            background-color: #{$background-secondary};
+            background-color: $layout-secondary-resize-handle-color-background-default;
             cursor: w-resize;
             flex-shrink: 0;
             display: flex;
@@ -58,7 +50,7 @@ $scrollbar-secondary: #{$palette-color-fk-black-50};
             flex-direction: column;
 
             &__dot {
-                background-color: #{$border-dots-secondary};
+                background-color: $layout-secondary-resize-handle-dot-color-background;
                 width: #{$layout-secondary-dot-diameter};
                 height: #{$layout-secondary-dot-diameter};
                 border-radius: 2px;
@@ -67,7 +59,7 @@ $scrollbar-secondary: #{$palette-color-fk-black-50};
         }
 
         &__border:hover {
-            background-color: #{$border-hover-secondary};
+            background-color: $layout-secondary-resize-handle-color-background-hover;
         }
 
         &__inner {
@@ -108,8 +100,8 @@ $scrollbar-secondary: #{$palette-color-fk-black-50};
                 }
 
                 &::-webkit-scrollbar-thumb {
-                    background: #{$scrollbar-secondary};
-                    border: 1px solid #{$scrollbar-secondary};
+                    background: $layout-secondary-scrollbar-thumb-color-background;
+                    border: 1px solid $layout-secondary-scrollbar-thumb-color-background;
                     box-sizing: border-box;
                     border-radius: 33px;
                 }

--- a/packages/design/src/components/layout-secondary/_variables.scss
+++ b/packages/design/src/components/layout-secondary/_variables.scss
@@ -1,1 +1,6 @@
-// stylelint-disable no-empty-source -- placeholder file
+$layout-secondary-color-background: var(--fkds-color-background-secondary) !default;
+$layout-secondary-resize-handle-color-background-default: var(--fkds-color-background-secondary) !default;
+$layout-secondary-resize-handle-color-background-hover: var(--fkds-color-action-background-secondary-hover) !default;
+$layout-secondary-resize-handle-dot-color-background: var(--fkds-color-action-text-secondary-default) !default;
+$layout-secondary-scrollbar-thumb-color-background: var(--fkds-color-border-primary) !default;
+$layout-secondary-button-tertiary-color-background-hover: var(--fkds-color-action-background-secondary-hover) !default;

--- a/packages/theme-default/src/shared/_index.scss
+++ b/packages/theme-default/src/shared/_index.scss
@@ -24,7 +24,7 @@
     // BACKGROUND COLORS
     // *****************
     --f-background-overlay: rgba(0, 0, 0, 0.75); // modal, loader
-    --f-background-sidepanel-button-tertiary-hover: #{$palette-color-bluebell-15}; //  FLeftPanel and FRightPanel
+    --f-background-sidepanel-button-tertiary-hover: var(--fkds-color-action-background-secondary-hover); //  FLeftPanel and FRightPanel
 
     // *******************
     // COLOR VARIABLES END


### PR DESCRIPTION
Lägger till semantiska färgtokens för left/right panel samt mappar om gamla `--f-background-sidepanel-button-tertiary-hover` till semantisk token för bakåtkompatibilitet (kan antagligen deprekeras senare)