### PR TITLE
docs: fix broken reference in example (refs SFKUI-6500)

### DIFF
--- a/docs/guides/validation/examples/CombinedFormatterParserExample.vue
+++ b/docs/guides/validation/examples/CombinedFormatterParserExample.vue
@@ -21,7 +21,7 @@ export default defineComponent({
     <div class="row">
         <div class="col col--md-9">
             <f-text-field
-                id="combined-formatter-parser"
+                id="combined-formatter-example"
                 v-model="modelValue"
                 v-validation.maxLength="{ maxLength: { length: 20 } }"
                 :formatter="formatNumber"


### PR DESCRIPTION
Senaste html-validate är kinkigare med attribut som refererar till andra element, i det här fallet att `<output for="..">` måste referera ett element som faktiskt existerar. Vet inte varför men renovate mergade in den versionen och nu failar allt på main med:

```
1 html-validate error was detected
┌─────────┬─────────────────────────┬──────────────────────────────────────────────────────────────┬──────────────────────────┐
│ (index) │ rule                    │ message                                                      │ selector                 │
├─────────┼─────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────┤
│ 0       │ 'no-missing-references' │ 'Element references missing id "combined-formatter-example"' │ '#fkui-vue-element-0003' │
└─────────┴─────────────────────────┴──────────────────────────────────────────────────────────────┴──────────────────────────┘
      1) "after each" hook for "guides/formatting-and-parsing/formatter-parser.html"
```