### PR TITLE
fix: respect focus box shadow theme override (refs SFKUI-6500)

### DIFF
--- a/packages/design/src/core/mixins/_focus.scss
+++ b/packages/design/src/core/mixins/_focus.scss
@@ -1,7 +1,4 @@
-$focus-box-shadow:
-    0 0 0 2px var(--fkds-focus-indicator-color-background),
-    0 0 0 4px var(--fkds-focus-indicator-color),
-    0 0 0 6px var(--fkds-focus-indicator-color-background) !default;
+$focus-box-shadow: var(--f-focus-box-shadow) !default;
 
 @mixin focus-indicator() {
     box-shadow: $focus-box-shadow;


### PR DESCRIPTION
Backar beslutet att flytta fokusmarkeringens box-shadow till mixinen, så att det fortsatt går att styra både utformning och färger på temanivå.