### PR TITLE
refactor: deprecate legacy theme color variables (refs SFKUI-6500)

### DIFF
--- a/packages/design/src/components/icon/_icon-stack.scss
+++ b/packages/design/src/components/icon/_icon-stack.scss
@@ -138,13 +138,13 @@
         border-radius: 100%;
         overflow: hidden;
         .f-icon-circle {
-            color: var(--f-icon-color-success-background);
-            fill: var(--f-icon-color-success-background);
+            color: $icon-stack-circle-color-background;
+            fill: $icon-stack-circle-color-background;
             width: 100%;
             height: 100%;
         }
         .icon:not(.f-icon-circle) {
-            color: var(--f-icon-color-success);
+            color: $icon-stack-circle-color-content;
             position: absolute;
         }
     }

--- a/packages/design/src/components/icon/_variables.scss
+++ b/packages/design/src/components/icon/_variables.scss
@@ -22,3 +22,8 @@ $icon-success-color-content: var(--fkds-color-text-primary) !default;
 $icon-tooltip-color-background: var(--fkds-color-action-background-primary-default);
 $icon-tooltip-color-border: var(--fkds-color-action-border-primary-default);
 $icon-tooltip-color-content: var(--fkds-color-text-inverted);
+
+// STACK CIRCLE
+// Legacy colors used until icon-stack--circle is deprecated.
+$icon-stack-circle-color-background: #dbe9e2 !default;
+$icon-stack-circle-color-content: #35805b !default;

--- a/packages/theme-default/src/deprecated-variables.json
+++ b/packages/theme-default/src/deprecated-variables.json
@@ -302,5 +302,8 @@
     "--f-button-default-padding-top",
     "--f-button-default-padding-right",
     "--f-button-default-padding-bottom",
-    "--f-button-default-padding-left"
+    "--f-button-default-padding-left",
+    "--f-icon-color-success",
+    "--f-icon-color-success-background",
+    "--f-tooltip-border-color"
 ]

--- a/packages/theme-default/src/fkui-css-variables-deprecated.scss
+++ b/packages/theme-default/src/fkui-css-variables-deprecated.scss
@@ -439,7 +439,7 @@ $palette-color-hav-20: #dbe0ec !default;
     --f-button-default-padding-bottom: 1rem;
     --f-button-default-padding-left: 1.5rem;
 
-    // Deprecated since v6.50.0
+    // Deprecated since %version%
     --f-icon-color-success: #35805b;
     --f-icon-color-success-background: #dbe9e2;
     --f-tooltip-border-color: #8d8e91;

--- a/packages/theme-default/src/fkui-css-variables-deprecated.scss
+++ b/packages/theme-default/src/fkui-css-variables-deprecated.scss
@@ -438,6 +438,11 @@ $palette-color-hav-20: #dbe0ec !default;
     --f-button-default-padding-right: 1.5rem;
     --f-button-default-padding-bottom: 1rem;
     --f-button-default-padding-left: 1.5rem;
+
+    // Deprecated since v6.50.0
+    --f-icon-color-success: #35805b;
+    --f-icon-color-success-background: #dbe9e2;
+    --f-tooltip-border-color: #8d8e91;
 }
 
 @if $global {

--- a/packages/theme-default/src/shared/_index.scss
+++ b/packages/theme-default/src/shared/_index.scss
@@ -1,7 +1,5 @@
 // stylelint-disable custom-property-empty-line-before -- technical debt, should just add a comment before each block
 
-@use "../palette-variables" as *;
-
 @mixin variables {
     // ***********
     // TEXT COLORS
@@ -17,9 +15,6 @@
     // ***********
     // ICON COLORS
     // ***********
-    --f-icon-color-success: #{$palette-color-green-a-85}; // message-box, text-field, form-step
-    --f-icon-color-success-background: #{$palette-color-green-a-15};
-
     // *****************
     // BACKGROUND COLORS
     // *****************
@@ -170,7 +165,6 @@
     --f-modal-title-font-size: #{$_f-font-size-h4};
 
     --f-tooltip-close-button-margin: 0.375rem 0.375rem 0.625rem 0.625rem;
-    --f-tooltip-border-color: #{$palette-color-fk-black-50};
     --f-tooltip-border-width: var(--f-border-width-medium);
 
     --f-loader-size: 4rem;


### PR DESCRIPTION
Deprekering av de sista palettfärgerna i temafilen inför införandet av ny palett.

icon-stack hanteras och får egna variabler under en övergångsperiod innan deprekering (används inte i fkui).