### PR TITLE
fix: resolve vue labs docs examples (refs SFKUI-6500)

### DIFF
--- a/docs.config.js
+++ b/docs.config.js
@@ -54,7 +54,7 @@ module.exports = {
     },
     outputFolder: "./public",
     cacheFolder: "./temp/docs",
-    exampleFolders: ["./packages/vue/src", "./docs"],
+    exampleFolders: ["./packages/vue/src", "./packages/vue-labs/src", "./docs"],
     templateFolders: ["./docs/templates"],
     setupPath: path.resolve("docs/src/setup.ts"),
     sourceFiles: [


### PR DESCRIPTION
Efter uppdateringen till `@forsakringskassan/docs-generator@3.1.0` failar Cypress e2e setup när docs-manifestet byggs. 

Lägger till `packages/vue-labs/src` i `exampleFolders` så att docs-generatorn kan lösa labs-exempel som exempelvis `XTimeTextFieldExample.vue`.

Verifiering:
- Verifierat att docs-generatorn kan bygga manifestet lokalt med `@forsakringskassan/docs-generator@3.1.0`.
- `npm exec -- prettier --check docs.config.js`
- `npm exec -- eslint docs.config.js`

 (felsökning gjord med Codex)