### PR TITLE
feat: `FButton` change prop `size` and `variant` to required (refs SFKUI-7994)

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -21,13 +21,16 @@ Använd primär knapp för det primära och det mest troliga alternativet för a
 Generellt ska endast en primär knapp finnas på en sida.
 I fallet när en sida består av flera olika delar kan varje del ha en primär knapp.
 
+```html static
+<f-button size="medium" variant="primary"> Knapptext </f-button>
+```
+
 ## Sekundär knapp
 
 Använd sekundär knapp fristående eller tillsammans med en primär knapp.
 
-```diff
--<f-button> Knapptext </f-button>
-+<f-button variant="secondary"> Knapptext </f-button>
+```html static
+<f-button size="medium" variant="secondary"> Knapptext </f-button>
 ```
 
 ## Tertiär knapp
@@ -39,23 +42,22 @@ Den kan användas som en tredje knapp tillsammans med en primär och en sekundä
 Tertiär knapp ska alltid ha ikon, förutom när den används i en grupp tillsammans med en primär eller sekundär knapp.
 Knapptexten är understruken om en tertiär knapp används utan en ikon.
 
-```diff
--<f-button> Knapptext </f-button>
-+<f-button variant="tertiary"> Knapptext </f-button>
+```html static
+<f-button size="medium" variant="tertiary"> Knapptext </f-button>
 ```
 
 Nedtonad tertiär knapp används för funktioner som inte har att göra med det huvudsakliga flödet eller innehållet på en sida, till exempel "Skriv ut".
 
 ```diff
--<f-button variant="tertiary"> Knapptext </f-button>
-+<f-button variant="tertiary" tertiary-style="muted"> Knapptext </f-button>
+-<f-button size="medium" variant="tertiary"> Knapptext </f-button>
++<f-button size="medium" variant="tertiary" tertiary-style="muted"> Knapptext </f-button>
 ```
 
 Inverterad tertiär knapp används för att få en bättre kontrast mot en mörk bakgrund.
 
 ```diff
--<f-button> Knapptext </f-button>
-+<f-button variant="tertiary" tertiary-style="inverted"> Knapptext </f-button>
+-<f-button size="medium" variant="tertiary"> Knapptext </f-button>
++<f-button size="medium" variant="tertiary" tertiary-style="inverted"> Knapptext </f-button>
 ```
 
 ### Linjera tertiär knapp med innehåll
@@ -80,11 +82,6 @@ Knapparnas storlekar kan användas för att förstärka den visuella hierarkin m
 Knappens bredd bestäms av längden på knapptexten.
 För varje knappstorlek finns en minsta bredd.
 
-```diff
--<f-button> text </f-button>
-+<f-button size="large"> text </f-button>
-```
-
 ## Fullbredd
 
 Fullbreddsknappar är främst avsedda att användas på ytor upp till 639 pixlars bredd.
@@ -95,8 +92,8 @@ Knappar som har storleken Large sätts automatiskt till fullbredd när skärmbre
 Knappar (small & medium) är som standard inte fullbredd i mobil men kan aktiveras med prop `mobile-full-width`.
 
 ```diff
--<f-button> text </f-button>
-+<f-button mobile-full-width> text </f-button>
+-<f-button size="medium" variant="primary"> text </f-button>
++<f-button size="medium" variant="primary" mobile-full-width> text </f-button>
 ```
 
 ## Ikon
@@ -105,8 +102,8 @@ Alla typer av knappar kan ha en ikon som placeras till höger eller vänster om 
 Använd ikoner för att förtydliga knappens funktion och skapa snabbare igenkänning.
 
 ```diff
--<f-button> text </f-button>
-+<f-button icon-left="pen"> text </f-button>
+-<f-button size="medium" variant="primary"> text </f-button>
++<f-button size="medium" variant="primary" icon-left="pen"> text </f-button>
 ```
 
 ## Hantering av asynkrona åtgärder
@@ -130,8 +127,8 @@ Om funktionen som körs vid knapptryck är synkron (ej asynkron, returnerar inge
 +   }
 </script>
 <template>
--   <f-button> text </f-button>
-+   <f-button @click="syncOperation"> text </f-button>
+-   <f-button size="medium" variant="primary"> text </f-button>
++   <f-button size="medium" variant="primary" @click="syncOperation"> text </f-button>
 </template>
 ```
 
@@ -152,8 +149,8 @@ Om funktionen returnerar en `Promise` (till exempel vid användning av `async/aw
 +}
 </script>
 <template>
--   <f-button> text </f-button>
-+   <f-button @click="asyncOperation"> text </f-button>
+-   <f-button size="medium" variant="primary"> text </f-button>
++   <f-button size="medium" variant="primary" @click="asyncOperation"> text </f-button>
 </template>
 ```
 
@@ -178,8 +175,8 @@ Om åtgärden är asynkron men inte returnerar en `Promise` (till exempel `fetch
 +   });
 </script>
 <template>
--   <f-button> text </f-button>
-+   <f-button @click="backgroundJob"> text </f-button>
+-   <f-button size="medium" variant="primary"> text </f-button>
++   <f-button size="medium" variant="primary" @click="backgroundJob"> text </f-button>
 </template>
 ```
 

--- a/docs/components/page-layout/examples/FLayoutApplicationTemplateExample.vue
+++ b/docs/components/page-layout/examples/FLayoutApplicationTemplateExample.vue
@@ -79,7 +79,9 @@ export default defineComponent({
 
                     <template #content>
                         <p>{{ selectedText }}</p>
-                        <f-button @click="closePanel()">Stäng</f-button>
+                        <f-button size="medium" variant="primary" @click="closePanel()">
+                            Stäng
+                        </f-button>
                     </template>
                     <template #default>
                         <div class="container-fluid">

--- a/docs/components/validation/examples/RequiredExample.vue
+++ b/docs/components/validation/examples/RequiredExample.vue
@@ -24,7 +24,13 @@ export default defineComponent({
     <f-validation-form :use-error-list="false" @submit="onSubmit">
         <f-text-field v-model="model" v-validation.required> Fyll i minst ett tecken </f-text-field>
         <div class="button-group">
-            <f-button id="submit" class="button-group__item" size="large" type="submit">
+            <f-button
+                id="submit"
+                class="button-group__item"
+                size="large"
+                variant="primary"
+                type="submit"
+            >
                 Spara
             </f-button>
             <f-button class="button-group__item" size="large" variant="secondary" @click="onCancel">

--- a/docs/functions/cypress/pageobjects/FLabelPageObject/FLabelPageObject-error-icon.vue
+++ b/docs/functions/cypress/pageobjects/FLabelPageObject/FLabelPageObject-error-icon.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { FTextField, FValidationForm } from "@fkui/vue";
+import { FButton, FTextField, FValidationForm } from "@fkui/vue";
 </script>
 
 <!-- cut above -->
 <template>
     <f-validation-form>
         <f-text-field v-validation.required v-test="'awesome-label'"> Etikett </f-text-field>
-        <button type="submit" class="button button--primary">Skicka in</button>
+        <f-button type="submit" size="large" variant="primary">Skicka in</f-button>
     </f-validation-form>
 </template>

--- a/docs/functions/cypress/pageobjects/FLabelPageObject/FLabelPageObject-error-message.vue
+++ b/docs/functions/cypress/pageobjects/FLabelPageObject/FLabelPageObject-error-message.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { FTextField, FValidationForm } from "@fkui/vue";
+import { FButton, FTextField, FValidationForm } from "@fkui/vue";
 </script>
 
 <!-- cut above -->
 <template>
     <f-validation-form>
         <f-text-field v-validation.required v-test="'awesome-label'"> Etikett </f-text-field>
-        <button type="submit" class="button button--primary">Skicka in</button>
+        <f-button type="submit" size="large" variant="primary">Skicka in</f-button>
     </f-validation-form>
 </template>

--- a/docs/styles/examples/CompareDensity.vue
+++ b/docs/styles/examples/CompareDensity.vue
@@ -196,6 +196,7 @@ export default defineComponent({
                                 class="button-group__item"
                                 align-text
                                 icon-left="pen"
+                                size="medium"
                                 variant="tertiary"
                             >
                                 <span> Ändra </span>
@@ -204,6 +205,7 @@ export default defineComponent({
                                 class="button-group__item"
                                 align-text
                                 icon-left="trashcan"
+                                size="medium"
                                 variant="tertiary"
                             >
                                 <span> Ta bort </span>
@@ -213,12 +215,17 @@ export default defineComponent({
                 </f-card>
 
                 <div class="button-group">
-                    <f-button class="button-group__item"> Medium </f-button>
-                    <f-button class="button-group__item" variant="secondary"> Medium </f-button>
+                    <f-button class="button-group__item" size="medium" variant="primary">
+                        Medium
+                    </f-button>
+                    <f-button class="button-group__item" size="medium" variant="secondary">
+                        Medium
+                    </f-button>
                     <f-button
                         class="button-group__item"
                         align-text
                         icon-left="paper-clip"
+                        size="medium"
                         variant="tertiary"
                     >
                         Medium
@@ -226,7 +233,9 @@ export default defineComponent({
                 </div>
 
                 <div class="button-group">
-                    <f-button class="button-group__item" size="large"> Large </f-button>
+                    <f-button class="button-group__item" size="large" variant="primary">
+                        Large
+                    </f-button>
                     <f-button class="button-group__item" size="large" variant="secondary">
                         Large
                     </f-button>

--- a/examples/page-layout/src/views/XOverviewView.vue
+++ b/examples/page-layout/src/views/XOverviewView.vue
@@ -25,7 +25,9 @@ function openThing(): void {
 <template>
     <h1>Översikt</h1>
     <p>Lorem ipsum dolor sit amet</p>
-    <f-button variant="secondary" @click="openThing">Öppna en helt annan detaljpanel</f-button>
+    <f-button size="medium" variant="secondary" @click="openThing">
+        Öppna en helt annan detaljpanel
+    </f-button>
 
     <f-interactive-table
         :rows="ankeborgare"

--- a/packages/vue-labs/src/components/XFileDragdrop/XFileDragdrop.vue
+++ b/packages/vue-labs/src/components/XFileDragdrop/XFileDragdrop.vue
@@ -252,6 +252,7 @@ EventBus.$on("RENSA_FIL_VALJARE", () => {
                         <f-button
                             data-test="file-item__file-remove"
                             icon-left="trashcan"
+                            size="medium"
                             variant="tertiary"
                             :aria-label="`Ta bort ${fileName}`"
                             @click="taBortFil"

--- a/packages/vue/src/components/FButton/FButton.cy.ts
+++ b/packages/vue/src/components/FButton/FButton.cy.ts
@@ -13,8 +13,10 @@ function createComponent(options?: {
     tertiaryStyle?: string;
     variant?: string;
 }): DefineComponent {
-    const { iconLeft, iconRight, mobileFullWidth, tertiaryStyle, variant } =
+    const { iconLeft, iconRight, mobileFullWidth, tertiaryStyle } =
         options ?? {};
+
+    const variant = options?.variant ?? "primary";
 
     const testName = Cypress.currentTest.titlePath.join(" ");
     return defineComponent({
@@ -36,6 +38,7 @@ function createComponent(options?: {
                 <p style="border: 1px dashed hotpink">
                     <f-button
                         :variant="variant"
+                        size="medium"
                         :icon-left="iconLeft"
                         :icon-right="iconRight"
                         :mobile-full-width="mobileFullWidth"

--- a/packages/vue/src/components/FButton/FButton.spec.ts
+++ b/packages/vue/src/components/FButton/FButton.spec.ts
@@ -25,6 +25,8 @@ describe("props", () => {
             const wrapper = shallowMount(FButton, {
                 props: {
                     disabled: true,
+                    size: "medium",
+                    variant: "primary",
                 },
             });
             const button = wrapper.get("button");
@@ -44,6 +46,8 @@ describe("props", () => {
         const wrapper = shallowMount(FButton, {
             props: {
                 type: "submit",
+                size: "medium",
+                variant: "primary",
             },
         });
         const button = wrapper.get("button");
@@ -56,6 +60,8 @@ describe("props", () => {
             props: {
                 iconLeft: "foo",
                 iconLibrary: "bar",
+                size: "medium",
+                variant: "primary",
             },
         });
         const icon = wrapper.getComponent(FIcon);
@@ -77,7 +83,9 @@ describe("html-validate", () => {
 
     it("should allow basic button", async () => {
         expect.assertions(1);
-        const markup = /* HTML */ ` <f-button> lorem ipsum </f-button> `;
+        const markup = /* HTML */ `
+            <f-button size="medium" variant="primary"> lorem ipsum </f-button>
+        `;
         const report = await htmlvalidate.validateString(markup);
         expect(report).toBeValid();
     });
@@ -86,9 +94,15 @@ describe("html-validate", () => {
         it("should allow valid values", async () => {
             expect.assertions(1);
             const markup = /* HTML */ `
-                <f-button type="submit"> lorem ipsum </f-button>
-                <f-button type="reset"> lorem ipsum </f-button>
-                <f-button type="button"> lorem ipsum </f-button>
+                <f-button type="submit" size="medium" variant="primary">
+                    lorem ipsum
+                </f-button>
+                <f-button type="reset" size="medium" variant="primary">
+                    lorem ipsum
+                </f-button>
+                <f-button type="button" size="medium" variant="primary">
+                    lorem ipsum
+                </f-button>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeValid();
@@ -97,17 +111,21 @@ describe("html-validate", () => {
         it("should not allow invalid values", async () => {
             expect.assertions(2);
             const markup = /* HTML */ `
-                <f-button type="invalid"> lorem ipsum </f-button>
+                <f-button type="invalid" size="medium" variant="primary">
+                    lorem ipsum
+                </f-button>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeInvalid();
             await expect(report).toMatchInlineCodeframe(`
-                error: Attribute "type" has invalid value "invalid" (attribute-allowed-values)
-                  1 |
-                > 2 |                 <f-button type="invalid"> lorem ipsum </f-button>
-                    |                                 ^^^^^^^
-                  3 |
-                Selector: f-button
+              error: Attribute "type" has invalid value "invalid" (attribute-allowed-values)
+                1 |
+              > 2 |                 <f-button type="invalid" size="medium" variant="primary">
+                  |                                 ^^^^^^^
+                3 |                     lorem ipsum
+                4 |                 </f-button>
+                5 |
+              Selector: f-button
             `);
         });
 
@@ -115,20 +133,22 @@ describe("html-validate", () => {
             expect.assertions(2);
             const markup = /* HTML */ `
                 <form>
-                    <f-button> lorem ipsum </f-button>
+                    <f-button size="medium" variant="primary">
+                        lorem ipsum
+                    </f-button>
                 </form>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeInvalid();
             await expect(report).toMatchInlineCodeframe(`
-                error: <form> element must have a submit button (wcag/h32)
-                  1 |
-                > 2 |                 <form>
-                    |                  ^^^^
-                  3 |                     <f-button> lorem ipsum </f-button>
-                  4 |                 </form>
-                  5 |
-                Selector: form
+              error: <form> element must have a submit button (wcag/h32)
+                1 |
+              > 2 |                 <form>
+                  |                  ^^^^
+                3 |                     <f-button size="medium" variant="primary">
+                4 |                         lorem ipsum
+                5 |                     </f-button>
+              Selector: form
             `);
         });
 
@@ -136,7 +156,9 @@ describe("html-validate", () => {
             expect.assertions(1);
             const markup = /* HTML */ `
                 <form>
-                    <f-button type="submit"> lorem ipsum </f-button>
+                    <f-button type="submit" size="medium" variant="primary">
+                        lorem ipsum
+                    </f-button>
                 </form>
             `;
             const report = await htmlvalidate.validateString(markup);
@@ -148,9 +170,15 @@ describe("html-validate", () => {
         it("should allow valid values", async () => {
             expect.assertions(1);
             const markup = /* HTML */ `
-                <f-button variant="primary"> lorem ipsum </f-button>
-                <f-button variant="secondary"> lorem ipsum </f-button>
-                <f-button variant="tertiary"> lorem ipsum </f-button>
+                <f-button size="medium" variant="primary">
+                    lorem ipsum
+                </f-button>
+                <f-button size="medium" variant="secondary">
+                    lorem ipsum
+                </f-button>
+                <f-button size="medium" variant="tertiary">
+                    lorem ipsum
+                </f-button>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeValid();
@@ -159,17 +187,21 @@ describe("html-validate", () => {
         it("should not allow invalid values", async () => {
             expect.assertions(2);
             const markup = /* HTML */ `
-                <f-button variant="invalid"> lorem ipsum </f-button>
+                <f-button size="medium" variant="invalid">
+                    lorem ipsum
+                </f-button>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeInvalid();
             await expect(report).toMatchInlineCodeframe(`
-                error: Attribute "variant" has invalid value "invalid" (attribute-allowed-values)
-                  1 |
-                > 2 |                 <f-button variant="invalid"> lorem ipsum </f-button>
-                    |                                    ^^^^^^^
-                  3 |
-                Selector: f-button
+              error: Attribute "variant" has invalid value "invalid" (attribute-allowed-values)
+                1 |
+              > 2 |                 <f-button size="medium" variant="invalid">
+                  |                                                  ^^^^^^^
+                3 |                     lorem ipsum
+                4 |                 </f-button>
+                5 |
+              Selector: f-button
             `);
         });
     });
@@ -178,9 +210,15 @@ describe("html-validate", () => {
         it("should allow valid values", async () => {
             expect.assertions(1);
             const markup = /* HTML */ `
-                <f-button size="small"> lorem ipsum </f-button>
-                <f-button size="medium"> lorem ipsum </f-button>
-                <f-button size="large"> lorem ipsum </f-button>
+                <f-button size="small" variant="primary">
+                    lorem ipsum
+                </f-button>
+                <f-button size="medium" variant="primary">
+                    lorem ipsum
+                </f-button>
+                <f-button size="large" variant="primary">
+                    lorem ipsum
+                </f-button>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeValid();
@@ -189,17 +227,21 @@ describe("html-validate", () => {
         it("should not allow invalid values", async () => {
             expect.assertions(2);
             const markup = /* HTML */ `
-                <f-button size="invalid"> lorem ipsum </f-button>
+                <f-button size="invalid" variant="primary">
+                    lorem ipsum
+                </f-button>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeInvalid();
             await expect(report).toMatchInlineCodeframe(`
-                error: Attribute "size" has invalid value "invalid" (attribute-allowed-values)
-                  1 |
-                > 2 |                 <f-button size="invalid"> lorem ipsum </f-button>
-                    |                                 ^^^^^^^
-                  3 |
-                Selector: f-button
+              error: Attribute "size" has invalid value "invalid" (attribute-allowed-values)
+                1 |
+              > 2 |                 <f-button size="invalid" variant="primary">
+                  |                                 ^^^^^^^
+                3 |                     lorem ipsum
+                4 |                 </f-button>
+                5 |
+              Selector: f-button
             `);
         });
     });
@@ -208,8 +250,12 @@ describe("html-validate", () => {
         it("should allow either icon-left or icon-right", async () => {
             expect.assertions(1);
             const markup = /* HTML */ `
-                <f-button icon-left="icon"> lorem ipsum </f-button>
-                <f-button icon-right="icon"> lorem ipsum </f-button>
+                <f-button icon-left="icon" size="medium" variant="primary">
+                    lorem ipsum
+                </f-button>
+                <f-button icon-right="icon" size="medium" variant="primary">
+                    lorem ipsum
+                </f-button>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeValid();
@@ -218,29 +264,36 @@ describe("html-validate", () => {
         it("should not allow both icon-left and icon-right", async () => {
             expect.assertions(2);
             const markup = /* HTML */ `
-                <f-button icon-left="icon" icon-right="icon">
+                <f-button
+                    icon-left="icon"
+                    icon-right="icon"
+                    size="medium"
+                    variant="primary"
+                >
                     lorem ipsum
                 </f-button>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeInvalid();
             await expect(report).toMatchInlineCodeframe(`
-                error: "icon-left" attribute cannot be used on <f-button> in this context: cannot be used at the same time as "icon-right" (attribute-misuse)
-                  1 |
-                > 2 |                 <f-button icon-left="icon" icon-right="icon">
-                    |                           ^^^^^^^^^
-                  3 |                     lorem ipsum
-                  4 |                 </f-button>
-                  5 |
-                Selector: f-button
-                error: "icon-right" attribute cannot be used on <f-button> in this context: cannot be used at the same time as "icon-left" (attribute-misuse)
-                  1 |
-                > 2 |                 <f-button icon-left="icon" icon-right="icon">
-                    |                                            ^^^^^^^^^^
-                  3 |                     lorem ipsum
-                  4 |                 </f-button>
-                  5 |
-                Selector: f-button
+              error: "icon-left" attribute cannot be used on <f-button> in this context: cannot be used at the same time as "icon-right" (attribute-misuse)
+                1 |
+                2 |                 <f-button
+              > 3 |                     icon-left="icon"
+                  |                     ^^^^^^^^^
+                4 |                     icon-right="icon"
+                5 |                     size="medium"
+                6 |                     variant="primary"
+              Selector: f-button
+              error: "icon-right" attribute cannot be used on <f-button> in this context: cannot be used at the same time as "icon-left" (attribute-misuse)
+                2 |                 <f-button
+                3 |                     icon-left="icon"
+              > 4 |                     icon-right="icon"
+                  |                     ^^^^^^^^^^
+                5 |                     size="medium"
+                6 |                     variant="primary"
+                7 |                 >
+              Selector: f-button
             `);
         });
     });
@@ -249,8 +302,12 @@ describe("html-validate", () => {
         it("should allow disabled and mobile-full-width", async () => {
             expect.assertions(1);
             const markup = /* HTML */ `
-                <f-button disabled> lorem ipsum </f-button>
-                <f-button mobile-full-width> lorem ipsum </f-button>
+                <f-button disabled size="medium" variant="primary">
+                    lorem ipsum
+                </f-button>
+                <f-button mobile-full-width size="medium" variant="primary">
+                    lorem ipsum
+                </f-button>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeValid();
@@ -261,7 +318,11 @@ describe("html-validate", () => {
         it("should allow tertiary-style and align-text when variant is tertiary", async () => {
             expect.assertions(1);
             const markup = /* HTML */ `
-                <f-button variant="tertiary" tertiary-style="muted">
+                <f-button
+                    size="medium"
+                    variant="tertiary"
+                    tertiary-style="muted"
+                >
                     lorem ipsum
                 </f-button>
                 <f-button variant="tertiary" align-text> lorem ipsum </f-button>
@@ -273,55 +334,73 @@ describe("html-validate", () => {
         it("should not allow tertiary-style without variant tertiary", async () => {
             expect.assertions(2);
             const markup = /* HTML */ `
-                <f-button tertiary-style="muted"> lorem ipsum </f-button>
-            `;
-            const report = await htmlvalidate.validateString(markup);
-            expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
-                error: "tertiary-style" attribute cannot be used on <f-button> in this context: "variant" attribute must be "tertiary" (attribute-misuse)
-                  1 |
-                > 2 |                 <f-button tertiary-style="muted"> lorem ipsum </f-button>
-                    |                           ^^^^^^^^^^^^^^
-                  3 |
-                Selector: f-button
-            `);
-        });
-
-        it("should not allow invalid tertiary-style value", async () => {
-            expect.assertions(2);
-            const markup = /* HTML */ `
-                <f-button tertiary-style="invalid" variant="tertiary">
+                <f-button
+                    size="medium"
+                    variant="primary"
+                    tertiary-style="muted"
+                >
                     lorem ipsum
                 </f-button>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeInvalid();
             await expect(report).toMatchInlineCodeframe(`
-                error: Attribute "tertiary-style" has invalid value "invalid" (attribute-allowed-values)
-                  1 |
-                > 2 |                 <f-button tertiary-style="invalid" variant="tertiary">
-                    |                                           ^^^^^^^
-                  3 |                     lorem ipsum
-                  4 |                 </f-button>
-                  5 |
-                Selector: f-button
+              error: "tertiary-style" attribute cannot be used on <f-button> in this context: "variant" attribute must be "tertiary" (attribute-misuse)
+                3 |                     size="medium"
+                4 |                     variant="primary"
+              > 5 |                     tertiary-style="muted"
+                  |                     ^^^^^^^^^^^^^^
+                6 |                 >
+                7 |                     lorem ipsum
+                8 |                 </f-button>
+              Selector: f-button
+            `);
+        });
+
+        it("should not allow invalid tertiary-style value", async () => {
+            expect.assertions(2);
+            const markup = /* HTML */ `
+                <f-button
+                    size="medium"
+                    tertiary-style="invalid"
+                    variant="tertiary"
+                >
+                    lorem ipsum
+                </f-button>
+            `;
+            const report = await htmlvalidate.validateString(markup);
+            expect(report).toBeInvalid();
+            await expect(report).toMatchInlineCodeframe(`
+              error: Attribute "tertiary-style" has invalid value "invalid" (attribute-allowed-values)
+                2 |                 <f-button
+                3 |                     size="medium"
+              > 4 |                     tertiary-style="invalid"
+                  |                                     ^^^^^^^
+                5 |                     variant="tertiary"
+                6 |                 >
+                7 |                     lorem ipsum
+              Selector: f-button
             `);
         });
 
         it("should not allow align-text without variant tertiary", async () => {
             expect.assertions(2);
             const markup = /* HTML */ `
-                <f-button align-text> lorem ipsum </f-button>
+                <f-button size="medium" variant="primary" align-text>
+                    lorem ipsum
+                </f-button>
             `;
             const report = await htmlvalidate.validateString(markup);
             expect(report).toBeInvalid();
             await expect(report).toMatchInlineCodeframe(`
-                error: "align-text" attribute cannot be used on <f-button> in this context: "variant" attribute must be "tertiary" (attribute-misuse)
-                  1 |
-                > 2 |                 <f-button align-text> lorem ipsum </f-button>
-                    |                           ^^^^^^^^^^
-                  3 |
-                Selector: f-button
+              error: "align-text" attribute cannot be used on <f-button> in this context: "variant" attribute must be "tertiary" (attribute-misuse)
+                1 |
+              > 2 |                 <f-button size="medium" variant="primary" align-text>
+                  |                                                           ^^^^^^^^^^
+                3 |                     lorem ipsum
+                4 |                 </f-button>
+                5 |
+              Selector: f-button
             `);
         });
     });

--- a/packages/vue/src/components/FButton/FButton.vue
+++ b/packages/vue/src/components/FButton/FButton.vue
@@ -13,7 +13,7 @@ const props = defineProps({
      */
     variant: {
         type: String as PropType<"primary" | "secondary" | "tertiary">,
-        default: "primary",
+        required: true,
         validator(value: string) {
             return ["primary", "secondary", "tertiary"].includes(value);
         },
@@ -27,7 +27,7 @@ const props = defineProps({
      */
     size: {
         type: String as PropType<"small" | "medium" | "large">,
-        default: "medium",
+        required: true,
         validator(value: string) {
             return ["small", "medium", "large"].includes(value);
         },

--- a/packages/vue/src/components/FButton/FButtonAsyncOperation.cy.ts
+++ b/packages/vue/src/components/FButton/FButtonAsyncOperation.cy.ts
@@ -17,8 +17,10 @@ function createComponent(options?: {
     resolve(): void;
     reject(): void;
 } {
-    const { iconLeft, iconRight, mobileFullWidth, tertiaryStyle, variant } =
+    const { iconLeft, iconRight, mobileFullWidth, tertiaryStyle } =
         options ?? {};
+
+    const variant = options?.variant ?? "primary";
 
     const testName = Cypress.currentTest.titlePath.join(" ");
     let resolve: () => void, reject: () => void;
@@ -64,6 +66,7 @@ function createComponent(options?: {
                 <p style="border: 1px dashed hotpink">
                     <f-button
                         :variant="variant"
+                        size="medium"
                         :icon-left="iconLeft"
                         :icon-right="iconRight"
                         :mobile-full-width="mobileFullWidth"
@@ -77,6 +80,7 @@ function createComponent(options?: {
                     <f-button
                         id="button2"
                         :variant="variant"
+                        size="medium"
                         :icon-left="iconLeft"
                         :icon-right="iconRight"
                         :mobile-full-width="mobileFullWidth"

--- a/packages/vue/src/components/FButton/examples/FButtonGroupExample.vue
+++ b/packages/vue/src/components/FButton/examples/FButtonGroupExample.vue
@@ -4,8 +4,10 @@ import { FButton } from "@fkui/vue";
 
 <template>
     <div class="button-group">
-        <f-button class="button-group__item" icon-left="success"> Knapp 1 i grupp </f-button>
-        <f-button class="button-group__item" variant="secondary" icon-left="error">
+        <f-button class="button-group__item" icon-left="success" size="medium" variant="primary">
+            Knapp 1 i grupp
+        </f-button>
+        <f-button class="button-group__item" icon-left="error" size="medium" variant="secondary">
             Knapp 2 i grupp
         </f-button>
     </div>

--- a/packages/vue/src/components/FButton/examples/FButtonListExample.vue
+++ b/packages/vue/src/components/FButton/examples/FButtonListExample.vue
@@ -5,13 +5,17 @@ import { FButton } from "@fkui/vue";
 <template>
     <ul class="button-list no-marker">
         <li>
-            <f-button variant="tertiary" icon-left="success"> Knapp 1 i lista </f-button>
+            <f-button size="medium" variant="tertiary" icon-left="success">
+                Knapp 1 i lista
+            </f-button>
         </li>
         <li>
-            <f-button variant="tertiary" icon-left="cross"> Knapp 2 i lista </f-button>
+            <f-button size="medium" variant="tertiary" icon-left="cross">
+                Knapp 2 i lista
+            </f-button>
         </li>
         <li>
-            <f-button variant="tertiary" icon-left="pen"> Knapp 3 i lista </f-button>
+            <f-button size="medium" variant="tertiary" icon-left="pen"> Knapp 3 i lista </f-button>
         </li>
     </ul>
 </template>

--- a/packages/vue/src/components/FButton/examples/FButtonLiveExample.vue
+++ b/packages/vue/src/components/FButton/examples/FButtonLiveExample.vue
@@ -9,8 +9,8 @@ export default defineComponent({
     components: { LiveExample, FCheckboxField, FFieldset, FRadioField, FSelectField },
     data() {
         return {
-            variant: undefined as undefined | string,
-            size: undefined as undefined | string,
+            variant: "primary",
+            size: "medium",
             disabled: false,
             tertiaryStyle: undefined as undefined | string,
             hasIcon: false,
@@ -85,7 +85,7 @@ export default defineComponent({
     <live-example :components :template :livemethods="livemethods()">
         <f-select-field v-model="variant">
             <template #label> Typ </template>
-            <option :value="undefined">Primär</option>
+            <option value="primary">Primär</option>
             <option value="secondary">Sekundär</option>
             <option value="tertiary">Tertiär</option>
         </f-select-field>

--- a/packages/vue/src/components/FCard/examples/FCardExample.vue
+++ b/packages/vue/src/components/FCard/examples/FCardExample.vue
@@ -28,10 +28,17 @@ export default defineComponent({
         </template>
         <template #footer>
             <div class="button-group">
-                <f-button variant="tertiary" align-text class="button-group__item" icon-left="pen">
+                <f-button
+                    size="medium"
+                    variant="tertiary"
+                    align-text
+                    class="button-group__item"
+                    icon-left="pen"
+                >
                     Ändra
                 </f-button>
                 <f-button
+                    size="medium"
                     variant="tertiary"
                     align-text
                     class="button-group__item"

--- a/packages/vue/src/components/FCard/examples/FCardValidationExample.vue
+++ b/packages/vue/src/components/FCard/examples/FCardValidationExample.vue
@@ -45,6 +45,7 @@ function setValid(): void {
                         class="button-group__item"
                         align-text
                         icon-left="pen"
+                        size="medium"
                         variant="tertiary"
                     >
                         <span>
@@ -59,6 +60,7 @@ function setValid(): void {
                         class="button-group__item"
                         align-text
                         icon-left="trashcan"
+                        size="medium"
                         variant="tertiary"
                     >
                         <span> Ta bort </span>
@@ -67,7 +69,9 @@ function setValid(): void {
             </template>
         </f-card>
 
-        <f-button type="submit">Simulera inskick av formulär</f-button>
+        <f-button type="submit" size="medium" variant="primary">
+            Simulera inskick av formulär
+        </f-button>
     </f-validation-form>
 
     <f-button

--- a/packages/vue/src/components/FContextMenu/examples/FContextMenuExample.vue
+++ b/packages/vue/src/components/FContextMenu/examples/FContextMenuExample.vue
@@ -47,6 +47,8 @@ export default defineComponent({
             ref="popupAnchor"
             data-test="open-example-contextmenu-button"
             aria-haspopup="menu"
+            size="medium"
+            variant="primary"
             @click="onClick"
         >
             Öppna

--- a/packages/vue/src/components/FContextMenu/examples/FContextMenuExampleTextOnly.vue
+++ b/packages/vue/src/components/FContextMenu/examples/FContextMenuExampleTextOnly.vue
@@ -50,6 +50,8 @@ export default defineComponent({
             ref="popupAnchor"
             data-test="open-example-contextmenu-button"
             aria-haspopup="menu"
+            size="medium"
+            variant="primary"
             @click="onClick"
         >
             Öppna

--- a/packages/vue/src/components/FDetailsPanel/examples/FDetailsPanelEdit.vue
+++ b/packages/vue/src/components/FDetailsPanel/examples/FDetailsPanelEdit.vue
@@ -86,6 +86,7 @@ function openPanel(row: Row): void {
                                     <f-button
                                         class="button-group__item"
                                         size="small"
+                                        variant="primary"
                                         @click="exampleScope.close('save')"
                                     >
                                         Spara

--- a/packages/vue/src/components/FDetailsPanel/examples/FDetailsPanelExample.vue
+++ b/packages/vue/src/components/FDetailsPanel/examples/FDetailsPanelExample.vue
@@ -29,7 +29,14 @@ function openPanel(): void {
                     </example-panel>
                 </f-resize-pane>
 
-                <f-button :slot="layoutScope.content" @click="openPanel"> Öppna </f-button>
+                <f-button
+                    :slot="layoutScope.content"
+                    size="medium"
+                    variant="primary"
+                    @click="openPanel"
+                >
+                    Öppna
+                </f-button>
             </template>
         </f-page-layout>
     </div>

--- a/packages/vue/src/components/FDetailsPanel/examples/FDetailsPanelExclusive.vue
+++ b/packages/vue/src/components/FDetailsPanel/examples/FDetailsPanelExclusive.vue
@@ -63,12 +63,20 @@ function openPanel4(): void {
 
             <div :slot="content" class="content">
                 <div>
-                    <f-button @click="openPanel1"> Öppna panel 1 </f-button>
-                    <f-button @click="openPanel2"> Öppna panel 2 </f-button>
+                    <f-button size="medium" variant="primary" @click="openPanel1">
+                        Öppna panel 1
+                    </f-button>
+                    <f-button size="medium" variant="primary" @click="openPanel2">
+                        Öppna panel 2
+                    </f-button>
                 </div>
                 <div>
-                    <f-button @click="openPanel3"> Öppna panel 3 </f-button>
-                    <f-button @click="openPanel4"> Öppna panel 4 </f-button>
+                    <f-button size="medium" variant="primary" @click="openPanel3">
+                        Öppna panel 3
+                    </f-button>
+                    <f-button size="medium" variant="primary" @click="openPanel4">
+                        Öppna panel 4
+                    </f-button>
                 </div>
 
                 <p>

--- a/packages/vue/src/components/FDetailsPanel/examples/FDetailsPanelTestbed.vue
+++ b/packages/vue/src/components/FDetailsPanel/examples/FDetailsPanelTestbed.vue
@@ -42,7 +42,7 @@ function openPanel(): void {
         </component>
 
         <div slot="content" class="content">
-            <f-button @click="openPanel"> Öppna panel </f-button>
+            <f-button size="medium" variant="primary" @click="openPanel"> Öppna panel </f-button>
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis tincidunt ipsum
                 tortor. Aliquam erat eros, maximus rhoncus quam ut, dignissim ullamcorper nunc.

--- a/packages/vue/src/components/FExpand/examples/FExpandExample.vue
+++ b/packages/vue/src/components/FExpand/examples/FExpandExample.vue
@@ -19,7 +19,7 @@ export default defineComponent({
         <f-expand>
             <div v-if="expanded">Expanded content</div>
         </f-expand>
-        <f-button @click="expanded = !expanded">
+        <f-button size="medium" variant="primary" @click="expanded = !expanded">
             {{ expanded ? `Close` : `Open` }}
         </f-button>
     </div>

--- a/packages/vue/src/components/FFieldset/examples/FFieldsetCheckboxScreenshot.vue
+++ b/packages/vue/src/components/FFieldset/examples/FFieldsetCheckboxScreenshot.vue
@@ -92,7 +92,9 @@ const data = ref();
                 </template>
             </f-fieldset>
 
-            <f-button id="button" type="submit"> Validate </f-button>
+            <f-button id="button" type="submit" size="medium" variant="primary">
+                Validate
+            </f-button>
         </template>
     </f-validation-form>
 </template>

--- a/packages/vue/src/components/FFieldset/examples/FFieldsetChipScreenshot.vue
+++ b/packages/vue/src/components/FFieldset/examples/FFieldsetChipScreenshot.vue
@@ -75,7 +75,9 @@ const choices2 = ref([]);
                 </f-checkbox-field>
             </f-fieldset>
 
-            <f-button id="button" type="submit"> Validate </f-button>
+            <f-button id="button" type="submit" size="medium" variant="primary">
+                Validate
+            </f-button>
         </template>
     </f-validation-form>
 </template>

--- a/packages/vue/src/components/FFieldset/examples/FFieldsetRadiobuttonScreenshot.vue
+++ b/packages/vue/src/components/FFieldset/examples/FFieldsetRadiobuttonScreenshot.vue
@@ -48,7 +48,9 @@ const modelValue2 = ref();
                 </template>
             </f-fieldset>
 
-            <f-button id="button" type="submit"> Validate </f-button>
+            <f-button id="button" type="submit" size="medium" variant="primary">
+                Validate
+            </f-button>
         </template>
     </f-validation-form>
 </template>

--- a/packages/vue/src/components/FFileItem/examples/FFileItemButtonProgress.vue
+++ b/packages/vue/src/components/FFileItem/examples/FFileItemButtonProgress.vue
@@ -41,6 +41,7 @@ export default defineComponent({
                     v-if="filteredProgress < 100"
                     data-test="file-item__file-remove"
                     icon-left="close"
+                    size="medium"
                     variant="tertiary"
                 >
                     Avbryt uppladdning
@@ -49,6 +50,7 @@ export default defineComponent({
                     v-else-if="filteredProgress === 100"
                     data-test="file-item__file-remove"
                     icon-left="trashcan"
+                    size="medium"
                     variant="tertiary"
                 >
                     Ta bort

--- a/packages/vue/src/components/FLayoutLeftPanel/FLayoutLeftPanel.vue
+++ b/packages/vue/src/components/FLayoutLeftPanel/FLayoutLeftPanel.vue
@@ -142,6 +142,7 @@ export default defineComponent({
                         ref="open-button"
                         icon-right="bars"
                         tertiary-style="muted"
+                        size="medium"
                         variant="tertiary"
                         @click="toggleSideNavigation"
                     >

--- a/packages/vue/src/components/FLayoutRightPanel/examples/FLayoutRightPanelVisualExample.vue
+++ b/packages/vue/src/components/FLayoutRightPanel/examples/FLayoutRightPanelVisualExample.vue
@@ -67,7 +67,7 @@ export default defineComponent({
 
                 <template #content>
                     <p>{{ selectedText }}</p>
-                    <f-button @click="closePanel()">Stäng</f-button>
+                    <f-button size="medium" variant="primary" @click="closePanel()">Stäng</f-button>
                 </template>
                 <template #default>
                     <div class="container-fluid">

--- a/packages/vue/src/components/FLoader/examples/FLoaderLiveExample.vue
+++ b/packages/vue/src/components/FLoader/examples/FLoaderLiveExample.vue
@@ -90,7 +90,7 @@ export default defineComponent({
         <f-checkbox-field v-if="overlay" v-model="focusOnOverlay" :value="true">
             Fokusera på meddelande
         </f-checkbox-field>
-        <f-button @click="toggleLoader()"> Visa </f-button>
+        <f-button size="medium" variant="primary" @click="toggleLoader()"> Visa </f-button>
         <p>Laddningsindikatorn visas i {{ loaderTime }} sekunder.</p>
     </live-example>
 </template>

--- a/packages/vue/src/components/FModal/FModal.cy.ts
+++ b/packages/vue/src/components/FModal/FModal.cy.ts
@@ -100,6 +100,7 @@ function generateModalMarkup(focusStrategy = "on"): string {
                         </f-button>
                         <f-button
                             size="large"
+                            variant="primary"
                             class="button-group__item"
                             @click="onClickCloseModal"
                         >

--- a/packages/vue/src/components/FModal/examples/FConfirmModalApiExample.vue
+++ b/packages/vue/src/components/FModal/examples/FConfirmModalApiExample.vue
@@ -37,6 +37,6 @@ export default defineComponent({
 
 <template>
     <div>
-        <f-button variant="secondary" @click="onClick">Ta bort</f-button>
+        <f-button size="medium" variant="secondary" @click="onClick">Ta bort</f-button>
     </div>
 </template>

--- a/packages/vue/src/components/FModal/examples/FConfirmModalCustomButtons.vue
+++ b/packages/vue/src/components/FModal/examples/FConfirmModalCustomButtons.vue
@@ -39,7 +39,7 @@ export default defineComponent({
 
 <template>
     <div>
-        <f-button variant="secondary" @click="onClick">Tre knappar</f-button>
+        <f-button size="medium" variant="secondary" @click="onClick">Tre knappar</f-button>
         <pre> Modalen stängdes med resultatet: {{ action }} </pre>
     </div>
 </template>

--- a/packages/vue/src/components/FModal/examples/FFormModalApiExample.vue
+++ b/packages/vue/src/components/FModal/examples/FFormModalApiExample.vue
@@ -32,7 +32,12 @@ export default defineComponent({
 
 <template>
     <div class="f-form-modal-example">
-        <f-button data-test="form-modal-api-example-button" variant="secondary" @click="onClick">
+        <f-button
+            data-test="form-modal-api-example-button"
+            size="medium"
+            variant="secondary"
+            @click="onClick"
+        >
             Öppna Modal
         </f-button>
         <div v-if="result">

--- a/packages/vue/src/components/FModal/examples/FModalLiveExample.vue
+++ b/packages/vue/src/components/FModal/examples/FModalLiveExample.vue
@@ -38,14 +38,21 @@ export default defineComponent({
         },
         button(): string {
             return /* HTML */ `
-                <f-button variant="secondary" @click="isOpen = !isOpen"> Öppna modal </f-button>
+                <f-button size="medium" variant="secondary" @click="isOpen = !isOpen">
+                    Öppna modal
+                </f-button>
             `;
         },
         footer(): string {
             return /* HTML */ `
                 <template #footer>
                     <div class="button-group">
-                        <f-button class="button-group__item" size="large" @click="isOpen = false">
+                        <f-button
+                            class="button-group__item"
+                            size="large"
+                            variant="primary"
+                            @click="isOpen = false"
+                        >
                             Stäng
                         </f-button>
                     </div>

--- a/packages/vue/src/components/FModal/examples/FModalUsage.vue
+++ b/packages/vue/src/components/FModal/examples/FModalUsage.vue
@@ -11,6 +11,6 @@ async function onClick(): Promise<void> {
 
 <template>
     <div>
-        <f-button variant="secondary" @click="onClick">Open</f-button>
+        <f-button size="medium" variant="secondary" @click="onClick">Open</f-button>
     </div>
 </template>

--- a/packages/vue/src/components/FModal/examples/MyAwesomeModal.vue
+++ b/packages/vue/src/components/FModal/examples/MyAwesomeModal.vue
@@ -10,7 +10,12 @@ const emit = defineEmits<{ close: [] }>();
         <template #content> My awesome content </template>
         <template #footer>
             <div class="button-group">
-                <f-button class="button-group__item" size="large" @click="emit('close')">
+                <f-button
+                    class="button-group__item"
+                    size="large"
+                    variant="primary"
+                    @click="emit('close')"
+                >
                     Close
                 </f-button>
             </div>

--- a/packages/vue/src/components/FOffline/examples/FOfflineExample.vue
+++ b/packages/vue/src/components/FOffline/examples/FOfflineExample.vue
@@ -30,6 +30,6 @@ export default defineComponent({
 <template>
     <div v-test="'offlineExample'">
         <f-offline> {{ offlineMessage }} </f-offline>
-        <f-button @click="toggle">Visa/Dölj komponent</f-button>
+        <f-button size="medium" variant="primary" @click="toggle">Visa/Dölj komponent</f-button>
     </div>
 </template>

--- a/packages/vue/src/components/FProgressbar/examples/FProgressbarExample.vue
+++ b/packages/vue/src/components/FProgressbar/examples/FProgressbarExample.vue
@@ -36,10 +36,22 @@ export default defineComponent({
         ><span class="sr-only">Debug-data: </span>value: {{currentProgress}}</pre>
 
         <div class="button-group">
-            <f-button class="button-group__item" data-test="increase" @click="increase()">
+            <f-button
+                class="button-group__item"
+                data-test="increase"
+                size="medium"
+                variant="primary"
+                @click="increase()"
+            >
                 Increase
             </f-button>
-            <f-button class="button-group__item" data-test="decrease" @click="decrease()">
+            <f-button
+                class="button-group__item"
+                data-test="decrease"
+                size="medium"
+                variant="primary"
+                @click="decrease()"
+            >
                 Decrease
             </f-button>
             <label>

--- a/packages/vue/src/components/FTable/docs/FTableAddRemoveExample.vue
+++ b/packages/vue/src/components/FTable/docs/FTableAddRemoveExample.vue
@@ -91,7 +91,7 @@ async function onRemoveRow(row: Row): Promise<void> {
         <template #caption>Lägg till och ta bort rad i tabell</template>
     </f-table>
 
-    <f-button variant="secondary" data-test="add-row-button" @click="onAddRow">
+    <f-button size="medium" variant="secondary" data-test="add-row-button" @click="onAddRow">
         Lägg till rad
     </f-button>
 </template>

--- a/packages/vue/src/components/FTable/docs/FTableBulkLiveExample.vue
+++ b/packages/vue/src/components/FTable/docs/FTableBulkLiveExample.vue
@@ -109,10 +109,10 @@ const livemethods = {
 
 const actionsTemplate = /* HTML */ `
     <div class="button-group">
-        <f-button variant="secondary" @click="onRemoveSelectedRows">
+        <f-button size="medium" variant="secondary" @click="onRemoveSelectedRows">
             Ta bort valda frukt(er)
         </f-button>
-        <f-button variant="secondary" @click="onRestoreRows"> Återställ </f-button>
+        <f-button size="medium" variant="secondary" @click="onRestoreRows"> Återställ </f-button>
     </div>
 `;
 

--- a/packages/vue/src/components/FTable/tests/FTableExpandablePaginationExample.vue
+++ b/packages/vue/src/components/FTable/tests/FTableExpandablePaginationExample.vue
@@ -174,7 +174,7 @@ function onRemoveSelectedRows(): void {
 </script>
 
 <template>
-    <f-button variant="secondary" @click="onRemoveSelectedRows"> Ta bort markerade rader </f-button>
+    <f-button size="medium" variant="secondary" @click="onRemoveSelectedRows"> Ta bort markerade rader </f-button>
 
     <f-sort-filter-dataset :data="rows" :sortable-attributes>
         <template #default="{ sortFilterResult }">
@@ -197,5 +197,5 @@ function onRemoveSelectedRows(): void {
         </template>
     </f-sort-filter-dataset>
 
-    <f-button variant="secondary" @click="onAddRow">Lägg till rad</f-button>
+    <f-button size="medium" variant="secondary" @click="onAddRow">Lägg till rad</f-button>
 </template>

--- a/packages/vue/src/components/FTable/tests/FTableInputFieldsExample.vue
+++ b/packages/vue/src/components/FTable/tests/FTableInputFieldsExample.vue
@@ -230,7 +230,7 @@ function validataAll(): void {
 </script>
 
 <template>
-    <f-button variant="secondary" @click="validataAll"> Interagerbart element före </f-button>
+    <f-button size="medium" variant="secondary" @click="validataAll"> Interagerbart element före </f-button>
     <div id="all">
         Testpersonnummer från Skatteverket
         <f-table :rows :columns="columns1" key-attribute="id" striped> </f-table>
@@ -240,5 +240,5 @@ function validataAll(): void {
     <pre>Summa: {{ { sum } }}</pre>
     <h3>Rows ({{ rows.length }} items):</h3>
     <pre>{{ rows }}</pre>
-    <f-button variant="secondary" @click="validataAll"> Interagerbart element efter </f-button>
+    <f-button size="medium" variant="secondary" @click="validataAll"> Interagerbart element efter </f-button>
 </template>

--- a/packages/vue/src/components/FTable/tests/FTableSortFilterExample.vue
+++ b/packages/vue/src/components/FTable/tests/FTableSortFilterExample.vue
@@ -102,9 +102,11 @@ function onChangeDataset(): void {
 
     <p data-test="selected-count">Valda rader: {{ selectedRows.length }}</p>
 
-    <f-button variant="secondary" @click="onAddRow">Lägg till rad</f-button>
-    <f-button variant="secondary" @click="onRemoveSelectedRows"> Ta bort markerade rader </f-button>
-    <f-button data-test="change-dataset" variant="secondary" @click="onChangeDataset">Ändra dataset</f-button>
+    <f-button size="medium" variant="secondary" @click="onAddRow">Lägg till rad</f-button>
+    <f-button size="medium" variant="secondary" @click="onRemoveSelectedRows"> Ta bort markerade rader </f-button>
+    <f-button data-test="change-dataset" size="medium" variant="secondary" @click="onChangeDataset">
+        Ändra dataset
+    </f-button>
     <f-sort-filter-dataset v-test="'filter'" :data="rows" :sortable-attributes>
         <template #default="{ sortFilterResult }">
             <f-table

--- a/packages/vue/src/components/FTable/tests/FTableSortFilterPaginationExample.vue
+++ b/packages/vue/src/components/FTable/tests/FTableSortFilterPaginationExample.vue
@@ -115,9 +115,11 @@ function onChangeDataset(): void {
 
     <p data-test="selected-count">Valda rader: {{ selectedRows.length }}</p>
 
-    <f-button data-test="add-row" variant="secondary" @click="onAddRow">Lägg till rad</f-button>
-    <f-button variant="secondary" @click="onRemoveSelectedRows"> Ta bort markerade rader </f-button>
-    <f-button data-test="change-dataset" variant="secondary" @click="onChangeDataset">Ändra dataset</f-button>
+    <f-button data-test="add-row" size="medium" variant="secondary" @click="onAddRow">Lägg till rad</f-button>
+    <f-button size="medium" variant="secondary" @click="onRemoveSelectedRows"> Ta bort markerade rader </f-button>
+    <f-button data-test="change-dataset" size="medium" variant="secondary" @click="onChangeDataset">
+        Ändra dataset
+    </f-button>
 
     <f-sort-filter-dataset
         ref="sortFilter"

--- a/packages/vue/src/components/FValidationForm/examples/FValidationFormDefault.vue
+++ b/packages/vue/src/components/FValidationForm/examples/FValidationFormDefault.vue
@@ -73,7 +73,9 @@ export default defineComponent({
             </f-fieldset>
 
             <div class="button-group">
-                <f-button class="button-group__item" size="large" type="submit">Spara</f-button>
+                <f-button class="button-group__item" size="large" variant="primary" type="submit">
+                    Spara
+                </f-button>
                 <f-button
                     class="button-group__item"
                     size="large"

--- a/packages/vue/src/components/FValidationForm/examples/FValidationFormServerError.vue
+++ b/packages/vue/src/components/FValidationForm/examples/FValidationFormServerError.vue
@@ -54,7 +54,9 @@ export default defineComponent({
                 Ett annat inmatningsfält
             </f-text-field>
             <div class="button-group">
-                <f-button class="button-group__item" size="large" type="submit"> Spara </f-button>
+                <f-button class="button-group__item" size="large" variant="primary" type="submit">
+                    Spara
+                </f-button>
                 <f-button
                     class="button-group__item"
                     size="large"

--- a/packages/vue/src/components/FValidationForm/examples/NoErrorList.vue
+++ b/packages/vue/src/components/FValidationForm/examples/NoErrorList.vue
@@ -45,6 +45,7 @@ export default defineComponent({
                     class="button-group__item"
                     data-test="submit-button"
                     size="large"
+                    variant="primary"
                     type="submit"
                 >
                     Spara

--- a/packages/vue/src/components/FValidationForm/examples/WithErrorList.vue
+++ b/packages/vue/src/components/FValidationForm/examples/WithErrorList.vue
@@ -45,6 +45,7 @@ export default defineComponent({
                     class="button-group__item"
                     data-test="submit-button"
                     size="large"
+                    variant="primary"
                     type="submit"
                 >
                     Spara

--- a/packages/vue/src/components/FValidationForm/examples/WithErrorListAndCbFunction.vue
+++ b/packages/vue/src/components/FValidationForm/examples/WithErrorListAndCbFunction.vue
@@ -57,6 +57,7 @@ export default defineComponent({
                     class="button-group__item"
                     data-test="submit-button"
                     size="large"
+                    variant="primary"
                     type="submit"
                 >
                     Spara

--- a/packages/vue/src/components/FValidationGroup/examples/OptimizationExample.vue
+++ b/packages/vue/src/components/FValidationGroup/examples/OptimizationExample.vue
@@ -71,7 +71,9 @@ export default defineComponent({
             </div>
         </f-validation-group>
 
-        <f-button :disabled="!favoritGrupp.isValid"> Lägg till något nytt </f-button>
+        <f-button size="medium" variant="primary" :disabled="!favoritGrupp.isValid">
+            Lägg till något nytt
+        </f-button>
 
         <p>isValid:</p>
         <pre data-test="favorit-grupp-is-valid">{{ favoritGrupp.isValid }}</pre>

--- a/packages/vue/src/components/FWizard/examples/FWizardExampleAddStep.vue
+++ b/packages/vue/src/components/FWizard/examples/FWizardExampleAddStep.vue
@@ -73,7 +73,7 @@ export default defineComponent({
         >
             <f-wizard-step key="fruktkorg-antal" v-test="'myOrderStep'" title="Min beställning">
                 <h3>Fruktkorg</h3>
-                <f-button icon-left="plus" variant="tertiary" @click="addBasket">
+                <f-button icon-left="plus" size="medium" variant="tertiary" @click="addBasket">
                     Lägg till fruktkorg
                 </f-button>
             </f-wizard-step>
@@ -104,7 +104,12 @@ export default defineComponent({
                     </f-checkbox-field>
                 </f-fieldset>
 
-                <f-button icon-left="trashcan" variant="tertiary" @click="removeBasket(item)">
+                <f-button
+                    icon-left="trashcan"
+                    size="medium"
+                    variant="tertiary"
+                    @click="removeBasket(item)"
+                >
                     Ta bort fruktkorg
                 </f-button>
             </f-wizard-step>
@@ -122,7 +127,9 @@ export default defineComponent({
         <!-- [html-validate-disable-next no-inline-style] -->
         <p style="margin-top: 30px">
             Ett steg kan öppnas programatiskt, t.ex. man klickar 'ändra' i ett granska-steg.
-            <f-button @click="current = 'baz'">Öppna sista steget</f-button>
+            <f-button size="medium" variant="primary" @click="current = 'baz'">
+                Öppna sista steget
+            </f-button>
         </p>
         <pre>v-model: {{ current }}</pre>
     </div>

--- a/packages/vue/src/design-component-tests/Button/examples/ButtonButtonGroupFullWidthExample.vue
+++ b/packages/vue/src/design-component-tests/Button/examples/ButtonButtonGroupFullWidthExample.vue
@@ -19,7 +19,12 @@ export default defineComponent({
     <div style="background-color: beige; padding: 20px">
         <!-- [html-validate-disable-next no-inline-style] -->
         <div class="button-group" style="border: 1px black dotted">
-            <f-button class="button-group__item" :mobile-full-width="useFullWidth" size="small">
+            <f-button
+                class="button-group__item"
+                :mobile-full-width="useFullWidth"
+                size="small"
+                variant="primary"
+            >
                 Primary
             </f-button>
             <f-button
@@ -42,12 +47,18 @@ export default defineComponent({
         </div>
         <!-- [html-validate-disable-next no-inline-style] -->
         <div class="button-group" style="border: 1px black dotted">
-            <f-button class="button-group__item" :mobile-full-width="useFullWidth">
+            <f-button
+                class="button-group__item"
+                :mobile-full-width="useFullWidth"
+                size="medium"
+                variant="primary"
+            >
                 Primary
             </f-button>
             <f-button
                 class="button-group__item"
                 :mobile-full-width="useFullWidth"
+                size="medium"
                 variant="secondary"
             >
                 Secondary
@@ -56,6 +67,7 @@ export default defineComponent({
                 class="button-group__item"
                 icon-left="paper-clip"
                 :mobile-full-width="useFullWidth"
+                size="medium"
                 variant="tertiary"
             >
                 Tertiary
@@ -63,7 +75,12 @@ export default defineComponent({
         </div>
         <!-- [html-validate-disable-next no-inline-style] -->
         <div class="button-group" style="border: 1px black dotted">
-            <f-button class="button-group__item" :mobile-full-width="useFullWidth" size="large">
+            <f-button
+                class="button-group__item"
+                :mobile-full-width="useFullWidth"
+                size="large"
+                variant="primary"
+            >
                 Primary
             </f-button>
             <f-button
@@ -86,12 +103,18 @@ export default defineComponent({
         </div>
         <!-- [html-validate-disable-next no-inline-style] -->
         <div class="button-group" style="border: 1px black dotted">
-            <f-button class="button-group__item" :mobile-full-width="useFullWidth">
+            <f-button
+                class="button-group__item"
+                :mobile-full-width="useFullWidth"
+                size="medium"
+                variant="primary"
+            >
                 Primary
             </f-button>
             <f-button
                 class="button-group__item"
                 :mobile-full-width="useFullWidth"
+                size="medium"
                 variant="secondary"
             >
                 Secondary
@@ -100,6 +123,7 @@ export default defineComponent({
                 class="button-group__item"
                 icon-left="paper-clip"
                 :mobile-full-width="useFullWidth"
+                size="medium"
                 variant="tertiary"
             >
                 Tertiary
@@ -107,6 +131,7 @@ export default defineComponent({
             <f-button
                 class="button-group__item"
                 :mobile-full-width="useFullWidth"
+                size="medium"
                 variant="tertiary"
             >
                 Discrete
@@ -114,6 +139,7 @@ export default defineComponent({
             <f-button
                 class="button-group__item"
                 :mobile-full-width="useFullWidth"
+                size="medium"
                 tertiary-style="inverted"
                 variant="tertiary"
             >
@@ -122,6 +148,7 @@ export default defineComponent({
             <f-button
                 class="button-group__item"
                 :mobile-full-width="useFullWidth"
+                size="medium"
                 variant="secondary"
             >
                 Standard

--- a/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandRecommended.vue
+++ b/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandRecommended.vue
@@ -36,7 +36,9 @@ export default defineComponent({
 
 <template>
     <div>
-        <f-button @click="isExpanded = !isExpanded">Öppna/stäng animering</f-button>
+        <f-button size="medium" variant="primary" @click="isExpanded = !isExpanded">
+            Öppna/stäng animering
+        </f-button>
         <label><input v-model="isAnimated" type="checkbox" /> Animera</label>
         <label><input v-model="hasOpacity" type="checkbox" /> Opacitet</label>
         <label><input v-model="useVShow" type="checkbox" /> Use v-show instead of v-if</label>

--- a/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandTestComponent.vue
+++ b/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandTestComponent.vue
@@ -17,7 +17,9 @@ export default defineComponent({
 
 <template>
     <div>
-        <f-button @click="isExpanded = !isExpanded">Öppna/stäng animering</f-button>
+        <f-button size="medium" variant="primary" @click="isExpanded = !isExpanded">
+            Öppna/stäng animering
+        </f-button>
         <i-animate-expand :expanded="isExpanded" opacity>
             <!-- [html-validate-disable-next no-inline-style] -->
             <div :style></div>

--- a/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandToggleTwo.vue
+++ b/packages/vue/src/internal-components/IAnimateExpand/examples/IAnimateExpandToggleTwo.vue
@@ -17,7 +17,7 @@ export default defineComponent({
 
 <template>
     <div>
-        <f-button @click="toggle = !toggle">Toggle</f-button>
+        <f-button size="medium" variant="primary" @click="toggle = !toggle">Toggle</f-button>
         <label><input v-model="opacity" type="checkbox" /> Toning</label>
 
         <i-animate-expand :opacity :expanded="toggle">

--- a/packages/vue/src/internal-components/IPopup/examples/IPopupExample.vue
+++ b/packages/vue/src/internal-components/IPopup/examples/IPopupExample.vue
@@ -27,7 +27,7 @@ export default defineComponent({
 
 <template>
     <div>
-        <f-button ref="popupAnchor" variant="secondary" @click="onClickOpen">
+        <f-button ref="popupAnchor" size="medium" variant="secondary" @click="onClickOpen">
             Öppna popup
         </f-button>
 
@@ -40,7 +40,9 @@ export default defineComponent({
                     formbräden och regaler tillverkas och försäljas Kaster som äro dåligt hopkomna
                     och af otillräckligt.
                 </p>
-                <f-button variant="tertiary" @click="onClickClose">Stäng popup</f-button>
+                <f-button size="medium" variant="tertiary" @click="onClickClose">
+                    Stäng popup
+                </f-button>
             </div>
         </i-popup>
     </div>

--- a/packages/vue/src/internal-components/IPopupError/examples/IPopupErrorExample.vue
+++ b/packages/vue/src/internal-components/IPopupError/examples/IPopupErrorExample.vue
@@ -2,6 +2,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import {
+    FButton,
     FEmailTextField,
     FInteractiveTable,
     FPostalCodeTextField,
@@ -12,6 +13,7 @@ import {
 export default defineComponent({
     name: "TestApp",
     components: {
+        FButton,
         FInteractiveTable,
         FTableColumn,
         FValidationForm,
@@ -62,6 +64,6 @@ export default defineComponent({
                 </f-table-column>
             </template>
         </f-interactive-table>
-        <button class="button button--primary" type="submit">Submit</button>
+        <f-button size="large" variant="primary" type="submit">Submit</f-button>
     </f-validation-form>
 </template>

--- a/packages/vue/src/internal-components/IPopupMenu/examples/IPopupMenuExample.vue
+++ b/packages/vue/src/internal-components/IPopupMenu/examples/IPopupMenuExample.vue
@@ -78,6 +78,7 @@ export default defineComponent({
         <f-button
             id="popup-menu-open-button"
             ref="popup-anchor"
+            size="medium"
             variant="secondary"
             @click="onClick"
             @keyup="onKeyUp"

--- a/packages/vue/src/plugins/error/examples/ErrorPluginExample.vue
+++ b/packages/vue/src/plugins/error/examples/ErrorPluginExample.vue
@@ -28,10 +28,20 @@ export default defineComponent({
 
 <template>
     <div>
-        <f-button v-test="'generate-error'" variant="secondary" @click="generateError()">
+        <f-button
+            v-test="'generate-error'"
+            size="medium"
+            variant="secondary"
+            @click="generateError()"
+        >
             Fel
         </f-button>
-        <f-button v-test="'generate-warning'" variant="secondary" @click="generateWarning()">
+        <f-button
+            v-test="'generate-warning'"
+            size="medium"
+            variant="secondary"
+            @click="generateWarning()"
+        >
             Varning
         </f-button>
     </div>

--- a/packages/vue/src/plugins/test/examples/TestPluginHidden.vue
+++ b/packages/vue/src/plugins/test/examples/TestPluginHidden.vue
@@ -22,7 +22,7 @@ export default defineComponent({
             Barnets namn
         </f-text-field>
 
-        <f-button @click="isVisible = !isVisible">
+        <f-button size="medium" variant="primary" @click="isVisible = !isVisible">
             {{ isVisible ? "Göm inmatningsfält" : "Visa inmatningsfält" }}
         </f-button>
     </div>

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginDynamicValidation.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginDynamicValidation.vue
@@ -64,6 +64,6 @@ export default defineComponent({
             </div>
         </div>
 
-        <f-button type="submit">Signera</f-button>
+        <f-button type="submit" size="medium" variant="primary">Signera</f-button>
     </f-validation-form>
 </template>

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginFormValidation.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginFormValidation.vue
@@ -37,6 +37,6 @@ export default defineComponent({
             </f-text-field>
         </div>
 
-        <f-button type="submit">Trigga fel</f-button>
+        <f-button type="submit" size="medium" variant="primary">Trigga fel</f-button>
     </f-validation-form>
 </template>

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginRevalidate.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginRevalidate.vue
@@ -22,5 +22,7 @@ export default defineComponent({
 </script>
 
 <template>
-    <f-button @click="validateAllFieldsOnPage()"> Validera alla fält på sidan </f-button>
+    <f-button size="medium" variant="primary" @click="validateAllFieldsOnPage()">
+        Validera alla fält på sidan
+    </f-button>
 </template>

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginRevalidateList.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginRevalidateList.vue
@@ -25,7 +25,11 @@ function onReplaceList(): void {
             </template>
         </f-text-field>
 
-        <f-button id="add-item" @click="onAddItem">Add item</f-button>
-        <f-button id="replace-list" @click="onReplaceList">Replace list</f-button>
+        <f-button id="add-item" size="medium" variant="primary" @click="onAddItem">
+            Add item
+        </f-button>
+        <f-button id="replace-list" size="medium" variant="primary" @click="onReplaceList">
+            Replace list
+        </f-button>
     </div>
 </template>

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginToggleEnabled.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginToggleEnabled.vue
@@ -28,7 +28,12 @@ export default defineComponent({
         >
             Max tio tecken
         </f-text-field>
-        <f-button data-test="validator-enabled-button" @click="toggleEnabled = !toggleEnabled">
+        <f-button
+            data-test="validator-enabled-button"
+            size="medium"
+            variant="primary"
+            @click="toggleEnabled = !toggleEnabled"
+        >
             Aktivera/Inaktivera
         </f-button>
     </div>

--- a/packages/vue/src/plugins/validation/examples/ValidationPluginValidateAll.vue
+++ b/packages/vue/src/plugins/validation/examples/ValidationPluginValidateAll.vue
@@ -22,5 +22,7 @@ export default defineComponent({
 </script>
 
 <template>
-    <f-button @click="validateAllFieldsOnPage()"> Validera alla fält på sidan </f-button>
+    <f-button size="medium" variant="primary" @click="validateAllFieldsOnPage()">
+        Validera alla fält på sidan
+    </f-button>
 </template>

--- a/packages/vue/src/utils/mount-component/examples/MyAwesomeComponent.vue
+++ b/packages/vue/src/utils/mount-component/examples/MyAwesomeComponent.vue
@@ -24,6 +24,6 @@ export default defineComponent({
 <template>
     <div>
         <p>Hej {{ name }}!</p>
-        <f-button size="small" @click="onClick"> Svara </f-button>
+        <f-button size="small" variant="primary" @click="onClick"> Svara </f-button>
     </div>
 </template>


### PR DESCRIPTION
Håller på att se över vad som är kvar för `.button` till `f-button` migreringen.

Migrerar här ett par kvarvarande exempel till `f-button`.
~Finns också önskemål att sätta `size` och `variant` explicit så la till dessa till alla `f-button` som saknade det. Ändringarna ska inte påverka nåt visuellt.~ Edit: Ändrat för att göra `size` och `variant` obligatoriska istället efter vidare diskussion.

Finns härefter bara ett par knappar kvar i komponenter att utvärdera om det går att migrera.