### PR TITLE
refactor: cannot import before project is built (refs SFKUI-6500)

### DIFF
--- a/packages/test-utils/src/matchers/to-have-focus.vitest.spec.ts
+++ b/packages/test-utils/src/matchers/to-have-focus.vitest.spec.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import "@fkui/test-utils/vitest";
+import { toHaveFocus } from "./to-have-focus";
+
+expect.extend({
+    toHaveFocus,
+});
 
 describe("toHaveFocus (vitest)", () => {
     let element: HTMLElement;


### PR DESCRIPTION
Inför framtida fel: vi kan inte importera `@fkui/test-utils/vitest` om inte projektet är byggt. Gör på samma sätt som testet för jest fungerar: vi importerar funktionen direkt och anropar `expect.extend()`.