### PR TITLE
ci: pin tags instead of branches (refs SFKUI-6500)

### DIFF
--- a/.github/workflows/artifact-size.yml
+++ b/.github/workflows/artifact-size.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Build
               run: npm run build
             - name: Run analyzer
-              uses: ext/artifact-size-analyzer/analyze@ef6b5b7db48682b36b735629a378ae4645c19746 # v1
+              uses: ext/artifact-size-analyzer/analyze@ef6b5b7db48682b36b735629a378ae4645c19746 # v1.2.4
               with:
                   config-file: .github/artifact-size.json
                   artifact-name: base-size
@@ -47,7 +47,7 @@ jobs:
             - name: Build
               run: npm run build
             - name: Run analyzer (current)
-              uses: ext/artifact-size-analyzer/analyze@ef6b5b7db48682b36b735629a378ae4645c19746 # v1
+              uses: ext/artifact-size-analyzer/analyze@ef6b5b7db48682b36b735629a378ae4645c19746 # v1.2.4
               with:
                   config-file: .github/artifact-size.json
                   artifact-name: current-size
@@ -70,7 +70,7 @@ jobs:
               run: npm ci
             - name: Compare results
               id: compare
-              uses: ext/artifact-size-analyzer/compare@e6ea4695468f796425ace714a345ab717bfd1b70 # main
+              uses: ext/artifact-size-analyzer/compare@ef6b5b7db48682b36b735629a378ae4645c19746 # v1.2.4
               with:
                   base-artifact: base-size
                   current-artifact: current-size

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
             - name: Install Dependencies
               run: npm ci
             - name: npm-pkg-lint
-              uses: ext/npm-pkg-lint@b7f53dadcdde76d39ccf425daf9fb6a7db374b70 # master
+              uses: ext/npm-pkg-lint@84d8e69371164f32be0f5485693d354361de65d5 # v5.1.7
               with:
                   folders: packages/*
                   allow-dependencies: fk-icons


### PR DESCRIPTION
Brancherna rör på sig ganska mycket, nästan dagligen, utan att något egentligen förändras. Blir lite onödigt mycket jobb för renovate till ingen nytta.

Nu hämtas taggarna kopplade till releaser istället.