### PR TITLE
build(deps): explicitly set allow-scripts (refs SFKUI-6500)

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,5 +135,16 @@
   "engines": {
     "node": "^22.16 || >= 24",
     "npm": ">= 7"
+  },
+  "allowScripts": {
+    "@forsakringskassan/commitlint-config": true,
+    "@parcel/watcher": false,
+    "core-js": false,
+    "cypress": true,
+    "esbuild": true,
+    "fsevents": false,
+    "nx": false,
+    "simple-git-hooks": true,
+    "unrs-resolver": true
   }
 }


### PR DESCRIPTION
NPM är på väg att införa att install scripts inte längre tillåts by default. Just nu om man har en purfärsk npm så får man varningar om att scripten inte är tillåtna och om man hatar sig själv så man kan slå på `strict-allow-scripts`, då slutar typ alla repon.

Flera sätts till `false` för att explicit inte tillåta dem:

*  `@parcel/watcher`: postinstall behövs för att det ska fungera men vi använder inte detta (beroende från `sass`)
* `core-js`: reklam
* `fsevents`: oklart, det verkar vara kopplat till osx, kanske behövs? någon med osx kanske kommer skrika att det inte längre fungerar.
* `nx`: vill verifiera credentials till cloudtjänst, det använder vi inte så ser inte poäng med att köra scriptet

De andra tillåts explicit:

* `@forsakringskassan/commitlint-config` och `simple-git-hooks`: här jobbar @OlofFredriksson med att få bort postinstall men tills det är klart behöver det tillåtas annars installeras inte commitlint som det ska
* `cypress`: skulle gå att installera från prepare med `cypress install` (men gissar att man då själv måste hålla koll på CI miljövariabler osv)
* `esbuild` och `unrs-resolver`: drar in bin-paket, är lite läskigt men verkar behövas.
