### PR TITLE
refactor: fix example imports (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FButton/examples/FButtonListExample.vue
+++ b/packages/vue/src/components/FButton/examples/FButtonListExample.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import FButton from "../FButton.vue";
+import { FButton } from "@fkui/vue";
 </script>
 
 <template>

--- a/packages/vue/src/components/FCalendar/examples/FCalendarLiveExample.vue
+++ b/packages/vue/src/components/FCalendar/examples/FCalendarLiveExample.vue
@@ -3,8 +3,7 @@
 import { defineComponent } from "vue";
 import { FDate } from "@fkui/date";
 import { LiveExample } from "@forsakringskassan/docs-live-example";
-import FCheckboxField from "../../FCheckboxField/FCheckboxField.vue";
-import { FCalendar, FCalendarDay } from "@fkui/vue";
+import { FCalendar, FCalendarDay, FCheckboxField } from "@fkui/vue";
 
 export default defineComponent({
     name: "FCalendarLiveExample",

--- a/packages/vue/src/components/FCalendar/examples/ICalendarNavbarExample.vue
+++ b/packages/vue/src/components/FCalendar/examples/ICalendarNavbarExample.vue
@@ -2,7 +2,7 @@
 <script lang="ts">
 import { defineComponent, shallowRef } from "vue";
 import { FDate } from "@fkui/date";
-import { ICalendarNavbar } from "../../../internal-components";
+import { ICalendarNavbar } from "@fkui/vue";
 
 export default defineComponent({
     components: {

--- a/packages/vue/src/components/FModal/examples/ExampleModal.vue
+++ b/packages/vue/src/components/FModal/examples/ExampleModal.vue
@@ -1,10 +1,11 @@
 <!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
-import type { FModalSize, modalSizes } from "../sizes";
 import {
     type FModalButtonDescriptor,
+    type FModalSize,
     type FValidationFormCallback,
+    type modalSizes,
     FFormModal,
     FTextField,
 } from "@fkui/vue";

--- a/packages/vue/src/components/FNavigationMenu/examples/router.ts
+++ b/packages/vue/src/components/FNavigationMenu/examples/router.ts
@@ -1,4 +1,4 @@
-import { type NavigationMenuItem } from "../navigation-menu-item";
+import { type NavigationMenuItem } from "@fkui/vue";
 
 function generateExampleLabelsAndRoutes(
     nbRoutes: number,

--- a/packages/vue/src/components/FResizePane/examples/FResizePaneLiveExample.vue
+++ b/packages/vue/src/components/FResizePane/examples/FResizePaneLiveExample.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { computed, defineComponent, ref } from "vue";
 import { LiveExample } from "@forsakringskassan/docs-live-example";
-import { type LayoutAreaAttachPanel } from "../../FPageLayout";
 import {
+    type LayoutAreaAttachPanel,
     FCheckboxField,
     FFieldset,
     FPageLayout,

--- a/packages/vue/src/components/FWizard/examples/FWizardTestComponent.vue
+++ b/packages/vue/src/components/FWizard/examples/FWizardTestComponent.vue
@@ -1,8 +1,13 @@
 <!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { type PropType, defineComponent } from "vue";
-import { FWizard, FWizardStep } from "..";
-import { type FValidationFormCallback, FCheckboxField, FFieldset } from "../..";
+import {
+    type FValidationFormCallback,
+    FCheckboxField,
+    FFieldset,
+    FWizard,
+    FWizardStep,
+} from "@fkui/vue";
 
 export default defineComponent({
     components: { FWizard, FWizardStep, FFieldset, FCheckboxField },

--- a/packages/vue/src/internal-components/IPopupMenu/examples/IPopupMenuExample.vue
+++ b/packages/vue/src/internal-components/IPopupMenu/examples/IPopupMenuExample.vue
@@ -1,8 +1,7 @@
 <!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
-import { IPopupMenu } from "..";
-import { FButton } from "@fkui/vue";
+import { FButton, IPopupMenu } from "@fkui/vue";
 
 const exampleItems = [
     { label: "Länk 1", key: "MENU_1" },


### PR DESCRIPTION
Krävs för att kunna paketera exempel för inkludering i andra siter. (Annars går det inte bygga dem, filerna som de refererar till inkluderas inte i paketeringen).

Plus att vi inte ska ha såna importer ändå, konsumenterna kan inte heller importera dem. Så copy-paste fungerar inte för dem.