### PR TITLE
docs: fix IPopup and IPopupMenue examples (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/internal-components/IPopup/examples/IPopupExample.vue
+++ b/packages/vue/src/internal-components/IPopup/examples/IPopupExample.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
-import { FButton, IPopup } from "@fkui/vue";
+import { FButton, IPopup, findHTMLElementFromVueRef } from "@fkui/vue";
 
 export default defineComponent({
     name: "IPopupExample",
@@ -21,6 +21,9 @@ export default defineComponent({
         onClose() {
             this.isOpen = false;
         },
+        anchor(): HTMLElement | undefined {
+            return findHTMLElementFromVueRef(this.$refs.popupAnchor);
+        },
     },
 });
 </script>
@@ -31,7 +34,7 @@ export default defineComponent({
             Öppna popup
         </f-button>
 
-        <i-popup :is-open :anchor="$refs.popupAnchor as HTMLElement" @close="onClose">
+        <i-popup :is-open :anchor="anchor()" @close="onClose">
             <div class="my-awesome-popup">
                 <p>
                     Träutensilierna i ett tryckeri äro ingalunda en oviktig faktor, för trevnadens,

--- a/packages/vue/src/internal-components/IPopupMenu/examples/IPopupMenuExample.vue
+++ b/packages/vue/src/internal-components/IPopupMenu/examples/IPopupMenuExample.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
-import { FButton, IPopupMenu } from "@fkui/vue";
+import { FButton, IPopupMenu, findHTMLElementFromVueRef } from "@fkui/vue";
 
 const exampleItems = [
     { label: "Länk 1", key: "MENU_1" },
@@ -33,8 +33,8 @@ export default defineComponent({
         };
     },
     methods: {
-        getAnchor(): HTMLElement {
-            return this.$refs["popup-anchor"] as HTMLElement;
+        anchor(): HTMLElement | undefined {
+            return findHTMLElementFromVueRef(this.$refs["popup-anchor"]);
         },
         onClose(): void {
             this.popupOpen = false;
@@ -93,7 +93,7 @@ export default defineComponent({
             v-model:focused-item="focusedItem"
             :items
             :is-open="popupOpen"
-            :anchor="getAnchor()"
+            :anchor="anchor()"
             enable-keyboard-navigation
             @close="onClose"
         ></i-popup-menu>


### PR DESCRIPTION
Fixar så att exemplen inte kraschar när man klickar på knappen för att öppna


Såg att knappen i popup också ser felaktig ut (nu när man kan öppna den).
Det får lösas i egen PR.
<img width="522" height="460" alt="image" src="https://github.com/user-attachments/assets/734c04af-b4fb-4f7d-9e11-8e11e69f9fb9" />
