### PR TITLE
feat: add selector objects (part 2)

### DIFF
--- a/etc/vue-cypress.api.md
+++ b/etc/vue-cypress.api.md
@@ -103,7 +103,7 @@ class FCheckboxFieldPageObject implements BasePageObject {
     // (undocumented)
     details(): DefaultCypressChainable;
     // (undocumented)
-    el: () => DefaultCypressChainable;
+    el(): DefaultCypressChainable;
     // (undocumented)
     isSelected(): Cypress.Chainable<boolean>;
     // (undocumented)
@@ -111,7 +111,7 @@ class FCheckboxFieldPageObject implements BasePageObject {
     // (undocumented)
     select(): DefaultCypressChainable;
     // (undocumented)
-    selector: string;
+    get selector(): string;
     // (undocumented)
     value(): Cypress.Chainable<string>;
 }

--- a/etc/vue-selectors.api.md
+++ b/etc/vue-selectors.api.md
@@ -15,6 +15,14 @@ export function FButtonSelectors(selector?: string): Readonly<{
 }>;
 
 // @public
+export function FCheckboxFieldSelectors(selector?: string): Readonly<{
+    readonly selector: string;
+    checkbox(): string;
+    label(): string;
+    details(): string;
+}>;
+
+// @public
 export function FCrudDatasetSelectors(selector?: string): Readonly<{
     readonly selector: string;
     addButton(): string;

--- a/packages/vue/src/cypress/FCheckboxField.pageobject.ts
+++ b/packages/vue/src/cypress/FCheckboxField.pageobject.ts
@@ -1,11 +1,11 @@
+import { FCheckboxFieldSelectors } from "../selectors";
 import { type BasePageObject, type DefaultCypressChainable } from "./common";
 
 /**
  * @public
  */
 export class FCheckboxFieldPageObject implements BasePageObject {
-    public selector: string;
-    public el: () => DefaultCypressChainable;
+    private _selectors: ReturnType<typeof FCheckboxFieldSelectors>;
 
     /**
      * @param selector - the root of the checkbox, usually `<div class="checkbox">...</div>`.
@@ -13,20 +13,28 @@ export class FCheckboxFieldPageObject implements BasePageObject {
      */
     public constructor(selector: string, index?: number) {
         if (index) {
-            this.selector = `${selector}:nth(${String(index)})`;
+            this._selectors = FCheckboxFieldSelectors(
+                `${selector}:nth(${String(index)})`,
+            );
         } else {
-            this.selector = selector;
+            this._selectors = FCheckboxFieldSelectors(selector);
         }
+    }
 
-        this.el = () => cy.get(this.selector);
+    public get selector(): string {
+        return this._selectors.selector;
+    }
+
+    public el(): DefaultCypressChainable {
+        return cy.get(this._selectors.selector);
     }
 
     public checkbox(): Cypress.Chainable<JQuery<HTMLInputElement>> {
-        return cy.get(`${this.selector} input`);
+        return cy.get(this._selectors.checkbox());
     }
 
     public label(): DefaultCypressChainable {
-        return cy.get(`${this.selector} .checkbox__label`);
+        return cy.get(this._selectors.label());
     }
 
     public select(): DefaultCypressChainable {
@@ -46,6 +54,6 @@ export class FCheckboxFieldPageObject implements BasePageObject {
     }
 
     public details(): DefaultCypressChainable {
-        return cy.get(`${this.selector} .checkbox__details`);
+        return cy.get(this._selectors.details());
     }
 }

--- a/packages/vue/src/selectors/FCheckboxField.selectors.spec.ts
+++ b/packages/vue/src/selectors/FCheckboxField.selectors.spec.ts
@@ -1,0 +1,93 @@
+import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
+import { mount } from "@vue/test-utils";
+import { expect, it } from "vitest";
+import { FCheckboxField } from "../components";
+import { injectionKeys as fieldsetInjectionKeys } from "../components/FFieldset/use-fieldset";
+import { FCheckboxFieldSelectors } from "./FCheckboxField.selectors";
+
+const defaultMountOptions = {
+    attachTo: createPlaceholderInDocument(),
+    global: {
+        provide: {
+            [fieldsetInjectionKeys.sharedName as symbol]: "my-group",
+        },
+    },
+};
+
+it("should use default selector when no selector was given", () => {
+    expect.assertions(2);
+    const wrapper = mount(FCheckboxField, {
+        ...defaultMountOptions,
+        props: { value: "agree" },
+        slots: { default: "I agree" },
+    });
+    const { selector } = FCheckboxFieldSelectors();
+    const root = wrapper.get(selector);
+    expect(selector).toBe(".checkbox");
+    expect(root.classes()).toContain("checkbox");
+});
+
+it("should use explicit selector when custom selector was given", () => {
+    expect.assertions(2);
+    const wrapper = mount(FCheckboxField, {
+        ...defaultMountOptions,
+        props: { value: "agree" },
+        slots: { default: "I agree" },
+        attrs: { "data-test": "agree" },
+    });
+    const { selector } = FCheckboxFieldSelectors('[data-test="agree"]');
+    expect(selector).toBe('[data-test="agree"]');
+    expect(wrapper.find(selector).exists()).toBeTruthy();
+});
+
+it("input() should return the checkbox input element", () => {
+    expect.assertions(2);
+    const wrapper = mount(FCheckboxField, {
+        ...defaultMountOptions,
+        props: { value: "agree" },
+        slots: { default: "I agree" },
+    });
+    const { checkbox } = FCheckboxFieldSelectors();
+    const el = wrapper.get(checkbox());
+    expect(el.element.tagName.toLowerCase()).toBe("input");
+    expect((el.element as HTMLInputElement).type).toBe("checkbox");
+});
+
+it("label() should return the label element", () => {
+    expect.assertions(1);
+    const wrapper = mount(FCheckboxField, {
+        ...defaultMountOptions,
+        props: { value: "agree" },
+        slots: { default: "I agree" },
+    });
+    const { label } = FCheckboxFieldSelectors();
+    expect(wrapper.get(label()).text()).toContain("I agree");
+});
+
+it("details() should exist when details slot is used with showDetails always", () => {
+    expect.assertions(1);
+    const wrapper = mount(FCheckboxField, {
+        ...defaultMountOptions,
+        global: {
+            provide: {
+                [fieldsetInjectionKeys.sharedName as symbol]: "my-group",
+                [fieldsetInjectionKeys.showDetails as symbol]: "always",
+            },
+        },
+        props: { value: "agree" },
+        slots: { default: "I agree", details: "Extra info" },
+    });
+    const { details } = FCheckboxFieldSelectors();
+    expect(wrapper.find(details()).exists()).toBeTruthy();
+});
+
+it("details() should not exist when details slot is not used", () => {
+    expect.assertions(1);
+    const wrapper = mount(FCheckboxField, {
+        ...defaultMountOptions,
+        props: { value: "agree" },
+        slots: { default: "I agree" },
+    });
+    const { details } = FCheckboxFieldSelectors();
+    expect(wrapper.find(details()).exists()).toBeFalsy();
+});

--- a/packages/vue/src/selectors/FCheckboxField.selectors.spec.ts
+++ b/packages/vue/src/selectors/FCheckboxField.selectors.spec.ts
@@ -23,7 +23,7 @@ it("should use default selector when no selector was given", () => {
     });
     const { selector } = FCheckboxFieldSelectors();
     const root = wrapper.get(selector);
-    expect(selector).toBe(".checkbox");
+    expect(selector).toBe(":scope");
     expect(root.classes()).toContain("checkbox");
 });
 

--- a/packages/vue/src/selectors/FCheckboxField.selectors.ts
+++ b/packages/vue/src/selectors/FCheckboxField.selectors.ts
@@ -1,0 +1,113 @@
+/**
+ * Selectors for `FCheckboxField`.
+ *
+ * @public
+ * @since %version%
+ * @param selector - The selector for the FCheckboxField component.
+ * @returns An object with selector methods for the FCheckboxField component.
+ */
+export function FCheckboxFieldSelectors(selector: string = ".checkbox") {
+    return Object.freeze({
+        /**
+         * The base selector for the component.
+         *
+         * This is the same selector that the consumer provided.
+         *
+         * @public
+         * @since %version%
+         * @returns The root selector for the component.
+         */
+        get selector(): string {
+            return selector;
+        },
+
+        /**
+         * Get the checkbox input element.
+         *
+         * Use this to assert the checked state or value. To check or uncheck
+         * the checkbox programmatically, click `label()` instead.
+         *
+         * @example Cypress
+         *
+         * ```ts
+         * const { checkbox } = FCheckboxFieldSelectors();
+         * cy.get(checkbox()).should("be.checked");
+         * cy.get(checkbox()).should("have.value", "my-value");
+         * ```
+         *
+         * @example Playwright
+         *
+         * ```ts
+         * const { checkbox } = FCheckboxFieldSelectors();
+         * await expect(page.locator(checkbox())).toBeChecked();
+         * await expect(page.locator(checkbox())).toHaveValue("my-value");
+         * ```
+         *
+         * @public
+         * @since %version%
+         * @returns A selector for the checkbox input element.
+         */
+        checkbox(): string {
+            return `${selector} .checkbox__input`;
+        },
+
+        /**
+         * Get the label element.
+         *
+         * Clicking the label checks or unchecks the checkbox.
+         *
+         * @example Cypress
+         *
+         * ```ts
+         * const { label } = FCheckboxFieldSelectors();
+         * cy.get(label()).should("contain.text", "Accept terms");
+         * // Check the checkbox:
+         * cy.get(label()).click();
+         * ```
+         *
+         * @example Playwright
+         *
+         * ```ts
+         * const { label } = FCheckboxFieldSelectors();
+         * await expect(page.locator(label())).toContainText("Accept terms");
+         * // Check the checkbox:
+         * await page.locator(label()).click();
+         * ```
+         *
+         * @public
+         * @since %version%
+         * @returns A selector for the label element.
+         */
+        label(): string {
+            return `${selector} .checkbox__label`;
+        },
+
+        /**
+         * Get the details element.
+         *
+         * The details element is only present when the `details` slot is used
+         * and visible (controlled by the parent `FFieldset` `showDetails` prop).
+         *
+         * @example Cypress
+         *
+         * ```ts
+         * const { details } = FCheckboxFieldSelectors();
+         * cy.get(details()).should("contain.text", "Additional information");
+         * ```
+         *
+         * @example Playwright
+         *
+         * ```ts
+         * const { details } = FCheckboxFieldSelectors();
+         * await expect(page.locator(details())).toContainText("Additional information");
+         * ```
+         *
+         * @public
+         * @since %version%
+         * @returns A selector for the details element.
+         */
+        details(): string {
+            return `${selector} .checkbox__details`;
+        },
+    });
+}

--- a/packages/vue/src/selectors/FCheckboxField.selectors.ts
+++ b/packages/vue/src/selectors/FCheckboxField.selectors.ts
@@ -6,7 +6,7 @@
  * @param selector - The selector for the FCheckboxField component.
  * @returns An object with selector methods for the FCheckboxField component.
  */
-export function FCheckboxFieldSelectors(selector: string = ".checkbox") {
+export function FCheckboxFieldSelectors(selector: string = ":scope") {
     return Object.freeze({
         /**
          * The base selector for the component.

--- a/packages/vue/src/selectors/index.ts
+++ b/packages/vue/src/selectors/index.ts
@@ -1,5 +1,6 @@
 export { FBadgeSelectors } from "./FBadge.selectors";
 export { FButtonSelectors } from "./FButton.selectors";
+export { FCheckboxFieldSelectors } from "./FCheckboxField.selectors";
 export { FCrudDatasetSelectors } from "./FCrudDataset.selectors";
 export { FDetailsPanelSelectors } from "./FDetailsPanel.selectors";
 export { FExpandableParagraphSelectors } from "./FExpandableParagraph.selectors";


### PR DESCRIPTION
Ny omgång selectorobjekt, denna gången med de som kräver mindre ändringar (exempelvis metoder som inte haft samma namn som cypress).

---

Lista med ohanterade:

* `FCalendarSelectors` -  finns inget motsvarande för cypress (§1)
* `FCardSelectors` - finns inget motsvarande för cypress (§1)
* `FConfirmModalSelectors` - finns inget motsvarande för cypress (§1)
* `FContextMenuSelectors` - linjerar inte med cypress (§2)
* `FDataTableSelectors` - finns inget motsvarande för cypress (§1)
* `FDatepickerFieldSelectors` - linjerar inte med cypress (§2)
* `FDefinitionListSelectors` - linjerar inte med cypress (§2)
* `FDialogueTreeSelectors` - linjerar inte med cypress (§2)
* `FErrorListSelectors` - linjerar inte med cypress (§2)
* `FExpandablePanelSelectors` - cypress pageobjektet använder `:has(..)` när den nog inte borde men det blir att det 
divergerar från selectorobjekten (§3)
* `FFieldsetSelectors` - linjerar inte med cypress (§2)
* `FFileItemSelectors` - behöver åtgärdas (§3)
* `FFileSelectorSelectors` - linjerar inte med cypress (§2)
* `FFormModalSelectors` - linjerar inte med cypress (§2)
* `FIconSelectors` - finns inget motsvarande för cypress (§1)
* `FDataTableSelectors` - linjerar inte med cypress (§2)
* `FLayoutApplicationTemplateSelectors` - finns inget motsvarande för cypress (§1)
* `FLayoutLeftPanelSelectors` - finns inget motsvarande för cypress (§1)
* `FLayoutRightPanelSelectors` - finns inget motsvarande för cypress (§1)
* `FLogoSelectors` - finns inget motsvarande för cypress (§1)
* `FMessageBoxSelectors` - linjerar inte med cypress (§2)
* `FModalSelectors` - linjerar inte med cypress (§2)
* `FNavigationMenuSelectors` - finns inget motsvarande för cypress (§1)
* `FOfflineSelectors` - linjerar inte med cypress (§2)
* `FOutputFieldSelectors` - linjerar inte med cypress (§2)
* `FPageHeaderSelectors` - finns inget motsvarande för cypress (§1)
* `FProgressbarSelectors`- linjerar inte med cypress (§2)
* `FRadioFieldSelectors` - linjerar inte med cypress (§2)
* `FSelectFieldSelectors` - linjerar inte med cypress (§2)
* `FSortFilterDatasetSelectors` - linjerar inte med cypress (§2)
* `FStaticFieldSelectors` - linjerar inte med cypress (§2)
* `FTableSelectors` - linjerar inte med cypress (§2)
* `FTableButtonSelectors` - finns inget motsvarande för cypress (§1)
* `FTextareaFieldSelectors` - linjerar inte med cypress (§2)
* `FTextFieldSelectors` - linjerar inte med cypress (§2)
* `FTooltipSelectors` - linjerar inte med cypress (§2)
* `FValidationFormSelectors` - linjerar inte med cypress (§2)
* `FWizardSelectors` - finns inget motsvarande för cypress (§1)