### PR TITLE
refactor: update button active style (refs SFKUI-8038)

### DIFF
--- a/packages/design/src/components/button/_button.scss
+++ b/packages/design/src/components/button/_button.scss
@@ -14,6 +14,7 @@ $button--primary: (
     color--focus: $button-primary-color-text-focus,
     shadow: var(--f-button-shadow),
     shadow--hover: var(--f-button-shadow-hover),
+    shadow--active: var(--f-button-shadow-active),
     padding-top: core.densify(var(--f-button-primary-padding-top)),
     padding-right: var(--f-button-primary-padding-right),
     padding-bottom: core.densify(var(--f-button-primary-padding-bottom)),
@@ -27,12 +28,15 @@ $button--secondary: (
     background-color--active: $button-secondary-color-background-active,
     background-color--focus: $button-secondary-color-background-focus,
     border-color: $button-secondary-color-border-default,
+    border-color--hover: $button-secondary-color-border-hover,
+    border-color--active: $button-secondary-color-border-active,
     color: $button-secondary-color-text-default,
     color--hover: $button-secondary-color-text-hover,
     color--active: $button-secondary-color-text-active,
     color--focus: $button-secondary-color-text-focus,
     shadow: var(--f-button-shadow),
     shadow--hover: var(--f-button-shadow-hover),
+    shadow--active: var(--f-button-shadow-active),
     padding-top: core.densify(var(--f-button-secondary-padding-top)),
     padding-right: var(--f-button-secondary-padding-right),
     padding-bottom: core.densify(var(--f-button-secondary-padding-bottom)),
@@ -129,7 +133,6 @@ $button--tertiary: (
     min-width: var(--f-button-min-width);
     position: relative;
     text-align: center;
-    transition: background-color var(--f-animation-duration-medium) ease-out;
 
     @include core.breakpoint-down(sm) {
         max-width: var(--f-width-full);

--- a/packages/design/src/components/button/_variables.scss
+++ b/packages/design/src/components/button/_variables.scss
@@ -14,6 +14,8 @@ $button-secondary-color-background-hover: var(--fkds-color-action-background-sec
 $button-secondary-color-background-active: var(--fkds-color-action-background-secondary-active) !default;
 $button-secondary-color-background-focus: var(--fkds-color-action-background-secondary-focus) !default;
 $button-secondary-color-border-default: var(--fkds-color-action-border-primary-default) !default;
+$button-secondary-color-border-hover: var(--fkds-color-action-border-primary-hover) !default;
+$button-secondary-color-border-active: var(--fkds-color-action-border-primary-active) !default;
 $button-secondary-color-text-default: var(--fkds-color-action-text-primary-default) !default;
 $button-secondary-color-text-hover: var(--fkds-color-action-text-primary-hover) !default;
 $button-secondary-color-text-active: var(--fkds-color-action-text-primary-active) !default;

--- a/packages/design/src/core/mixins/_button.scss
+++ b/packages/design/src/core/mixins/_button.scss
@@ -21,6 +21,7 @@
     $color--disabled: $button-color-text-disabled,
     $shadow,
     $shadow--hover: $shadow,
+    $shadow--active: $shadow,
     $padding-top,
     $padding-right,
     $padding-bottom,
@@ -32,6 +33,9 @@
     box-shadow: $shadow;
     color: $color;
     padding: $padding-top $padding-right $padding-bottom $padding-left;
+    transition-duration: var(--f-button-animation-duration);
+    transition-property: background-color, border-color, transform;
+    transition-timing-function: var(--f-button-animation-curve);
 
     &:focus {
         background-color: $background-color--focus;
@@ -42,14 +46,16 @@
     &:hover {
         background-color: $background-color--hover;
         border-color: $border-color--hover;
-        color: $color--hover;
         box-shadow: $shadow--hover;
+        color: $color--hover;
     }
 
     &:active {
         background-color: $background-color--active;
         border-color: $border-color--active;
+        box-shadow: $shadow--active;
         color: $color--active;
+        transform: translateY(1px);
     }
 
     &:focus {
@@ -72,9 +78,10 @@
 
     &[aria-disabled="true"] {
         pointer-events: none;
+
         @media (forced-colors: active) {
-            color: GrayText;
             border-color: GrayText;
+            color: GrayText;
         }
     }
 }

--- a/packages/design/src/core/mixins/_button.scss
+++ b/packages/design/src/core/mixins/_button.scss
@@ -21,6 +21,7 @@
     $color--disabled: $button-color-text-disabled,
     $shadow,
     $shadow--hover: $shadow,
+    $shadow--active: $shadow,
     $padding-top,
     $padding-right,
     $padding-bottom,
@@ -32,6 +33,9 @@
     box-shadow: $shadow;
     color: $color;
     padding: $padding-top $padding-right $padding-bottom $padding-left;
+    transition-duration: var(--f-animation-duration-extra-short);
+    transition-property: background-color, border-color, transform;
+    transition-timing-function: var(--f-button-animation-curve);
 
     &:focus {
         background-color: $background-color--focus;
@@ -42,14 +46,16 @@
     &:hover {
         background-color: $background-color--hover;
         border-color: $border-color--hover;
-        color: $color--hover;
         box-shadow: $shadow--hover;
+        color: $color--hover;
     }
 
     &:active {
         background-color: $background-color--active;
         border-color: $border-color--active;
+        box-shadow: $shadow--active;
         color: $color--active;
+        transform: translateY(1px);
     }
 
     &:focus {
@@ -72,9 +78,10 @@
 
     &[aria-disabled="true"] {
         pointer-events: none;
+
         @media (forced-colors: active) {
-            color: GrayText;
             border-color: GrayText;
+            color: GrayText;
         }
     }
 }

--- a/packages/theme-default/src/shared/_index.scss
+++ b/packages/theme-default/src/shared/_index.scss
@@ -114,12 +114,15 @@
     $_f-button-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
     --f-button-shadow: #{$_f-button-shadow};
     --f-button-shadow-hover: #{$_f-button-shadow};
+    --f-button-shadow-active: none;
     --f-button-min-width: 9.5rem;
     --f-button-letter-spacing: 0.01rem;
     --f-button-default-line-height: 1.5rem;
     --f-button-discrete-radius-hover: none;
     --f-button-tertiary-table-column-action-icon-margin: 0 8px 0 2px;
     --f-button-tertiary-table-column-action-margin: 0 0 0 0.5rem;
+    --f-button-animation-curve: ease-out;
+    --f-button-animation-duration: 100ms;
 
     $_f-button-default-padding-top: 1rem;
     $_f-button-default-padding-right: 1.5rem;

--- a/packages/theme-default/src/shared/_index.scss
+++ b/packages/theme-default/src/shared/_index.scss
@@ -96,6 +96,7 @@
         0 0 0 6px var(--fkds-focus-indicator-color-background);
 
     // Effect related variables
+    --f-animation-duration-extra-short: 100ms;
     --f-animation-duration-short: 150ms;
     --f-animation-duration-medium: 350ms;
     --f-animation-duration-long: 500ms;
@@ -114,12 +115,14 @@
     $_f-button-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
     --f-button-shadow: #{$_f-button-shadow};
     --f-button-shadow-hover: #{$_f-button-shadow};
+    --f-button-shadow-active: none;
     --f-button-min-width: 9.5rem;
     --f-button-letter-spacing: 0.01rem;
     --f-button-default-line-height: 1.5rem;
     --f-button-discrete-radius-hover: none;
     --f-button-tertiary-table-column-action-icon-margin: 0 8px 0 2px;
     --f-button-tertiary-table-column-action-margin: 0 0 0 0.5rem;
+    --f-button-animation-curve: ease-out;
 
     $_f-button-default-padding-top: 1rem;
     $_f-button-default-padding-right: 1.5rem;


### PR DESCRIPTION
Sista ändringarna för mikrointeraktioner till knapp innan ´focus-visible´. Inför en transform vid `:active` baserat på skiss. Färgförändringarna vid interaktion slår inte förrän variablerna knapp använder ändras vid utökning av färgpaletten.

Todo:
- [x] Checka av med test
- [x] Final check med UX
- [x] ~Checka av prefer-reduced-motion med tillgänglighet~ Gör ny PR om ändringar krävs istället.