### PR TITLE
jsdom preparations

### DIFF
--- a/packages/logic/src/services/ValidationService/validation-service.spec.ts
+++ b/packages/logic/src/services/ValidationService/validation-service.spec.ts
@@ -231,12 +231,14 @@ describe("isValid()", () => {
     it("should return true if element is valid", async () => {
         expect.assertions(1);
         const element = createElement({ valid: true });
+        document.body.append(element);
         expect(await ValidationService.isValid(element)).toBeTruthy();
     });
 
     it("should return false if element has error", async () => {
         expect.assertions(1);
         const element = createElement({ valid: false });
+        document.body.append(element);
         expect(await ValidationService.isValid(element)).toBeFalsy();
     });
 
@@ -247,6 +249,7 @@ describe("isValid()", () => {
         const b = createElement({ valid: true });
         fieldset.append(a);
         fieldset.append(b);
+        document.body.append(fieldset);
         expect(await ValidationService.isValid(fieldset)).toBeTruthy();
     });
 
@@ -257,6 +260,7 @@ describe("isValid()", () => {
         const b = createElement({ valid: false });
         fieldset.append(a);
         fieldset.append(b);
+        document.body.append(fieldset);
         expect(await ValidationService.isValid(fieldset)).toBeFalsy();
     });
 
@@ -267,6 +271,7 @@ describe("isValid()", () => {
         const b = createElement({ valid: true });
         div.append(a);
         div.append(b);
+        document.body.append(div);
         expect(await ValidationService.isValid(div)).toBeTruthy();
     });
 
@@ -277,20 +282,29 @@ describe("isValid()", () => {
         const b = createElement({ valid: false });
         div.append(a);
         div.append(b);
+        document.body.append(div);
         expect(await ValidationService.isValid(div)).toBeFalsy();
     });
 
     it("should return true if all elements are valid", async () => {
         expect.assertions(1);
+        const div = document.createElement("div");
         const a = createElement({ valid: true });
         const b = createElement({ valid: true });
+        div.append(a);
+        div.append(b);
+        document.body.append(div);
         expect(await ValidationService.isValid([a, b])).toBeTruthy();
     });
 
     it("should return false if not all elements are valid", async () => {
         expect.assertions(1);
+        const div = document.createElement("div");
         const a = createElement({ valid: true });
         const b = createElement({ valid: false });
+        div.append(a);
+        div.append(b);
+        document.body.append(div);
         expect(await ValidationService.isValid([a, b])).toBeFalsy();
     });
 
@@ -301,6 +315,7 @@ describe("isValid()", () => {
         const bar = createElement({ valid: false, id: "bar" });
         root.append(foo);
         root.append(bar);
+        document.body.append(root);
         expect(await ValidationService.isValid("foo", root)).toBeTruthy();
         expect(await ValidationService.isValid("bar", root)).toBeFalsy();
     });
@@ -312,6 +327,7 @@ describe("isValid()", () => {
         const bar = createElement({ valid: true, id: "bar" });
         root.append(foo);
         root.append(bar);
+        document.body.append(root);
         expect(
             await ValidationService.isValid(["foo", "bar"], root),
         ).toBeTruthy();
@@ -334,6 +350,7 @@ describe("validateElement", () => {
     beforeEach(() => {
         inputElement = document.createElement("input");
         inputElement.id = "test-element";
+        document.body.append(inputElement);
     });
 
     it("should dispatch ValidityEvent to element by reference", async () => {

--- a/packages/vue/src/components/FTable/FTable.spec.ts
+++ b/packages/vue/src/components/FTable/FTable.spec.ts
@@ -1427,14 +1427,14 @@ describe("Clickable cells", () => {
         });
 
         const cell = wrapper.get<HTMLTableCellElement>(
-            "table tr:nth-child(2) td:first-child",
+            "tr:nth-child(2) td:first-child",
         );
 
         await nextTick();
         await cell.trigger("click");
 
         const checkbox = wrapper.get<HTMLInputElement>(
-            "table tr:nth-child(2) td:first-child input[type='checkbox']",
+            "tr:nth-child(2) td:first-child input[type='checkbox']",
         );
 
         expect(checkbox.element.checked).toBeTruthy();
@@ -1476,7 +1476,7 @@ describe("Clickable cells", () => {
         });
 
         const cell = wrapper.get<HTMLTableCellElement>(
-            "table tr:nth-child(2) td:first-child",
+            "tr:nth-child(2) td:first-child",
         );
 
         await nextTick();


### PR DESCRIPTION
Vi släpar ganska långt efter i jsdom version (pga att jest krävt det) men det behövs lite justeringar för att stega upp det. Det här är några förberedelser.

Två huvudområden:

1. För att validerings-api:et ska fungera måste elementet vara attached, element som inte är attached kommer inte att kunna matchas med selectorer likt `:invalid`.
2. Man kan inte längre matcha sig själv, `document.querySelector("table").querySelector("table")` matchar inte längre ett element. Nu har vi inte direkt skrivit kod på det sättet men indirekt om man har `<table>` som root i en wrapper så fungerar inte `wrapper.find("table ...")` eftersom "table" inte längre matchar sig själv.

Det sista är ett större problem men det kommer en separat PR som löser fler förekomster av det.