### PR TITLE
fix: retain card background when `FCard` is invalid (refs SFKUI-6500)

### DIFF
--- a/packages/design/src/components/card/_card.scss
+++ b/packages/design/src/components/card/_card.scss
@@ -13,6 +13,7 @@
     }
 
     &--error {
+        background-color: $card-color-background;
         border-radius: var(--f-border-radius-medium);
         border: var(--f-border-width-medium) solid $card-color-border-error;
     }


### PR DESCRIPTION
fixes #1524