### PR TITLE
refactor: html-validate vitest tests (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FBadge/FBadge.spec.ts
+++ b/packages/vue/src/components/FBadge/FBadge.spec.ts
@@ -39,8 +39,7 @@ describe("html-validate", () => {
                 <template #default> Badge text </template>
             </f-badge>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should report error when status is invalid", async () => {
@@ -50,7 +49,15 @@ describe("html-validate", () => {
                 <template #default> Badge text </template>
             </f-badge>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate();
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "status" has invalid value "conflict" (attribute-allowed-values)
+            1 |
+          > 2 |             <f-badge status="conflict">
+              |                              ^^^^^^^^
+            3 |                 <template #default> Badge text </template>
+            4 |             </f-badge>
+            5 |
+          Selector: f-badge"
+        `);
     });
 });

--- a/packages/vue/src/components/FButton/FButton.spec.ts
+++ b/packages/vue/src/components/FButton/FButton.spec.ts
@@ -1,10 +1,5 @@
 import "html-validate/vitest";
 import { shallowMount } from "@vue/test-utils";
-import {
-    FileSystemConfigLoader,
-    HtmlValidate,
-    cjsResolver,
-} from "html-validate";
 import { describe, expect, it } from "vitest";
 import { FIcon } from "../FIcon";
 import FButton from "./FButton.vue";
@@ -74,23 +69,12 @@ describe("props", () => {
 });
 
 describe("html-validate", () => {
-    const loader = new FileSystemConfigLoader([cjsResolver()], {
-        extends: [
-            "html-validate:recommended",
-            "html-validate-vue:recommended",
-            "@fkui/vue:recommended",
-        ],
-        plugins: [`<rootDir>/htmlvalidate/index.cjs`, "html-validate-vue"],
-    });
-    const htmlvalidate = new HtmlValidate(loader);
-
     it("should allow basic button", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
             <f-button size="medium" variant="primary"> lorem ipsum </f-button>
         `;
-        const report = await htmlvalidate.validateString(markup);
-        await expect(report).toBeValid();
+        await expect(markup).toBeValid();
     });
 
     describe("type attribute", () => {
@@ -107,20 +91,17 @@ describe("html-validate", () => {
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeValid();
+            await expect(markup).toBeValid();
         });
 
         it("should not allow invalid values", async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const markup = /* HTML */ `
                 <f-button type="invalid" size="medium" variant="primary">
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
               error: Attribute "type" has invalid value "invalid" (attribute-allowed-values)
                 1 |
               > 2 |                 <f-button type="invalid" size="medium" variant="primary">
@@ -133,7 +114,7 @@ describe("html-validate", () => {
         });
 
         it("should function as button by default", async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const markup = /* HTML */ `
                 <form>
                     <f-button size="medium" variant="primary">
@@ -141,9 +122,7 @@ describe("html-validate", () => {
                     </f-button>
                 </form>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
               error: <form> element must have a submit button (wcag/h32)
                 1 |
               > 2 |                 <form>
@@ -164,20 +143,17 @@ describe("html-validate", () => {
                     </f-button>
                 </form>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeValid();
+            await expect(markup).toBeValid();
         });
     });
 
     describe("variant attribute", () => {
         it("should be required", async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const markup = /* HTML */ `
                 <f-button size="medium"> lorem ipsum </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
               error: <f-button> is missing required "variant" attribute (element-required-attributes)
                 1 |
               > 2 |                 <f-button size="medium"> lorem ipsum </f-button>
@@ -200,20 +176,17 @@ describe("html-validate", () => {
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeValid();
+            await expect(markup).toBeValid();
         });
 
         it("should not allow invalid values", async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const markup = /* HTML */ `
                 <f-button size="medium" variant="invalid">
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
               error: Attribute "variant" has invalid value "invalid" (attribute-allowed-values)
                 1 |
               > 2 |                 <f-button size="medium" variant="invalid">
@@ -228,13 +201,11 @@ describe("html-validate", () => {
 
     describe("size attribute", () => {
         it("should be required", async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const markup = /* HTML */ `
                 <f-button variant="primary"> lorem ipsum </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
               error: <f-button> is missing required "size" attribute (element-required-attributes)
                 1 |
               > 2 |                 <f-button variant="primary"> lorem ipsum </f-button>
@@ -257,20 +228,17 @@ describe("html-validate", () => {
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeValid();
+            await expect(markup).toBeValid();
         });
 
         it("should not allow invalid values", async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const markup = /* HTML */ `
                 <f-button size="invalid" variant="primary">
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
               error: Attribute "size" has invalid value "invalid" (attribute-allowed-values)
                 1 |
               > 2 |                 <f-button size="invalid" variant="primary">
@@ -294,12 +262,11 @@ describe("html-validate", () => {
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeValid();
+            await expect(markup).toBeValid();
         });
 
         it("should not allow both icon-left and icon-right", async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const markup = /* HTML */ `
                 <f-button
                     icon-left="icon"
@@ -310,9 +277,7 @@ describe("html-validate", () => {
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
               error: "icon-left" attribute cannot be used on <f-button> in this context: cannot be used at the same time as "icon-right" (attribute-misuse)
                 1 |
                 2 |                 <f-button
@@ -346,8 +311,7 @@ describe("html-validate", () => {
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeValid();
+            await expect(markup).toBeValid();
         });
     });
 
@@ -366,12 +330,11 @@ describe("html-validate", () => {
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeValid();
+            await expect(markup).toBeValid();
         });
 
         it("should not allow tertiary-style without variant tertiary", async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const markup = /* HTML */ `
                 <f-button
                     size="medium"
@@ -381,9 +344,7 @@ describe("html-validate", () => {
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
               error: "tertiary-style" attribute cannot be used on <f-button> in this context: "variant" attribute must be "tertiary" (attribute-misuse)
                 3 |                     size="medium"
                 4 |                     variant="primary"
@@ -397,7 +358,7 @@ describe("html-validate", () => {
         });
 
         it("should not allow invalid tertiary-style value", async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const markup = /* HTML */ `
                 <f-button
                     size="medium"
@@ -407,9 +368,7 @@ describe("html-validate", () => {
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
               error: Attribute "tertiary-style" has invalid value "invalid" (attribute-allowed-values)
                 2 |                 <f-button
                 3 |                     size="medium"
@@ -423,15 +382,13 @@ describe("html-validate", () => {
         });
 
         it("should not allow align-text without variant tertiary", async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const markup = /* HTML */ `
                 <f-button size="medium" variant="primary" align-text>
                     lorem ipsum
                 </f-button>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
               error: "align-text" attribute cannot be used on <f-button> in this context: "variant" attribute must be "tertiary" (attribute-misuse)
                 1 |
               > 2 |                 <f-button size="medium" variant="primary" align-text>

--- a/packages/vue/src/components/FCalendar/FCalendarDay.spec.ts
+++ b/packages/vue/src/components/FCalendar/FCalendarDay.spec.ts
@@ -25,8 +25,7 @@ describe("html-validate", () => {
             >
             </i-calendar-day>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should allow child elements", async () => {
@@ -36,7 +35,6 @@ describe("html-validate", () => {
                 <span></span>
             </i-calendar-day>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/components/FCard/FCard.spec.ts
+++ b/packages/vue/src/components/FCard/FCard.spec.ts
@@ -1,22 +1,7 @@
 import { type VueWrapper, mount } from "@vue/test-utils";
-import {
-    FileSystemConfigLoader,
-    HtmlValidate,
-    cjsResolver,
-} from "html-validate/node";
 import { describe, expect, it } from "vitest";
 import FCard from "./FCard.vue";
 import "html-validate/vitest";
-
-const loader = new FileSystemConfigLoader([cjsResolver()], {
-    extends: [
-        "html-validate:recommended",
-        "html-validate-vue:recommended",
-        "@fkui/vue:recommended",
-    ],
-    plugins: [`<rootDir>/htmlvalidate/index.cjs`, "html-validate-vue"],
-});
-const htmlvalidate = new HtmlValidate(loader);
 
 function createWrapper({
     props = {},
@@ -72,15 +57,13 @@ describe("html-validate", () => {
                 <template #footer></template>
             </f-card>
         `;
-        const report = await htmlvalidate.validateString(markup);
-        await expect(report).toBeValid();
+        await expect(markup).toBeValid();
     });
 
     it("should not allow invalid values", async () => {
         expect.assertions(1);
         const markup = /* HTML */ ` <f-card></f-card> `;
-        const report = await htmlvalidate.validateString(markup);
-        await expect(report).toMatchInlineCodeframe(`
+        await expect(markup).toMatchInlineCodeframe(`
             "error: <f-card> component requires slot "default" to be implemented (vue/required-slots)
             > 1 |  <f-card></f-card>
                 |   ^^^^^^

--- a/packages/vue/src/components/FContextMenu/FContextMenu.spec.ts
+++ b/packages/vue/src/components/FContextMenu/FContextMenu.spec.ts
@@ -280,29 +280,47 @@ describe("html-validate", () => {
         const markup = /* HTML */ `
             <button type="button">
                 <f-context-menu anchor="" is-open items=""></f-context-menu>
+                button text
             </button>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-permitted-content",
-            message:
-                "<f-context-menu> element is not permitted as content under <button>",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-context-menu> element is not permitted as content under <button> (element-permitted-content)
+            1 |
+            2 |             <button type="button">
+          > 3 |                 <f-context-menu anchor="" is-open items=""></f-context-menu>
+              |                  ^^^^^^^^^^^^^^
+            4 |                 button text
+            5 |             </button>
+            6 |
+          Selector: button > f-context-menu"
+        `);
     });
 
     it("should not allow interactive children", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
             <f-context-menu anchor="" is-open items="">
-                <button type="button"></button>
+                <button type="button">button text</button>
             </f-context-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-permitted-content",
-            message:
-                "<button> element is not permitted as content under <f-context-menu>",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-context-menu> must not have text content (text-content)
+            1 |
+          > 2 |             <f-context-menu anchor="" is-open items="">
+              |              ^^^^^^^^^^^^^^
+            3 |                 <button type="button">button text</button>
+            4 |             </f-context-menu>
+            5 |
+          Selector: f-context-menu
+          error: <button> element is not permitted as content under <f-context-menu> (element-permitted-content)
+            1 |
+            2 |             <f-context-menu anchor="" is-open items="">
+          > 3 |                 <button type="button">button text</button>
+              |                  ^^^^^^
+            4 |             </f-context-menu>
+            5 |
+          Selector: f-context-menu > button"
+        `);
     });
 
     it("should not allow child elements", async () => {
@@ -312,12 +330,16 @@ describe("html-validate", () => {
                 <em></em>
             </f-context-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-permitted-content",
-            message:
-                "<em> element is not permitted as content under <f-context-menu>",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <em> element is not permitted as content under <f-context-menu> (element-permitted-content)
+            1 |
+            2 |             <f-context-menu anchor="" is-open items="">
+          > 3 |                 <em></em>
+              |                  ^^
+            4 |             </f-context-menu>
+            5 |
+          Selector: f-context-menu > em"
+        `);
     });
 
     it("should not allow text", async () => {
@@ -327,10 +349,15 @@ describe("html-validate", () => {
                 mjukglass
             </f-context-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "text-content",
-            message: "<f-context-menu> must not have text content",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-context-menu> must not have text content (text-content)
+            1 |
+          > 2 |             <f-context-menu anchor="" is-open items="">
+              |              ^^^^^^^^^^^^^^
+            3 |                 mjukglass
+            4 |             </f-context-menu>
+            5 |
+          Selector: f-context-menu"
+        `);
     });
 });

--- a/packages/vue/src/components/FCrudDataset/FCrudButton.spec.ts
+++ b/packages/vue/src/components/FCrudDataset/FCrudButton.spec.ts
@@ -133,8 +133,8 @@ describe("html-validate", () => {
                 </template>
             </f-crud-dataset>
         `;
-        await expect(markup("modify")).toMatchInlineCodeframe(`""`);
-        await expect(markup("delete")).toMatchInlineCodeframe(`""`);
+        await expect(markup("modify")).toBeValid();
+        await expect(markup("delete")).toBeValid();
         await expect(markup("foobar")).toMatchInlineCodeframe(`
             "error: Attribute "action" has invalid value "foobar" (attribute-allowed-values)
               4 |                 <template #default>

--- a/packages/vue/src/components/FCrudDataset/FCrudDataset.spec.ts
+++ b/packages/vue/src/components/FCrudDataset/FCrudDataset.spec.ts
@@ -755,11 +755,12 @@ describe("html-validate", () => {
     it("should require default slot", async () => {
         expect.assertions(1);
         const markup = /* HTML */ ` <f-crud-dataset></f-crud-dataset> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message:
-                '<f-crud-dataset> component requires slot "default" to be implemented',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-crud-dataset> component requires slot "default" to be implemented (vue/required-slots)
+          > 1 |  <f-crud-dataset></f-crud-dataset>
+              |   ^^^^^^^^^^^^^^
+          Selector: f-crud-dataset"
+        `);
     });
 
     it("should html-validate", async () => {
@@ -769,7 +770,6 @@ describe("html-validate", () => {
                 <template #default></template>
             </f-crud-dataset>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/components/FDataTable/FDataTable.spec.ts
+++ b/packages/vue/src/components/FDataTable/FDataTable.spec.ts
@@ -457,41 +457,79 @@ describe("html-validate", () => {
     it("should require `key-attribute` to be non-empty if used", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <f-data-table key-attribute=""></f-data-table>
+            <f-data-table rows key-attribute="">
+                <template #caption> lorem ipsum </template>
+                <template #default> </template>
+            </f-data-table>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message: 'Attribute "key-attribute" has invalid value ""',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "key-attribute" has invalid value "" (attribute-allowed-values)
+            1 |
+          > 2 |             <f-data-table rows key-attribute="">
+              |                                ^^^^^^^^^^^^^
+            3 |                 <template #caption> lorem ipsum </template>
+            4 |                 <template #default> </template>
+            5 |             </f-data-table>
+          Selector: f-data-table"
+        `);
     });
 
     it("should require row attribute", async () => {
         expect.assertions(1);
-        const markup = /* HTML */ ` <f-data-table></f-data-table> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message: '<f-data-table> is missing required "rows" attribute',
-        });
+        const markup = /* HTML */ `
+            <f-data-table>
+                <template #caption> lorem ipsum </template>
+                <template #default> </template>
+            </f-data-table>
+        `;
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-data-table> is missing required "rows" attribute (element-required-attributes)
+            1 |
+          > 2 |             <f-data-table>
+              |              ^^^^^^^^^^^^
+            3 |                 <template #caption> lorem ipsum </template>
+            4 |                 <template #default> </template>
+            5 |             </f-data-table>
+          Selector: f-data-table"
+        `);
     });
 
     it("should require caption slot", async () => {
         expect.assertions(1);
-        const markup = /* HTML */ ` <f-data-table></f-data-table> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message:
-                '<f-data-table> component requires slot "caption" to be implemented',
-        });
+        const markup = /* HTML */ `
+            <f-data-table rows>
+                <template #default> </template>
+            </f-data-table>
+        `;
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-data-table> component requires slot "caption" to be implemented (vue/required-slots)
+            1 |
+          > 2 |             <f-data-table rows>
+              |              ^^^^^^^^^^^^
+            3 |                 <template #default> </template>
+            4 |             </f-data-table>
+            5 |
+          Selector: f-data-table"
+        `);
     });
 
     it("should require default slot", async () => {
         expect.assertions(1);
-        const markup = /* HTML */ ` <f-data-table></f-data-table> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message:
-                '<f-data-table> component requires slot "default" to be implemented',
-        });
+        const markup = /* HTML */ `
+            <f-data-table rows>
+                <template #caption> lorem ipsum </template>
+            </f-data-table>
+        `;
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-data-table> component requires slot "default" to be implemented (vue/required-slots)
+            1 |
+          > 2 |             <f-data-table rows>
+              |              ^^^^^^^^^^^^
+            3 |                 <template #caption> lorem ipsum </template>
+            4 |             </f-data-table>
+            5 |
+          Selector: f-data-table"
+        `);
     });
 
     /* technical debt: this tests the wrong component */
@@ -512,7 +550,6 @@ describe("html-validate", () => {
                 E-post
             </f-email-text-field>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/components/FDatepickerField/FDatepickerField.spec.ts
+++ b/packages/vue/src/components/FDatepickerField/FDatepickerField.spec.ts
@@ -134,7 +134,7 @@ describe("html-validate", () => {
             const invalid = /* HTML */ `
                 <f-datepicker-field disabled="foobar"></f-datepicker-field>
             `;
-            await expect(valid).toMatchInlineCodeframe(`""`);
+            await expect(valid).toBeValid();
             await expect(invalid).toMatchInlineCodeframe(`
                 "error: Attribute "disabled" should omit value (attribute-boolean-style)
                   1 |
@@ -158,7 +158,7 @@ describe("html-validate", () => {
                 <f-datepicker-field :initial-month="myInitialDate">
                 </f-datepicker-field>
             `;
-            await expect(valid).toMatchInlineCodeframe(`""`);
+            await expect(valid).toBeValid();
         });
 
         it("highlight-today", async () => {
@@ -173,7 +173,7 @@ describe("html-validate", () => {
                 <f-datepicker-field highlight-today="foobar">
                 </f-datepicker-field>
             `;
-            await expect(valid).toMatchInlineCodeframe(`""`);
+            await expect(valid).toBeValid();
             await expect(invalid).toMatchInlineCodeframe(`
                 "error: Attribute "highlight-today" should omit value (attribute-boolean-style)
                   1 |
@@ -202,7 +202,7 @@ describe("html-validate", () => {
             const invalid = /* HTML */ `
                 <f-datepicker-field always-inline="foobar"></f-datepicker-field>
             `;
-            await expect(valid).toMatchInlineCodeframe(`""`);
+            await expect(valid).toBeValid();
             await expect(invalid).toMatchInlineCodeframe(`
                 "error: Attribute "always-inline" should omit value (attribute-boolean-style)
                   1 |
@@ -230,8 +230,7 @@ describe("html-validate", () => {
                     </template>
                 </f-datepicker-field>
             `;
-            /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-            await expect(markup).toHTMLValidate();
+            await expect(markup).toBeValid();
         });
 
         it("should not allow block content in #default slot", async () => {
@@ -274,7 +273,7 @@ describe("html-validate", () => {
                     </template>
                 </f-datepicker-field>
             `;
-            await expect(valid).toMatchInlineCodeframe(`""`);
+            await expect(valid).toBeValid();
             await expect(invalid).toMatchInlineCodeframe(`
                 "error: <div> element is not permitted as content under slot "tooltip" (<f-datepicker-field>) (element-permitted-content)
                   2 |                 <f-datepicker-field>
@@ -315,8 +314,7 @@ describe("html-validate", () => {
                     </template>
                 </f-datepicker-field>
             `;
-            /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-            await expect(markup).toHTMLValidate();
+            await expect(markup).toBeValid();
         });
 
         it("should not allow block content in #error-message slot", async () => {
@@ -350,8 +348,7 @@ describe("html-validate", () => {
                     </template>
                 </f-datepicker-field>
             `;
-            /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-            await expect(markup).toHTMLValidate();
+            await expect(markup).toBeValid();
         });
 
         it("should not allow block content in #description slot", async () => {

--- a/packages/vue/src/components/FErrorList/FErrorList.spec.ts
+++ b/packages/vue/src/components/FErrorList/FErrorList.spec.ts
@@ -5,11 +5,6 @@ import * as logic from "@fkui/logic";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
 import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
-import {
-    FileSystemConfigLoader,
-    HtmlValidate,
-    cjsResolver,
-} from "html-validate/node";
 import { describe, expect, it, vi } from "vitest";
 import { IFlexItem } from "../../internal-components/IFlex";
 import { type ErrorItem } from "../../types";
@@ -173,22 +168,11 @@ describe("navigation", () => {
 });
 
 describe("htmlvalidate", () => {
-    const loader = new FileSystemConfigLoader([cjsResolver()], {
-        extends: [
-            "html-validate:recommended",
-            "html-validate-vue:recommended",
-            "@fkui/vue:recommended",
-        ],
-        plugins: [`<rootDir>/htmlvalidate/index.cjs`, "html-validate-vue"],
-    });
-    const htmlvalidate = new HtmlValidate(loader);
-
     describe("items attribute", () => {
         it("should be required", async () => {
             expect.assertions(1);
             const markup = /* HTML */ ` <f-error-list></f-error-list> `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
                 "error: <f-error-list> is missing required "items" attribute (element-required-attributes)
                 > 1 |  <f-error-list></f-error-list>
                     |   ^^^^^^^^^^^^

--- a/packages/vue/src/components/FExpandablePanel/FExpandablePanel.spec.ts
+++ b/packages/vue/src/components/FExpandablePanel/FExpandablePanel.spec.ts
@@ -24,42 +24,42 @@ describe("snapshots", () => {
         expect.assertions(2);
         const wrapper = createWrapper();
         expect(wrapper.element).toMatchSnapshot();
-        await expect(wrapper.element).toHTMLValidate();
+        await expect(wrapper.html()).toBeValid();
     });
 
     it("should match snapshot when expanded", async () => {
         expect.assertions(2);
         const wrapper = createWrapper({ props: { expanded: true } });
         expect(wrapper.element).toMatchSnapshot();
-        await expect(wrapper.element).toHTMLValidate();
+        await expect(wrapper.html()).toBeValid();
     });
 
     it("should match snapshot with notification", async () => {
         expect.assertions(2);
         const wrapper = createWrapper({ props: { notifications: 2 } });
         expect(wrapper.element).toMatchSnapshot();
-        await expect(wrapper.element).toHTMLValidate();
+        await expect(wrapper.html()).toBeValid();
     });
 
     it("should match snapshot with generated id", async () => {
         expect.assertions(2);
         const wrapper = createWrapper({ props: { id: undefined } });
         expect(wrapper.element).toMatchSnapshot();
-        await expect(wrapper.element).toHTMLValidate();
+        await expect(wrapper.html()).toBeValid();
     });
 
     it("should match snapshot with custom heading level", async () => {
         expect.assertions(2);
         const wrapper = createWrapper({ props: { headerTag: "h3" } });
         expect(wrapper.element).toMatchSnapshot();
-        await expect(wrapper.element).toHTMLValidate();
+        await expect(wrapper.html()).toBeValid();
     });
 
     it('should match snapshot with "outside" slot', async () => {
         expect.assertions(2);
         const wrapper = createWrapper({ slots: { outside: "dolor sit amet" } });
         expect(wrapper.element).toMatchSnapshot();
-        await expect(wrapper.element).toHTMLValidate();
+        await expect(wrapper.html()).toBeValid();
     });
 });
 

--- a/packages/vue/src/components/FExpandableParagraph/FExpandableParagraph.spec.ts
+++ b/packages/vue/src/components/FExpandableParagraph/FExpandableParagraph.spec.ts
@@ -1,15 +1,7 @@
 import { type VueWrapper, mount, shallowMount } from "@vue/test-utils";
-import { type ConfigData } from "html-validate";
 import { describe, expect, it, vi } from "vitest";
 import FExpandableParagraph from "./FExpandableParagraph.vue";
 import "html-validate/vitest";
-
-const config: ConfigData = {
-    root: true,
-    rules: {
-        "no-inline-style": "off",
-    },
-};
 
 function createWrapper({
     props = {},
@@ -36,21 +28,21 @@ describe("snapshots", () => {
         expect.assertions(2);
         const wrapper = createWrapper();
         expect(wrapper.element).toMatchSnapshot();
-        await expect(wrapper.element).toHTMLValidate(config);
+        await expect(wrapper.html()).toBeValid();
     });
 
     it("should match snapshot when expanded", async () => {
         expect.assertions(2);
         const wrapper = createWrapper({ props: { expanded: true } });
         expect(wrapper.element).toMatchSnapshot();
-        await expect(wrapper.element).toHTMLValidate(config);
+        await expect(wrapper.html()).toBeValid();
     });
 
     it("should match snapshot with custom heading level", async () => {
         expect.assertions(2);
         const wrapper = createWrapper({ props: { headerTag: "h3" } });
         expect(wrapper.element).toMatchSnapshot();
-        await expect(wrapper.element).toHTMLValidate(config);
+        await expect(wrapper.html()).toBeValid();
     });
 
     it("should match snapshot with list styling", async () => {
@@ -59,7 +51,7 @@ describe("snapshots", () => {
             props: { headerTag: "h3", list: true },
         });
         expect(wrapper.element).toMatchSnapshot();
-        await expect(wrapper.element).toHTMLValidate(config);
+        await expect(wrapper.html()).toBeValid();
     });
 
     it("should match snapshot with related information", async () => {
@@ -69,7 +61,7 @@ describe("snapshots", () => {
             slots: { related: "dolor sit amet" },
         });
         expect(wrapper.element).toMatchSnapshot();
-        await expect(wrapper.element).toHTMLValidate(config);
+        await expect(wrapper.html()).toBeValid();
     });
 });
 

--- a/packages/vue/src/components/FFieldset/FFieldset.spec.ts
+++ b/packages/vue/src/components/FFieldset/FFieldset.spec.ts
@@ -415,7 +415,7 @@ describe("html-validate", () => {
                     </f-fieldset>
                 </div>
             `;
-            await expect(markup).toMatchInlineCodeframe(`""`);
+            await expect(markup).toBeValid();
         });
 
         it("should not be allowed where phrasing is expected", async () => {
@@ -427,7 +427,7 @@ describe("html-validate", () => {
                     </f-fieldset>
                 </span>
             `;
-            await expect(markup).toMatchInlineCodeframe(`""`);
+            await expect(markup).toBeValid();
         });
     });
 
@@ -439,7 +439,7 @@ describe("html-validate", () => {
                     <template #label> Label </template>
                 </f-fieldset>
             `;
-            await expect(markup).toMatchInlineCodeframe(`""`);
+            await expect(markup).toBeValid();
         });
 
         it("should not allow empty name", async () => {
@@ -480,7 +480,7 @@ describe("html-validate", () => {
                     <template #label> Label </template>
                 </f-fieldset>
             `;
-            await expect(markup).toMatchInlineCodeframe(`""`);
+            await expect(markup).toBeValid();
         });
 
         it("should not allow multiple content classes", async () => {
@@ -509,7 +509,7 @@ describe("html-validate", () => {
                     <template #label> Label </template>
                 </f-fieldset>
             `;
-            await expect(markup).toMatchInlineCodeframe(`""`);
+            await expect(markup).toBeValid();
         });
 
         it("should not allow multiple label classes", async () => {
@@ -553,7 +553,7 @@ describe("html-validate", () => {
                     </template>
                 </f-fieldset>
             `;
-            await expect(markup).toMatchInlineCodeframe(`""`);
+            await expect(markup).toBeValid();
         });
 
         it("should allow headings in label slot", async () => {
@@ -565,7 +565,7 @@ describe("html-validate", () => {
                     </template>
                 </f-fieldset>
             `;
-            await expect(markup).toMatchInlineCodeframe(`""`);
+            await expect(markup).toBeValid();
         });
 
         it("should not allow block elements in label slot", async () => {
@@ -600,7 +600,7 @@ describe("html-validate", () => {
                     </template>
                 </f-fieldset>
             `;
-            await expect(markup).toMatchInlineCodeframe(`""`);
+            await expect(markup).toBeValid();
         });
 
         it("should not allow block elements in description slot", async () => {
@@ -638,7 +638,7 @@ describe("html-validate", () => {
                     </template>
                 </f-fieldset>
             `;
-            await expect(markup).toMatchInlineCodeframe(`""`);
+            await expect(markup).toBeValid();
         });
 
         it("should not allow arbitrary elements in tooltip slot", async () => {

--- a/packages/vue/src/components/FFileSelector/FFileSelector.spec.ts
+++ b/packages/vue/src/components/FFileSelector/FFileSelector.spec.ts
@@ -122,7 +122,7 @@ describe("html-validate", () => {
             const invalid = /* HTML */ `
                 <f-file-selector disabled="foobar">text</f-file-selector>
             `;
-            await expect(valid).toMatchInlineCodeframe(`""`);
+            await expect(valid).toBeValid();
             await expect(invalid).toMatchInlineCodeframe(`
                 "error: Attribute "disabled" should omit value (attribute-boolean-style)
                   1 |

--- a/packages/vue/src/components/FIcon/FIcon.spec.ts
+++ b/packages/vue/src/components/FIcon/FIcon.spec.ts
@@ -1,23 +1,8 @@
 import { defineComponent } from "vue";
 import { type VueWrapper, mount } from "@vue/test-utils";
-import {
-    FileSystemConfigLoader,
-    HtmlValidate,
-    cjsResolver,
-} from "html-validate/node";
 import { describe, expect, it } from "vitest";
 import FIcon from "./FIcon.vue";
 import "html-validate/vitest";
-
-const loader = new FileSystemConfigLoader([cjsResolver()], {
-    extends: [
-        "html-validate:recommended",
-        "html-validate-vue:recommended",
-        "@fkui/vue:recommended",
-    ],
-    plugins: [`<rootDir>/htmlvalidate/index.cjs`, "html-validate-vue"],
-});
-const htmlvalidate = new HtmlValidate(loader);
 
 function createWrapper({
     props = {},
@@ -86,27 +71,22 @@ describe("props", () => {
                     <f-icon name="my-icon" flip="horizontal"></f-icon>
                     <f-icon name="my-icon" flip="vertical"></f-icon>
                 `;
-                const report = await htmlvalidate.validateString(
-                    markup,
-                    "foo.html",
-                );
-                await expect(report).toBeValid();
+                await expect(markup).toBeValid();
             });
 
             it("should not allow invalid values", async () => {
-                expect.assertions(2);
+                expect.assertions(1);
                 const markup = /* HTML */ `
                     <f-icon name="my-icon" flip="foo"></f-icon>
                 `;
-                const report = await htmlvalidate.validateString(
-                    markup,
-                    "file.html",
-                );
-                await expect(report).toBeInvalid();
-                expect(report).toHaveError(
-                    "attribute-allowed-values",
-                    'Attribute "flip" has invalid value "foo"',
-                );
+                await expect(markup).toMatchInlineCodeframe(`
+                  "error: Attribute "flip" has invalid value "foo" (attribute-allowed-values)
+                    1 |
+                  > 2 |                     <f-icon name="my-icon" flip="foo"></f-icon>
+                      |                                                  ^^^
+                    3 |
+                  Selector: f-icon"
+                `);
             });
         });
     });
@@ -138,18 +118,15 @@ describe("props", () => {
                     <f-icon name="my-icon" rotate="180"></f-icon>
                     <f-icon name="my-icon" rotate="270"></f-icon>
                 `;
-                const report = await htmlvalidate.validateString(markup);
-                await expect(report).toBeValid();
+                await expect(markup).toBeValid();
             });
 
             it("should not allow arbitrary degrees", async () => {
-                expect.assertions(2);
+                expect.assertions(1);
                 const markup = /* HTML */ `
                     <f-icon name="my-icon" rotate="42"></f-icon>
                 `;
-                const report = await htmlvalidate.validateString(markup);
-                await expect(report).toBeInvalid();
-                await expect(report).toMatchInlineCodeframe(`
+                await expect(markup).toMatchInlineCodeframe(`
                     "error: Attribute "rotate" has invalid value "42" (attribute-allowed-values)
                       1 |
                     > 2 |                     <f-icon name="my-icon" rotate="42"></f-icon>
@@ -160,13 +137,11 @@ describe("props", () => {
             });
 
             it("should not allow invalid values", async () => {
-                expect.assertions(2);
+                expect.assertions(1);
                 const markup = /* HTML */ `
                     <f-icon name="my-icon" rotate="foo"></f-icon>
                 `;
-                const report = await htmlvalidate.validateString(markup);
-                await expect(report).toBeInvalid();
-                await expect(report).toMatchInlineCodeframe(`
+                await expect(markup).toMatchInlineCodeframe(`
                     "error: Attribute "rotate" has invalid value "foo" (attribute-allowed-values)
                       1 |
                     > 2 |                     <f-icon name="my-icon" rotate="foo"></f-icon>

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.spec.ts
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.spec.ts
@@ -884,48 +884,79 @@ describe("html-validate", () => {
     it("should require `key-attribute` to be non-empty if used", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <f-interactive-table key-attribute=""></f-interactive-table>
+            <f-interactive-table rows key-attribute="">
+                <template #caption> lorem ipsum </template>
+                <template #default> </template>
+            </f-interactive-table>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message: 'Attribute "key-attribute" has invalid value ""',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "key-attribute" has invalid value "" (attribute-allowed-values)
+            1 |
+          > 2 |             <f-interactive-table rows key-attribute="">
+              |                                       ^^^^^^^^^^^^^
+            3 |                 <template #caption> lorem ipsum </template>
+            4 |                 <template #default> </template>
+            5 |             </f-interactive-table>
+          Selector: f-interactive-table"
+        `);
     });
 
     it("should require row attribute", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <f-interactive-table></f-interactive-table>
+            <f-interactive-table>
+                <template #caption> lorem ipsum </template>
+                <template #default> </template>
+            </f-interactive-table>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message:
-                '<f-interactive-table> is missing required "rows" attribute',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-interactive-table> is missing required "rows" attribute (element-required-attributes)
+            1 |
+          > 2 |             <f-interactive-table>
+              |              ^^^^^^^^^^^^^^^^^^^
+            3 |                 <template #caption> lorem ipsum </template>
+            4 |                 <template #default> </template>
+            5 |             </f-interactive-table>
+          Selector: f-interactive-table"
+        `);
     });
 
     it("should require caption slot", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <f-interactive-table></f-interactive-table>
+            <f-interactive-table rows>
+                <template #default> </template>
+            </f-interactive-table>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message:
-                '<f-interactive-table> component requires slot "caption" to be implemented',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-interactive-table> component requires slot "caption" to be implemented (vue/required-slots)
+            1 |
+          > 2 |             <f-interactive-table rows>
+              |              ^^^^^^^^^^^^^^^^^^^
+            3 |                 <template #default> </template>
+            4 |             </f-interactive-table>
+            5 |
+          Selector: f-interactive-table"
+        `);
     });
 
     it("should require default slot", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <f-interactive-table></f-interactive-table>
+            <f-interactive-table rows>
+                <template #caption> lorem ipsum </template>
+            </f-interactive-table>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message:
-                '<f-interactive-table> component requires slot "default" to be implemented',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-interactive-table> component requires slot "default" to be implemented (vue/required-slots)
+            1 |
+          > 2 |             <f-interactive-table rows>
+              |              ^^^^^^^^^^^^^^^^^^^
+            3 |                 <template #caption> lorem ipsum </template>
+            4 |             </f-interactive-table>
+            5 |
+          Selector: f-interactive-table"
+        `);
     });
 
     /* technical debt: this tests the wrong component */
@@ -946,7 +977,6 @@ describe("html-validate", () => {
                 E-post
             </f-email-text-field>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/components/FLayoutApplicationTemplate/FLayoutApplicationTemplate.spec.ts
+++ b/packages/vue/src/components/FLayoutApplicationTemplate/FLayoutApplicationTemplate.spec.ts
@@ -141,7 +141,6 @@ describe("html-validate", () => {
                 ${slotTemplates.join("")}
             </f-layout-application-template>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/components/FLayoutLeftPanel/FLayoutLeftPanel.spec.ts
+++ b/packages/vue/src/components/FLayoutLeftPanel/FLayoutLeftPanel.spec.ts
@@ -42,8 +42,7 @@ describe("html-validate", () => {
                 ${slotTemplates.join("")}
             </f-layout-left-panel>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should require defined slots", async () => {

--- a/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.spec.ts
+++ b/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.spec.ts
@@ -66,7 +66,6 @@ describe("html-validate", () => {
                 ${slotTemplates.join("")}
             </f-layout-right-panel>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/components/FList/FList.spec.ts
+++ b/packages/vue/src/components/FList/FList.spec.ts
@@ -653,20 +653,24 @@ describe("screenreader slot", () => {
 describe("html-validate", () => {
     it("should require `key-attribute` to be non-empty if used", async () => {
         expect.assertions(1);
-        const markup = /* HTML */ ` <f-list key-attribute=""></f-list> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message: 'Attribute "key-attribute" has invalid value ""',
-        });
+        const markup = /* HTML */ ` <f-list items key-attribute=""></f-list> `;
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "key-attribute" has invalid value "" (attribute-allowed-values)
+          > 1 |  <f-list items key-attribute=""></f-list>
+              |                ^^^^^^^^^^^^^
+          Selector: f-list"
+        `);
     });
 
     it("should require items attribute", async () => {
         expect.assertions(1);
         const markup = /* HTML */ ` <f-list></f-list> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message: '<f-list> is missing required "items" attribute',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-list> is missing required "items" attribute (element-required-attributes)
+          > 1 |  <f-list></f-list>
+              |   ^^^^^^
+          Selector: f-list"
+        `);
     });
 
     it("should allow aria-label or aria-labelledby", async () => {
@@ -677,8 +681,7 @@ describe("html-validate", () => {
             <h2 id="header">lorem ipsum</h2>
             <f-list :items="[]" aria-labelledby="header"></f-list>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should not allow empty aria-label", async () => {
@@ -686,10 +689,13 @@ describe("html-validate", () => {
         const markup = /* HTML */ `
             <f-list :items="[]" aria-label=""></f-list>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "attribute-allowed-values",
-            message: 'Attribute "aria-label" has invalid value ""',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "aria-label" has invalid value "" (attribute-allowed-values)
+            1 |
+          > 2 |             <f-list :items="[]" aria-label=""></f-list>
+              |                                 ^^^^^^^^^^
+            3 |
+          Selector: f-list"
+        `);
     });
 });

--- a/packages/vue/src/components/FLogo/FLogo.spec.ts
+++ b/packages/vue/src/components/FLogo/FLogo.spec.ts
@@ -1,9 +1,4 @@
 import { mount } from "@vue/test-utils";
-import {
-    FileSystemConfigLoader,
-    HtmlValidate,
-    cjsResolver,
-} from "html-validate/node";
 import { describe, expect, it } from "vitest";
 import "html-validate/vitest";
 import FLogo from "./FLogo.vue";
@@ -50,16 +45,6 @@ describe("size prop", () => {
 });
 
 describe("html-validate", () => {
-    const loader = new FileSystemConfigLoader([cjsResolver()], {
-        extends: [
-            "html-validate:recommended",
-            "html-validate-vue:recommended",
-            "@fkui/vue:recommended",
-        ],
-        plugins: [`<rootDir>/htmlvalidate/index.cjs`, "html-validate-vue"],
-    });
-    const htmlvalidate = new HtmlValidate(loader);
-
     it("should allow setting correct size values", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
@@ -67,15 +52,13 @@ describe("html-validate", () => {
             <f-logo size="large">foo</f-logo>
             <f-logo size="responsive">foo</f-logo>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should report error when size value is invalid", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `<f-logo size="huge">foo</f-logo>`;
-        const report = await htmlvalidate.validateString(markup);
-        await expect(report).toMatchInlineCodeframe(`
+        await expect(markup).toMatchInlineCodeframe(`
             "error: Attribute "size" has invalid value "huge" (attribute-allowed-values)
             > 1 | <f-logo size="huge">foo</f-logo>
                 |               ^^^^

--- a/packages/vue/src/components/FMessageBox/FMessageBox.spec.ts
+++ b/packages/vue/src/components/FMessageBox/FMessageBox.spec.ts
@@ -133,8 +133,7 @@ describe("html-validate", () => {
                 </template>
             </f-message-box>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should report error when obsolete heading slot is used", async () => {
@@ -144,15 +143,27 @@ describe("html-validate", () => {
                 <template v-slot:heading></template>
             </f-message-box>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate();
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-message-box> component has no slot "heading" (vue/available-slots)
+            1 |
+            2 |             <f-message-box type="warning">
+          > 3 |                 <template v-slot:heading></template>
+              |                           ^^^^^^^^^^^^^^
+            4 |             </f-message-box>
+            5 |
+          Selector: f-message-box"
+        `);
     });
 
     it("should report error when type is missing", async () => {
         expect.assertions(1);
         const markup = /* HTML */ ` <f-message-box></f-message-box> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate();
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-message-box> is missing required "type" attribute (element-required-attributes)
+          > 1 |  <f-message-box></f-message-box>
+              |   ^^^^^^^^^^^^^
+          Selector: f-message-box"
+        `);
     });
 
     it("should report error when type is invalid", async () => {
@@ -160,7 +171,13 @@ describe("html-validate", () => {
         const markup = /* HTML */ `
             <f-message-box type="foobar"></f-message-box>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate();
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "type" has invalid value "foobar" (attribute-allowed-values)
+            1 |
+          > 2 |             <f-message-box type="foobar"></f-message-box>
+              |                                  ^^^^^^
+            3 |
+          Selector: f-message-box"
+        `);
     });
 });

--- a/packages/vue/src/components/FModal/FFormModal/FFormModal.spec.ts
+++ b/packages/vue/src/components/FModal/FFormModal/FFormModal.spec.ts
@@ -380,18 +380,18 @@ describe("html-validate", () => {
     it("should allow usage without attributes, no attributes required", async () => {
         expect.assertions(1);
         const markup = /* HTML */ ` <f-form-modal></f-form-modal> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should not allow an invalid form-id attribute", async () => {
         expect.assertions(1);
         const markup = /* HTML */ ` <f-form-modal form-id="1"></f-form-modal> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "attribute-allowed-values",
-            message: 'Attribute "form-id" has invalid value "1"',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "form-id" has invalid value "1" (attribute-allowed-values)
+          > 1 |  <f-form-modal form-id="1"></f-form-modal>
+              |                         ^
+          Selector: f-form-modal"
+        `);
     });
 
     describe("attributes", () => {
@@ -404,8 +404,7 @@ describe("html-validate", () => {
                     <f-form-modal is-open></f-form-modal>
                     <f-form-modal :is-open="false"></f-form-modal>
                 `;
-                /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-                await expect(markup).toHTMLValidate();
+                await expect(markup).toBeValid();
             });
 
             it("should not allow empty string", async () => {
@@ -451,8 +450,7 @@ describe("html-validate", () => {
                 const markup = /* HTML */ `
                     <f-form-modal size="${size}"></f-form-modal>
                 `;
-                /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-                await expect(markup).toHTMLValidate();
+                await expect(markup).toBeValid();
             });
 
             it("fullscreen", async () => {
@@ -496,7 +494,6 @@ describe("html-validate", () => {
                 <template #input-text-fields></template>
             </f-form-modal>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/components/FNavigationMenu/FNavigationMenu.spec.ts
+++ b/packages/vue/src/components/FNavigationMenu/FNavigationMenu.spec.ts
@@ -183,8 +183,7 @@ describe("html-validate", () => {
         const markup = /* HTML */ `
             <f-navigation-menu routes="" vertical></f-navigation-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should not allow setting vertical value", async () => {
@@ -192,11 +191,14 @@ describe("html-validate", () => {
         const markup = /* HTML */ `
             <f-navigation-menu routes="" vertical=""></f-navigation-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "attribute-boolean-style",
-            message: 'Attribute "vertical" should omit value',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "vertical" should omit value (attribute-boolean-style)
+            1 |
+          > 2 |             <f-navigation-menu routes="" vertical=""></f-navigation-menu>
+              |                                          ^^^^^^^^
+            3 |
+          Selector: f-navigation-menu"
+        `);
     });
 
     it("should not be allowed in interactive components", async () => {
@@ -204,29 +206,47 @@ describe("html-validate", () => {
         const markup = /* HTML */ `
             <button type="button">
                 <f-navigation-menu routes=""></f-navigation-menu>
+                button text
             </button>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-permitted-content",
-            message:
-                "<f-navigation-menu> element is not permitted as content under <button>",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-navigation-menu> element is not permitted as content under <button> (element-permitted-content)
+            1 |
+            2 |             <button type="button">
+          > 3 |                 <f-navigation-menu routes=""></f-navigation-menu>
+              |                  ^^^^^^^^^^^^^^^^^
+            4 |                 button text
+            5 |             </button>
+            6 |
+          Selector: button > f-navigation-menu"
+        `);
     });
 
     it("should not allow interactive children", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
             <f-navigation-menu routes="">
-                <button type="button"></button>
+                <button type="button">button text</button>
             </f-navigation-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-permitted-content",
-            message:
-                "<button> element is not permitted as content under <f-navigation-menu>",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-navigation-menu> must not have text content (text-content)
+            1 |
+          > 2 |             <f-navigation-menu routes="">
+              |              ^^^^^^^^^^^^^^^^^
+            3 |                 <button type="button">button text</button>
+            4 |             </f-navigation-menu>
+            5 |
+          Selector: f-navigation-menu
+          error: <button> element is not permitted as content under <f-navigation-menu> (element-permitted-content)
+            1 |
+            2 |             <f-navigation-menu routes="">
+          > 3 |                 <button type="button">button text</button>
+              |                  ^^^^^^
+            4 |             </f-navigation-menu>
+            5 |
+          Selector: f-navigation-menu > button"
+        `);
     });
 
     it("should not allow child elements", async () => {
@@ -236,12 +256,16 @@ describe("html-validate", () => {
                 <em></em>
             </f-navigation-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-permitted-content",
-            message:
-                "<em> element is not permitted as content under <f-navigation-menu>",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <em> element is not permitted as content under <f-navigation-menu> (element-permitted-content)
+            1 |
+            2 |             <f-navigation-menu routes="">
+          > 3 |                 <em></em>
+              |                  ^^
+            4 |             </f-navigation-menu>
+            5 |
+          Selector: f-navigation-menu > em"
+        `);
     });
 
     it("should not allow text", async () => {
@@ -249,10 +273,13 @@ describe("html-validate", () => {
         const markup = /* HTML */ `
             <f-navigation-menu routes=""> mjukglass </f-navigation-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "text-content",
-            message: "<f-navigation-menu> must not have text content",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-navigation-menu> must not have text content (text-content)
+            1 |
+          > 2 |             <f-navigation-menu routes=""> mjukglass </f-navigation-menu>
+              |              ^^^^^^^^^^^^^^^^^
+            3 |
+          Selector: f-navigation-menu"
+        `);
     });
 });

--- a/packages/vue/src/components/FPageHeader/FPageHeader.spec.ts
+++ b/packages/vue/src/components/FPageHeader/FPageHeader.spec.ts
@@ -101,8 +101,7 @@ describe("html-validate", () => {
     it("should allow usage without attributes, no attributes required", async () => {
         expect.assertions(1);
         const markup = /* HTML */ ` <f-page-header></f-page-header> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should allow all slots", async () => {
@@ -113,8 +112,7 @@ describe("html-validate", () => {
             <f-page-header><template #default></template></f-page-header>
             <f-page-header><template #right></template></f-page-header>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("skip-link", async () => {
@@ -126,7 +124,7 @@ describe("html-validate", () => {
             <!-- omitted value -->
             <f-page-header skip-link></f-page-header>
         `;
-        await expect(valid).toMatchInlineCodeframe(`""`);
+        await expect(valid).toBeValid();
         await expect(invalid).toMatchInlineCodeframe(`
             "error: Attribute "skip-link" is missing value (attribute-allowed-values)
               1 |
@@ -144,8 +142,7 @@ describe("html-validate", () => {
             const markup = /* HTML */ `
                 <f-page-header header-tag="${headerTag}"></f-page-header>
             `;
-            /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-            await expect(markup).toHTMLValidate();
+            await expect(markup).toBeValid();
         });
 
         it("h2", async () => {

--- a/packages/vue/src/components/FSelectField/FSelectField.spec.ts
+++ b/packages/vue/src/components/FSelectField/FSelectField.spec.ts
@@ -248,8 +248,7 @@ describe("html-validate", () => {
                 <option>Apple</option>
             </f-select-field>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should be invalid", async () => {

--- a/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.spec.ts
+++ b/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.spec.ts
@@ -526,37 +526,59 @@ describe("html-validate", () => {
     it("should require data attribute", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <f-sort-filter-dataset></f-sort-filter-dataset>
+            <f-sort-filter-dataset sortable-attributes>
+                <template #default></template>
+            </f-sort-filter-dataset>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message:
-                '<f-sort-filter-dataset> is missing required "data" attribute',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-sort-filter-dataset> is missing required "data" attribute (element-required-attributes)
+            1 |
+          > 2 |             <f-sort-filter-dataset sortable-attributes>
+              |              ^^^^^^^^^^^^^^^^^^^^^
+            3 |                 <template #default></template>
+            4 |             </f-sort-filter-dataset>
+            5 |
+          Selector: f-sort-filter-dataset"
+        `);
     });
 
     it("should require sortable-attributes attribute", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <f-sort-filter-dataset></f-sort-filter-dataset>
+            <f-sort-filter-dataset data>
+                <template #default></template>
+            </f-sort-filter-dataset>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message:
-                '<f-sort-filter-dataset> is missing required "sortable-attributes" attribute',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-sort-filter-dataset> is missing required "sortable-attributes" attribute (element-required-attributes)
+            1 |
+          > 2 |             <f-sort-filter-dataset data>
+              |              ^^^^^^^^^^^^^^^^^^^^^
+            3 |                 <template #default></template>
+            4 |             </f-sort-filter-dataset>
+            5 |
+          Selector: f-sort-filter-dataset"
+        `);
     });
 
     it("should require default slot", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <f-sort-filter-dataset></f-sort-filter-dataset>
+            <f-sort-filter-dataset
+                data
+                sortable-attributes
+            ></f-sort-filter-dataset>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message:
-                '<f-sort-filter-dataset> component requires slot "default" to be implemented',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-sort-filter-dataset> component requires slot "default" to be implemented (vue/required-slots)
+            1 |
+          > 2 |             <f-sort-filter-dataset
+              |              ^^^^^^^^^^^^^^^^^^^^^
+            3 |                 data
+            4 |                 sortable-attributes
+            5 |             ></f-sort-filter-dataset>
+          Selector: f-sort-filter-dataset"
+        `);
     });
 
     it("html should be valid", async () => {
@@ -566,7 +588,6 @@ describe("html-validate", () => {
                 <template #default></template>
             </f-sort-filter-dataset>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/components/FTableButton/FTableButton.spec.ts
+++ b/packages/vue/src/components/FTableButton/FTableButton.spec.ts
@@ -140,7 +140,7 @@ describe("html-validate", () => {
                 <f-table-button>lorem ipsum</f-table-button>
             </f-table-column>
         `;
-        await expect(markup).toMatchInlineCodeframe(`""`);
+        await expect(markup).toBeValid();
     });
 
     it("should require FTableColumn ancestor", async () => {
@@ -165,7 +165,7 @@ describe("html-validate", () => {
                 <f-table-button>lorem ipsum</f-table-button>
             </f-table-column>
         `;
-        await expect(markup).toMatchInlineCodeframe(`""`);
+        await expect(markup).toBeValid();
     });
 
     it("should not allow empty icon prop", async () => {

--- a/packages/vue/src/components/FTableColumn/FTableColumn.spec.ts
+++ b/packages/vue/src/components/FTableColumn/FTableColumn.spec.ts
@@ -380,37 +380,55 @@ describe("html-validate", () => {
     it("should not allow invalid types", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <f-table-column type="foobar"></f-table-column>
+            <f-table-column title="Column title" type="foobar"></f-table-column>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message: 'Attribute "type" has invalid value "foobar"',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "type" has invalid value "foobar" (attribute-allowed-values)
+            1 |
+          > 2 |             <f-table-column title="Column title" type="foobar"></f-table-column>
+              |                                                        ^^^^^^
+            3 |
+          Selector: f-table-column"
+        `);
     });
 
     it("should not allow empty description", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <f-table-column description=""></f-table-column>
+            <f-table-column
+                title="Column title"
+                description=""
+            ></f-table-column>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message: 'Attribute "description" has invalid value ""',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "description" has invalid value "" (attribute-allowed-values)
+            2 |             <f-table-column
+            3 |                 title="Column title"
+          > 4 |                 description=""
+              |                 ^^^^^^^^^^^
+            5 |             ></f-table-column>
+            6 |
+          Selector: f-table-column"
+        `);
     });
 
     it("should not allow flow content", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <f-table-column>
+            <f-table-column title="Column title">
                 <div></div>
             </f-table-column>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            message:
-                "<div> element is not permitted as content under <f-table-column>",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <div> element is not permitted as content under <f-table-column> (element-permitted-content)
+            1 |
+            2 |             <f-table-column title="Column title">
+          > 3 |                 <div></div>
+              |                  ^^^
+            4 |             </f-table-column>
+            5 |
+          Selector: f-table-column > div"
+        `);
     });
 
     it("should allow phrasing content", async () => {
@@ -420,8 +438,7 @@ describe("html-validate", () => {
                 <span></span>
             </f-table-column>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should allow button content", async () => {
@@ -431,7 +448,6 @@ describe("html-validate", () => {
                 <button type="button">Foo</button>
             </f-table-column>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/components/FTextField/FTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/FTextField.spec.ts
@@ -590,19 +590,23 @@ describe("html-validate", () => {
         const valid = /* HTML */ `<f-tooltip
             screen-reader-text="lorem ipsum"
         />`;
-        const invalid = /* HTML */ `<div />`;
+        const invalid = /* HTML */ `<div></div>`;
         const markup = (child: string): string => /* HTML */ `
             <f-text-field v-validation.maxLength>
                 Label
                 <template #tooltip> ${child} </template>
             </f-text-field>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup(valid)).toHTMLValidate();
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup(invalid)).not.toHTMLValidate({
-            ruleId: "element-permitted-content",
-            message: `<div> element is not permitted as content under slot "tooltip" (<f-text-field>)`,
-        });
+        await expect(markup(valid)).toBeValid();
+        await expect(markup(invalid)).toMatchInlineCodeframe(`
+          "error: <div> element is not permitted as content under slot "tooltip" (<f-text-field>) (element-permitted-content)
+            2 |             <f-text-field v-validation.maxLength>
+            3 |                 Label
+          > 4 |                 <template #tooltip> <div></div> </template>
+              |                                      ^^^
+            5 |             </f-text-field>
+            6 |
+          Selector: f-text-field > template > div"
+        `);
     });
 });

--- a/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.spec.ts
@@ -400,8 +400,7 @@ describe("html-validate", () => {
                 E-post
             </f-email-text-field>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should allow custom label for default and extended field", async () => {
@@ -412,7 +411,6 @@ describe("html-validate", () => {
                 <template #extended-label> Upprepa e-post </template>
             </f-email-text-field>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.spec.ts
@@ -338,7 +338,6 @@ describe("html-validate", () => {
                 Telefonnummer
             </f-phone-text-field>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/components/FTextareaField/FTextareaField.spec.ts
+++ b/packages/vue/src/components/FTextareaField/FTextareaField.spec.ts
@@ -365,8 +365,7 @@ describe("html-validate", () => {
                 Label
             </f-textarea-field>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should be invalid", async () => {

--- a/packages/vue/src/components/FTooltip/FTooltip.spec.ts
+++ b/packages/vue/src/components/FTooltip/FTooltip.spec.ts
@@ -1,9 +1,4 @@
 import { type VueWrapper, mount } from "@vue/test-utils";
-import {
-    FileSystemConfigLoader,
-    HtmlValidate,
-    cjsResolver,
-} from "html-validate/node";
 import { describe, expect, it } from "vitest";
 import "html-validate/vitest";
 import FTooltip from "./FTooltip.vue";
@@ -93,16 +88,6 @@ describe("slots", () => {
 });
 
 describe("html-validate", () => {
-    const loader = new FileSystemConfigLoader([cjsResolver()], {
-        extends: [
-            "html-validate:recommended",
-            "html-validate-vue:recommended",
-            "@fkui/vue:recommended",
-        ],
-        plugins: [`<rootDir>/htmlvalidate/index.cjs`, "html-validate-vue"],
-    });
-    const htmlvalidate = new HtmlValidate(loader);
-
     it("close-button-text", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
@@ -124,8 +109,7 @@ describe("html-validate", () => {
                 screen-reader-text="foo"
             ></f-tooltip>
         `;
-        const report = htmlvalidate.validateString(markup);
-        await expect(report).toMatchInlineCodeframe(`
+        await expect(markup).toMatchInlineCodeframe(`
             "error: Attribute "close-button-text" is missing value (attribute-allowed-values)
               4 |
               5 |             <!-- should not allow omitted close-button-text value -->
@@ -172,8 +156,7 @@ describe("html-validate", () => {
             <f-tooltip header-tag="div" screen-reader-text="foo"></f-tooltip>
             <f-tooltip header-tag="span" screen-reader-text="foo"></f-tooltip>
         `;
-        const report = htmlvalidate.validateString(markup);
-        await expect(report).toMatchInlineCodeframe(`
+        await expect(markup).toMatchInlineCodeframe(`
             "error: Attribute "header-tag" is missing value (attribute-allowed-values)
               4 |
               5 |             <!-- omitted header-tag value -->
@@ -234,8 +217,7 @@ describe("html-validate", () => {
             <!-- should allow valid screen-reader-text -->
             <f-tooltip screen-reader-text="lorem ipsum"></f-tooltip>
         `;
-        const report = htmlvalidate.validateString(markup);
-        await expect(report).toMatchInlineCodeframe(`
+        await expect(markup).toMatchInlineCodeframe(`
             "error: <f-tooltip> is missing required "screen-reader-text" attribute (element-required-attributes)
               1 |
               2 |             <!-- should not allow missing screen-reader-text -->

--- a/packages/vue/src/components/FValidationForm/FValidationForm.spec.ts
+++ b/packages/vue/src/components/FValidationForm/FValidationForm.spec.ts
@@ -1,12 +1,6 @@
-import path from "node:path";
 import "html-validate/vitest";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
 import { type VueWrapper, mount } from "@vue/test-utils";
-import {
-    FileSystemConfigLoader,
-    HtmlValidate,
-    cjsResolver,
-} from "html-validate/node";
 import { describe, expect, it } from "vitest";
 import { ValidationPlugin } from "../../plugins";
 import { FTextField } from "../FTextField";
@@ -136,35 +130,19 @@ describe("events", () => {
 });
 
 describe("html-validate", () => {
-    const loader = new FileSystemConfigLoader([cjsResolver()], {
-        extends: [
-            "html-validate:recommended",
-            "html-validate-vue:recommended",
-            "@fkui/vue:recommended",
-        ],
-        plugins: [`<rootDir>/htmlvalidate/index.cjs`, "html-validate-vue"],
-        transform: {
-            ".*": "html-validate-vue:html",
-        },
-    });
-    const htmlvalidate = new HtmlValidate(loader);
-    const filename = path.basename(__filename);
-
     it("should allow flow content", async () => {
-        expect.assertions(2);
+        expect.assertions(1);
         const markup = /* HTML */ `
             <f-validation-form>
                 <div></div>
                 <button type="submit">submit</button>
             </f-validation-form>
         `;
-        const report = await htmlvalidate.validateString(markup, filename);
-        await expect(report).toMatchInlineCodeframe(`""`);
-        await expect(report).toBeValid();
+        await expect(markup).toBeValid();
     });
 
     it("should allow buttons in default slot", async () => {
-        expect.assertions(2);
+        expect.assertions(1);
         const markup = /* HTML */ `
             <f-validation-form>
                 <template #default>
@@ -173,13 +151,11 @@ describe("html-validate", () => {
                 </template>
             </f-validation-form>
         `;
-        const report = await htmlvalidate.validateString(markup, filename);
-        await expect(report).toMatchInlineCodeframe(`""`);
-        await expect(report).toBeValid();
+        await expect(markup).toBeValid();
     });
 
     it("should not allow flow content in error-message slot", async () => {
-        expect.assertions(2);
+        expect.assertions(1);
         const markup = /* HTML */ `
             <f-validation-form>
                 <template #error-message>
@@ -190,8 +166,7 @@ describe("html-validate", () => {
                 </template>
             </f-validation-form>
         `;
-        const report = await htmlvalidate.validateString(markup, filename);
-        await expect(report).toMatchInlineCodeframe(`
+        await expect(markup).toMatchInlineCodeframe(`
             "error: <div> element is not permitted as content under slot "error-message" (<f-validation-form>) (element-permitted-content)
               2 |             <f-validation-form>
               3 |                 <template #error-message>
@@ -202,11 +177,10 @@ describe("html-validate", () => {
               7 |                     <button type="submit">submit</button>
             Selector: f-validation-form > template:nth-child(1) > div"
         `);
-        await expect(report).toBeInvalid();
     });
 
     it("should allow heading and phrasing content in error-message slot", async () => {
-        expect.assertions(2);
+        expect.assertions(1);
         const markup = /* HTML */ `
             <f-validation-form>
                 <template #error-message>
@@ -218,13 +192,11 @@ describe("html-validate", () => {
                 </template>
             </f-validation-form>
         `;
-        const report = await htmlvalidate.validateString(markup, filename);
-        await expect(report).toMatchInlineCodeframe(`""`);
-        await expect(report).toBeValid();
+        await expect(markup).toBeValid();
     });
 
     it("should allow use-error-list setting via attribute", async () => {
-        expect.assertions(2);
+        expect.assertions(1);
         const markup = /* HTML */ `
             <f-validation-form use-error-list>
                 <template #default>
@@ -232,21 +204,17 @@ describe("html-validate", () => {
                 </template>
             </f-validation-form>
         `;
-        const report = await htmlvalidate.validateString(markup, filename);
-        await expect(report).toMatchInlineCodeframe(`""`);
-        await expect(report).toBeValid();
+        await expect(markup).toBeValid();
     });
 
     it("should require submit button", async () => {
-        expect.assertions(2);
+        expect.assertions(1);
         const markup = /* HTML */ ` <f-validation-form> </f-validation-form> `;
-        const report = await htmlvalidate.validateString(markup, filename);
-        await expect(report).toMatchInlineCodeframe(`
+        await expect(markup).toMatchInlineCodeframe(`
             "error: <f-validation-form> element must have a submit button (wcag/h32)
             > 1 |  <f-validation-form> </f-validation-form>
                 |   ^^^^^^^^^^^^^^^^^
             Selector: f-validation-form"
         `);
-        await expect(report).toBeInvalid();
     });
 });

--- a/packages/vue/src/components/FValidationGroup/FValidationGroup.spec.ts
+++ b/packages/vue/src/components/FValidationGroup/FValidationGroup.spec.ts
@@ -3,11 +3,6 @@ import { defineComponent } from "vue";
 import { type ValidatableHTMLElement } from "@fkui/logic";
 import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
-import {
-    FileSystemConfigLoader,
-    HtmlValidate,
-    cjsResolver,
-} from "html-validate/node";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     type ComponentUnmountEvent,
@@ -359,16 +354,6 @@ describe("v-model", () => {
 });
 
 describe("html-validate", () => {
-    const loader = new FileSystemConfigLoader([cjsResolver()], {
-        extends: [
-            "html-validate:recommended",
-            "html-validate-vue:recommended",
-            "@fkui/vue:recommended",
-        ],
-        plugins: [`<rootDir>/htmlvalidate/index.cjs`, "html-validate-vue"],
-    });
-    const htmlvalidate = new HtmlValidate(loader);
-
     describe("key attribute", () => {
         it("should be required", async () => {
             expect.assertions(1);
@@ -376,8 +361,7 @@ describe("html-validate", () => {
                 <f-validation-group></f-validation-group>
                 <f-validation-group key=""></f-validation-group>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
                 "error: <f-validation-group> is missing required "key" attribute (element-required-attributes)
                   1 |
                 > 2 |                 <f-validation-group></f-validation-group>
@@ -397,24 +381,20 @@ describe("html-validate", () => {
     });
 
     describe("stop-propagation attribute", () => {
-        it.each`
-            stopPropagation
-            ${"true"}
-            ${"false"}
-        `(
-            "valid when value is $stopPropagation",
-            async ({ stopPropagation }) => {
-                expect.assertions(1);
-                const markup = /* HTML */ `
-                    <f-validation-group
-                        stop-propagation="${String(stopPropagation)}"
-                        key="key"
-                    ></f-validation-group>
-                `;
-                const report = await htmlvalidate.validateString(markup);
-                await expect(report).toBeValid();
-            },
-        );
+        it("valid", async () => {
+            expect.assertions(1);
+            const markup = /* HTML */ `
+                <f-validation-group
+                    stop-propagation="true"
+                    key="key"
+                ></f-validation-group>
+                <f-validation-group
+                    stop-propagation="false"
+                    key="key"
+                ></f-validation-group>
+            `;
+            await expect(markup).toBeValid();
+        });
 
         it("invalid", async () => {
             expect.assertions(1);
@@ -424,8 +404,7 @@ describe("html-validate", () => {
                     key="key"
                 ></f-validation-group>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
                 "error: Attribute "stop-propagation" has invalid value "invalid" (attribute-allowed-values)
                   1 |
                   2 |                 <f-validation-group

--- a/packages/vue/src/components/FWizard/FWizard.spec.ts
+++ b/packages/vue/src/components/FWizard/FWizard.spec.ts
@@ -9,18 +9,18 @@ describe("html-validate", () => {
                 <div></div>
             </f-wizard>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should require header-tag attribute", async () => {
         expect.assertions(1);
         const markup = /* HTML */ ` <f-wizard></f-wizard> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-required-attributes",
-            message: '<f-wizard> is missing required "header-tag" attribute',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <f-wizard> is missing required "header-tag" attribute (element-required-attributes)
+          > 1 |  <f-wizard></f-wizard>
+              |   ^^^^^^^^
+          Selector: f-wizard"
+        `);
     });
 
     it("should allow h{1..6} header-tag attribute", async () => {
@@ -33,17 +33,17 @@ describe("html-validate", () => {
             <f-wizard header-tag="h5"></f-wizard>
             <f-wizard header-tag="h6"></f-wizard>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should not allow invalid header-tag attribute", async () => {
         expect.assertions(1);
         const markup = /* HTML */ ` <f-wizard header-tag="foobar"></f-wizard> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "attribute-allowed-values",
-            message: 'Attribute "header-tag" has invalid value "foobar"',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "header-tag" has invalid value "foobar" (attribute-allowed-values)
+          > 1 |  <f-wizard header-tag="foobar"></f-wizard>
+              |                        ^^^^^^
+          Selector: f-wizard"
+        `);
     });
 });

--- a/packages/vue/src/components/FWizard/FWizardStep.spec.ts
+++ b/packages/vue/src/components/FWizard/FWizardStep.spec.ts
@@ -128,7 +128,7 @@ describe("html-validate", () => {
                 </f-wizard-step>
             </f-wizard>
         `;
-        await expect(markup).toMatchInlineCodeframe(`""`);
+        await expect(markup).toBeValid();
     });
 
     it("should allow flow content in default slot", async () => {
@@ -142,7 +142,7 @@ describe("html-validate", () => {
                 </f-wizard-step>
             </f-wizard>
         `;
-        await expect(markup).toMatchInlineCodeframe(`""`);
+        await expect(markup).toBeValid();
     });
 
     it("should allow flow content in step-of slot", async () => {
@@ -156,7 +156,7 @@ describe("html-validate", () => {
                 </f-wizard-step>
             </f-wizard>
         `;
-        await expect(markup).toMatchInlineCodeframe(`""`);
+        await expect(markup).toBeValid();
     });
 
     it("should allow flow content in error-message slot", async () => {
@@ -170,7 +170,7 @@ describe("html-validate", () => {
                 </f-wizard-step>
             </f-wizard>
         `;
-        await expect(markup).toMatchInlineCodeframe(`""`);
+        await expect(markup).toBeValid();
     });
 
     it("should allow phrasing content in next-button-text slot", async () => {
@@ -184,7 +184,7 @@ describe("html-validate", () => {
                 </f-wizard-step>
             </f-wizard>
         `;
-        await expect(markup).toMatchInlineCodeframe(`""`);
+        await expect(markup).toBeValid();
     });
 
     it("should not allow flow content in next-button-text slot", async () => {
@@ -246,7 +246,7 @@ describe("html-validate", () => {
                 </f-wizard-step>
             </f-wizard>
         `;
-        await expect(markup).toMatchInlineCodeframe(`""`);
+        await expect(markup).toBeValid();
     });
 
     it("should not allow flow content in cancel-button-text slot", async () => {

--- a/packages/vue/src/internal-components/IAnimateExpand/IAnimateExpand.spec.ts
+++ b/packages/vue/src/internal-components/IAnimateExpand/IAnimateExpand.spec.ts
@@ -259,8 +259,7 @@ describe("html-validate", () => {
                 <i-animate-expand></i-animate-expand>
             </i-animate-expand>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it.each(["animate", "opacity", "use-v-show"])(
@@ -270,8 +269,7 @@ describe("html-validate", () => {
             const markup = /* HTML */ `
                 <i-animate-expand ${attr}></i-animate-expand>
             `;
-            /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-            await expect(markup).toHTMLValidate();
+            await expect(markup).toBeValid();
         },
     );
 
@@ -303,8 +301,7 @@ describe("html-validate", () => {
         const markup = /* HTML */ `
             <i-animate-expand expanded="${String(value)}"></i-animate-expand>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });
 

--- a/packages/vue/src/internal-components/IFlex/IFlex.spec.ts
+++ b/packages/vue/src/internal-components/IFlex/IFlex.spec.ts
@@ -1,9 +1,4 @@
 import { mount } from "@vue/test-utils";
-import {
-    FileSystemConfigLoader,
-    HtmlValidate,
-    cjsResolver,
-} from "html-validate/node";
 import { describe, expect, it } from "vitest";
 import "html-validate/vitest";
 import IFlex from "./IFlex.vue";
@@ -122,16 +117,6 @@ it("should have collapse class when collapse is specified", () => {
 });
 
 describe("html-validate", () => {
-    const loader = new FileSystemConfigLoader([cjsResolver()], {
-        extends: [
-            "html-validate:recommended",
-            "html-validate-vue:recommended",
-            "@fkui/vue:recommended",
-        ],
-        plugins: [`<rootDir>/htmlvalidate/index.cjs`, "html-validate-vue"],
-    });
-    const htmlvalidate = new HtmlValidate(loader);
-
     it("should allow <i-flex-item> as children", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
@@ -139,47 +124,49 @@ describe("html-validate", () => {
                 <i-flex-item></i-flex-item>
             </i-flex>
         `;
-        const report = await htmlvalidate.validateString(markup);
-        await expect(report).toBeValid();
+        await expect(markup).toBeValid();
     });
 
     it("should not allow arbitrary content", async () => {
-        expect.assertions(2);
+        expect.assertions(1);
         const markup = /* HTML */ `
             <i-flex>
                 <div></div>
                 <span></span>
             </i-flex>
         `;
-        const report = await htmlvalidate.validateString(markup);
-        await expect(report).toBeInvalid();
-        expect(report).toHaveErrors([
-            {
-                ruleId: "element-permitted-content",
-                message:
-                    "<div> element is not permitted as content under <i-flex>",
-            },
-            {
-                ruleId: "element-permitted-content",
-                message:
-                    "<span> element is not permitted as content under <i-flex>",
-            },
-        ]);
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <div> element is not permitted as content under <i-flex> (element-permitted-content)
+            1 |
+            2 |             <i-flex>
+          > 3 |                 <div></div>
+              |                  ^^^
+            4 |                 <span></span>
+            5 |             </i-flex>
+            6 |
+          Selector: i-flex > div
+          error: <span> element is not permitted as content under <i-flex> (element-permitted-content)
+            2 |             <i-flex>
+            3 |                 <div></div>
+          > 4 |                 <span></span>
+              |                  ^^^^
+            5 |             </i-flex>
+            6 |
+          Selector: i-flex > span"
+        `);
     });
 
     describe("gap attribute", () => {
         it.each(GAP)("%s", async (gap) => {
             expect.assertions(1);
             const markup = /* HTML */ ` <i-flex gap="${gap}"></i-flex> `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeValid();
+            await expect(markup).toBeValid();
         });
 
         it("invalid", async () => {
             expect.assertions(1);
             const markup = /* HTML */ ` <i-flex gap="invalid"></i-flex> `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
                 "error: Attribute "gap" has invalid value "invalid" (attribute-allowed-values)
                 > 1 |  <i-flex gap="invalid"></i-flex>
                     |               ^^^^^^^

--- a/packages/vue/src/internal-components/IFlex/IFlexItem.spec.ts
+++ b/packages/vue/src/internal-components/IFlex/IFlexItem.spec.ts
@@ -1,9 +1,4 @@
 import { mount } from "@vue/test-utils";
-import {
-    FileSystemConfigLoader,
-    HtmlValidate,
-    cjsResolver,
-} from "html-validate/node";
 import { describe, expect, it } from "vitest";
 import "html-validate/vitest";
 import IFlexItem from "./IFlexItem.vue";
@@ -73,16 +68,6 @@ describe("prop grow/shrink", () => {
 });
 
 describe("html-validate", () => {
-    const loader = new FileSystemConfigLoader([cjsResolver()], {
-        extends: [
-            "html-validate:recommended",
-            "html-validate-vue:recommended",
-            "@fkui/vue:recommended",
-        ],
-        plugins: [`<rootDir>/htmlvalidate/index.cjs`, "html-validate-vue"],
-    });
-    const htmlvalidate = new HtmlValidate(loader);
-
     it("should allow <i-flex> as parent", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
@@ -90,20 +75,17 @@ describe("html-validate", () => {
                 <i-flex-item></i-flex-item>
             </i-flex>
         `;
-        const report = await htmlvalidate.validateString(markup);
-        await expect(report).toBeValid();
+        await expect(markup).toBeValid();
     });
 
     it("should not allow arbitrary element as parent", async () => {
-        expect.assertions(2);
+        expect.assertions(1);
         const markup = /* HTML */ `
             <div>
                 <i-flex-item></i-flex-item>
             </div>
         `;
-        const report = await htmlvalidate.validateString(markup);
-        await expect(report).toBeInvalid();
-        await expect(report).toMatchInlineCodeframe(`
+        await expect(markup).toMatchInlineCodeframe(`
             "error: <i-flex-item> element requires a "i-flex > i-flex-item" ancestor (element-required-ancestor)
               1 |
               2 |             <div>
@@ -123,20 +105,17 @@ describe("html-validate", () => {
                     <i-flex-item align="${align}"></i-flex-item>
                 </i-flex>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeValid();
+            await expect(markup).toBeValid();
         });
 
         it("invalid", async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const markup = /* HTML */ `
                 <i-flex>
                     <i-flex-item align="invalid"></i-flex-item>
                 </i-flex>
             `;
-            const report = await htmlvalidate.validateString(markup);
-            await expect(report).toBeInvalid();
-            await expect(report).toMatchInlineCodeframe(`
+            await expect(markup).toMatchInlineCodeframe(`
                 "error: Attribute "align" has invalid value "invalid" (attribute-allowed-values)
                   1 |
                   2 |                 <i-flex>

--- a/packages/vue/src/internal-components/IPopup/IPopup.spec.ts
+++ b/packages/vue/src/internal-components/IPopup/IPopup.spec.ts
@@ -136,22 +136,24 @@ describe("events", () => {
 describe("html-validate", () => {
     it("should require is-open attribute", async () => {
         expect.assertions(1);
-        const markup = /* HTML */ ` <i-popup></i-popup> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-required-attributes",
-            message: '<i-popup> is missing required "is-open" attribute',
-        });
+        const markup = /* HTML */ ` <i-popup anchor></i-popup> `;
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <i-popup> is missing required "is-open" attribute (element-required-attributes)
+          > 1 |  <i-popup anchor></i-popup>
+              |   ^^^^^^^
+          Selector: i-popup"
+        `);
     });
 
     it("should require anchor attribute", async () => {
         expect.assertions(1);
-        const markup = /* HTML */ ` <i-popup></i-popup> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-required-attributes",
-            message: '<i-popup> is missing required "anchor" attribute',
-        });
+        const markup = /* HTML */ ` <i-popup is-open></i-popup> `;
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <i-popup> is missing required "anchor" attribute (element-required-attributes)
+          > 1 |  <i-popup is-open></i-popup>
+              |   ^^^^^^^
+          Selector: i-popup"
+        `);
     });
 
     it("should only allow setting valid `inline` values", async () => {
@@ -164,13 +166,15 @@ describe("html-validate", () => {
         const markupInvalid = /* HTML */ `
             <i-popup anchor="anchorref" is-open inline="foo"></i-popup>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markupValid).toHTMLValidate();
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markupInvalid).not.toHTMLValidate({
-            ruleId: "attribute-allowed-values",
-            message: 'Attribute "inline" has invalid value "foo"',
-        });
+        await expect(markupValid).toBeValid();
+        await expect(markupInvalid).toMatchInlineCodeframe(`
+          "error: Attribute "inline" has invalid value "foo" (attribute-allowed-values)
+            1 |
+          > 2 |             <i-popup anchor="anchorref" is-open inline="foo"></i-popup>
+              |                                                         ^^^
+            3 |
+          Selector: i-popup"
+        `);
     });
 
     it("should allow setting viewport value", async () => {
@@ -182,8 +186,7 @@ describe("html-validate", () => {
                 viewport="viewportref"
             ></i-popup>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should allow setting focus-element value", async () => {
@@ -195,7 +198,6 @@ describe("html-validate", () => {
                 focus-element="focuselementref"
             ></i-popup>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 });

--- a/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.spec.ts
+++ b/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.spec.ts
@@ -176,12 +176,13 @@ describe("v-model", () => {
 describe("html-validate", () => {
     it("should require is-open attribute", async () => {
         expect.assertions(1);
-        const markup = /* HTML */ ` <i-popup-menu></i-popup-menu> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-required-attributes",
-            message: '<i-popup-menu> is missing required "is-open" attribute',
-        });
+        const markup = /* HTML */ ` <i-popup-menu items></i-popup-menu> `;
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <i-popup-menu> is missing required "is-open" attribute (element-required-attributes)
+          > 1 |  <i-popup-menu items></i-popup-menu>
+              |   ^^^^^^^^^^^^
+          Selector: i-popup-menu"
+        `);
     });
 
     it("should allow setting is-open boolean attribute", async () => {
@@ -189,8 +190,7 @@ describe("html-validate", () => {
         const markup = /* HTML */ `
             <i-popup-menu is-open items=""></i-popup-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should not allow setting is-open value", async () => {
@@ -198,11 +198,14 @@ describe("html-validate", () => {
         const markup = /* HTML */ `
             <i-popup-menu is-open="" items=""></i-popup-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "attribute-boolean-style",
-            message: 'Attribute "is-open" should omit value',
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: Attribute "is-open" should omit value (attribute-boolean-style)
+            1 |
+          > 2 |             <i-popup-menu is-open="" items=""></i-popup-menu>
+              |                           ^^^^^^^
+            3 |
+          Selector: i-popup-menu"
+        `);
     });
 
     it("should allow setting anchor attribute", async () => {
@@ -210,74 +213,99 @@ describe("html-validate", () => {
         const markup = /* HTML */ `
             <i-popup-menu is-open items="" anchor=""></i-popup-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).toHTMLValidate();
+        await expect(markup).toBeValid();
     });
 
     it("should require items attribute", async () => {
         expect.assertions(1);
-        const markup = /* HTML */ ` <i-popup-menu></i-popup-menu> `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-required-attributes",
-            message: '<i-popup-menu> is missing required "items" attribute',
-        });
+        const markup = /* HTML */ ` <i-popup-menu is-open></i-popup-menu> `;
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <i-popup-menu> is missing required "items" attribute (element-required-attributes)
+          > 1 |  <i-popup-menu is-open></i-popup-menu>
+              |   ^^^^^^^^^^^^
+          Selector: i-popup-menu"
+        `);
     });
 
     it("should not be allowed in interactive components", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
             <button type="button">
-                <i-popup-menu items=""></i-popup-menu>
+                <i-popup-menu is-open items></i-popup-menu>
+                button text
             </button>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-permitted-content",
-            message:
-                "<i-popup-menu> element is not permitted as content under <button>",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <i-popup-menu> element is not permitted as content under <button> (element-permitted-content)
+            1 |
+            2 |             <button type="button">
+          > 3 |                 <i-popup-menu is-open items></i-popup-menu>
+              |                  ^^^^^^^^^^^^
+            4 |                 button text
+            5 |             </button>
+            6 |
+          Selector: button > i-popup-menu"
+        `);
     });
 
     it("should not allow interactive children", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <i-popup-menu items="">
-                <button type="button"></button>
+            <i-popup-menu is-open items>
+                <button type="button">button text</button>
             </i-popup-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-permitted-content",
-            message:
-                "<button> element is not permitted as content under <i-popup-menu>",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <i-popup-menu> must not have text content (text-content)
+            1 |
+          > 2 |             <i-popup-menu is-open items>
+              |              ^^^^^^^^^^^^
+            3 |                 <button type="button">button text</button>
+            4 |             </i-popup-menu>
+            5 |
+          Selector: i-popup-menu
+          error: <button> element is not permitted as content under <i-popup-menu> (element-permitted-content)
+            1 |
+            2 |             <i-popup-menu is-open items>
+          > 3 |                 <button type="button">button text</button>
+              |                  ^^^^^^
+            4 |             </i-popup-menu>
+            5 |
+          Selector: i-popup-menu > button"
+        `);
     });
 
     it("should not allow child elements", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <i-popup-menu items="">
+            <i-popup-menu is-open items>
                 <em></em>
             </i-popup-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "element-permitted-content",
-            message:
-                "<em> element is not permitted as content under <i-popup-menu>",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <em> element is not permitted as content under <i-popup-menu> (element-permitted-content)
+            1 |
+            2 |             <i-popup-menu is-open items>
+          > 3 |                 <em></em>
+              |                  ^^
+            4 |             </i-popup-menu>
+            5 |
+          Selector: i-popup-menu > em"
+        `);
     });
 
     it("should not allow text", async () => {
         expect.assertions(1);
         const markup = /* HTML */ `
-            <i-popup-menu items=""> mjukglass </i-popup-menu>
+            <i-popup-menu is-open items> mjukglass </i-popup-menu>
         `;
-        /* eslint-disable-next-line @typescript-eslint/await-thenable -- upstream typings are wrong */
-        await expect(markup).not.toHTMLValidate({
-            ruleId: "text-content",
-            message: "<i-popup-menu> must not have text content",
-        });
+        await expect(markup).toMatchInlineCodeframe(`
+          "error: <i-popup-menu> must not have text content (text-content)
+            1 |
+          > 2 |             <i-popup-menu is-open items> mjukglass </i-popup-menu>
+              |              ^^^^^^^^^^^^
+            3 |
+          Selector: i-popup-menu"
+        `);
     });
 });


### PR DESCRIPTION
Efter vitest migreringen kan vi nu förenkla dessa tester.