### PR TITLE
refactor: use explicit type imports in `*.spec.ts` (refs SFKUI-6500)

### DIFF
--- a/packages/vue-labs/src/components/XTimeTextField/XTimeTextField.spec.ts
+++ b/packages/vue-labs/src/components/XTimeTextField/XTimeTextField.spec.ts
@@ -1,6 +1,6 @@
 import { defineComponent } from "vue";
 import { ValidationPlugin } from "@fkui/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import XTimeTextField from "./XTimeTextField.vue";
 

--- a/packages/vue/src/components/FBadge/FBadge.spec.ts
+++ b/packages/vue/src/components/FBadge/FBadge.spec.ts
@@ -1,4 +1,4 @@
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import FBadge from "./FBadge.vue";
 import { statuses } from "./statuses";

--- a/packages/vue/src/components/FCard/FCard.spec.ts
+++ b/packages/vue/src/components/FCard/FCard.spec.ts
@@ -1,4 +1,4 @@
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import {
     FileSystemConfigLoader,
     HtmlValidate,

--- a/packages/vue/src/components/FCheckboxField/FCheckboxField.spec.ts
+++ b/packages/vue/src/components/FCheckboxField/FCheckboxField.spec.ts
@@ -1,5 +1,5 @@
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 import FCheckboxField from "./FCheckboxField.vue";
 

--- a/packages/vue/src/components/FContextMenu/FContextMenu.spec.ts
+++ b/packages/vue/src/components/FContextMenu/FContextMenu.spec.ts
@@ -2,7 +2,7 @@ import { defineComponent } from "vue";
 import "html-validate/vitest";
 import "@fkui/test-utils/vitest";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { config } from "../../config";

--- a/packages/vue/src/components/FCrudDataset/FCrudButton.spec.ts
+++ b/packages/vue/src/components/FCrudDataset/FCrudButton.spec.ts
@@ -1,5 +1,5 @@
 import "html-validate/vitest";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import FCrudButton from "./FCrudButton.vue";
 

--- a/packages/vue/src/components/FCrudDataset/FCrudDataset.spec.ts
+++ b/packages/vue/src/components/FCrudDataset/FCrudDataset.spec.ts
@@ -2,11 +2,11 @@ import "html-validate/vitest";
 import { type PropType, defineComponent, h } from "vue";
 import * as logic from "@fkui/logic";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount, shallowMount } from "@vue/test-utils";
+import { type VueWrapper, mount, shallowMount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { ValidationPlugin } from "../../plugins";
-import { ListItem } from "../../types";
+import { type ListItem } from "../../types";
 import {
     type FModalSize,
     FFormModal,

--- a/packages/vue/src/components/FDataTable/FDataTable.spec.ts
+++ b/packages/vue/src/components/FDataTable/FDataTable.spec.ts
@@ -3,7 +3,7 @@ import { defineComponent } from "vue";
 import { mount } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TranslationPlugin } from "../../plugins";
-import { FSortFilterDatasetMountCallback } from "../FSortFilterDataset";
+import { type FSortFilterDatasetMountCallback } from "../FSortFilterDataset";
 import { FTableColumn } from "../FTableColumn";
 import FDataTable from "./FDataTable.vue";
 

--- a/packages/vue/src/components/FDefinitionList/FDefinitionList.spec.ts
+++ b/packages/vue/src/components/FDefinitionList/FDefinitionList.spec.ts
@@ -1,7 +1,7 @@
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import FDefinitionList from "./FDefinitionList.vue";
-import { FDefinitionListItem } from "./f-definition-list-item";
+import { type FDefinitionListItem } from "./f-definition-list-item";
 
 const definitions = [
     { term: "Term 1", definition: "Description 1" },

--- a/packages/vue/src/components/FErrorList/FErrorList.spec.ts
+++ b/packages/vue/src/components/FErrorList/FErrorList.spec.ts
@@ -3,7 +3,7 @@ import "@fkui/test-utils/vitest";
 import { defineComponent } from "vue";
 import * as logic from "@fkui/logic";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import {
     FileSystemConfigLoader,
@@ -12,7 +12,7 @@ import {
 } from "html-validate/node";
 import { describe, expect, it, vi } from "vitest";
 import { IFlexItem } from "../../internal-components/IFlex";
-import { ErrorItem } from "../../types";
+import { type ErrorItem } from "../../types";
 import { FIcon } from "../FIcon";
 import FErrorList from "./FErrorList.vue";
 

--- a/packages/vue/src/components/FErrorList/focus-error.spec.ts
+++ b/packages/vue/src/components/FErrorList/focus-error.spec.ts
@@ -1,6 +1,6 @@
 import * as logic from "@fkui/logic";
 import { beforeAll, expect, it, vi } from "vitest";
-import { ErrorItem } from "../../types";
+import { type ErrorItem } from "../../types";
 import { focusError } from "./focus-error";
 
 vi.mock(import("@fkui/logic"));

--- a/packages/vue/src/components/FExpand/FExpand.spec.ts
+++ b/packages/vue/src/components/FExpand/FExpand.spec.ts
@@ -1,4 +1,4 @@
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import FExpand from "./FExpand.vue";
 

--- a/packages/vue/src/components/FExpandablePanel/FExpandablePanel.spec.ts
+++ b/packages/vue/src/components/FExpandablePanel/FExpandablePanel.spec.ts
@@ -1,4 +1,4 @@
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { type ConfigData } from "html-validate";
 import { describe, expect, it, vi } from "vitest";
 import FExpandablePanel from "./FExpandablePanel.vue";

--- a/packages/vue/src/components/FExpandableParagraph/FExpandableParagraph.spec.ts
+++ b/packages/vue/src/components/FExpandableParagraph/FExpandableParagraph.spec.ts
@@ -1,4 +1,4 @@
-import { VueWrapper, mount, shallowMount } from "@vue/test-utils";
+import { type VueWrapper, mount, shallowMount } from "@vue/test-utils";
 import { type ConfigData } from "html-validate";
 import { describe, expect, it, vi } from "vitest";
 import FExpandableParagraph from "./FExpandableParagraph.vue";

--- a/packages/vue/src/components/FFieldset/FFieldset.spec.ts
+++ b/packages/vue/src/components/FFieldset/FFieldset.spec.ts
@@ -5,10 +5,10 @@ import {
     type ValidityEvent,
     type ValidityMode,
 } from "@fkui/logic";
-import { VueWrapper, mount, shallowMount } from "@vue/test-utils";
+import { type VueWrapper, mount, shallowMount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { describe, expect, it, vi } from "vitest";
-import { ComponentValidityEvent } from "../../types";
+import { type ComponentValidityEvent } from "../../types";
 import { FIcon } from "../FIcon";
 import FFieldset from "./FFieldset.vue";
 import { useFieldset } from "./use-fieldset";

--- a/packages/vue/src/components/FFileItem/FFileItem.spec.ts
+++ b/packages/vue/src/components/FFileItem/FFileItem.spec.ts
@@ -1,4 +1,4 @@
-import { VueWrapper, shallowMount } from "@vue/test-utils";
+import { type VueWrapper, shallowMount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 import { TranslationPlugin } from "../../plugins";
 import FFileItem from "./FFileItem.vue";

--- a/packages/vue/src/components/FFileSelector/FFileSelector.spec.ts
+++ b/packages/vue/src/components/FFileSelector/FFileSelector.spec.ts
@@ -1,5 +1,5 @@
 import "html-validate/vitest";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 import FFileSelector from "./FFileSelector.vue";
 

--- a/packages/vue/src/components/FIcon/FIcon.spec.ts
+++ b/packages/vue/src/components/FIcon/FIcon.spec.ts
@@ -1,5 +1,5 @@
 import { defineComponent } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import {
     FileSystemConfigLoader,
     HtmlValidate,

--- a/packages/vue/src/components/FInteractiveTable/FInteractiveTable.spec.ts
+++ b/packages/vue/src/components/FInteractiveTable/FInteractiveTable.spec.ts
@@ -1,8 +1,8 @@
 import "html-validate/vitest";
 import { type ComponentOptions, defineComponent } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { FSortFilterDatasetMountCallback } from "../FSortFilterDataset";
+import { type FSortFilterDatasetMountCallback } from "../FSortFilterDataset";
 import { FTableColumn } from "../FTableColumn";
 import FInteractiveTable from "./FInteractiveTable.vue";
 

--- a/packages/vue/src/components/FInteractiveTable/use-expandable-table.spec.ts
+++ b/packages/vue/src/components/FInteractiveTable/use-expandable-table.spec.ts
@@ -1,5 +1,5 @@
 import "html-validate/vitest";
-import { defineComponent } from "vue";
+import { type defineComponent } from "vue";
 import { mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import { FTableColumn } from "../FTableColumn";

--- a/packages/vue/src/components/FLabel/FLabel.spec.ts
+++ b/packages/vue/src/components/FLabel/FLabel.spec.ts
@@ -1,5 +1,5 @@
 import "html-validate/vitest";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import FLabel from "./FLabel.vue";
 

--- a/packages/vue/src/components/FLayoutApplicationTemplate/FLayoutApplicationTemplate.spec.ts
+++ b/packages/vue/src/components/FLayoutApplicationTemplate/FLayoutApplicationTemplate.spec.ts
@@ -1,5 +1,5 @@
 import "html-validate/vitest";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import FLayoutApplicationTemplate from "./FLayoutApplicationTemplate.vue";
 

--- a/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.spec.ts
+++ b/packages/vue/src/components/FLayoutRightPanel/FLayoutRightPanel.spec.ts
@@ -1,7 +1,7 @@
 import "html-validate/vitest";
 import "@fkui/test-utils/vitest";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, flushPromises, mount } from "@vue/test-utils";
+import { type VueWrapper, flushPromises, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import FLayoutRightPanel from "./FLayoutRightPanel.vue";
 import { FLayoutRightPanelService } from "./services/f-layout-right-panel-service";

--- a/packages/vue/src/components/FList/FList.spec.ts
+++ b/packages/vue/src/components/FList/FList.spec.ts
@@ -1,9 +1,9 @@
 import "html-validate/vitest";
 import { defineComponent } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TranslationPlugin } from "../../plugins";
-import { ListArray, UnknownItem } from "../../types";
+import { type ListArray, type UnknownItem } from "../../types";
 import * as ListUtils from "../../utils/list-utils";
 import FList from "./FList.vue";
 

--- a/packages/vue/src/components/FModal/FFormModal/FFormModal.spec.ts
+++ b/packages/vue/src/components/FModal/FFormModal/FFormModal.spec.ts
@@ -1,7 +1,7 @@
 import "html-validate/vitest";
 import { defineComponent } from "vue";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ValidationPlugin } from "../../../plugins";

--- a/packages/vue/src/components/FNavigationMenu/FNavigationMenu.spec.ts
+++ b/packages/vue/src/components/FNavigationMenu/FNavigationMenu.spec.ts
@@ -3,7 +3,7 @@ import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import FNavigationMenu from "./FNavigationMenu.vue";
-import { NavigationMenuItem } from "./navigation-menu-item";
+import { type NavigationMenuItem } from "./navigation-menu-item";
 
 class ResizeObserverMock {
     public observe = vi.fn();

--- a/packages/vue/src/components/FNavigationMenu/navigation-menu-logic.spec.ts
+++ b/packages/vue/src/components/FNavigationMenu/navigation-menu-logic.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { MenuAction } from "../../types";
 import { type MenuItem } from "./menu-item";
 import {
-    MenuActionTarget,
+    type MenuActionTarget,
     doMenuAction,
     getNewItemIndexFromMenuAction,
 } from "./navigation-menu-logic";

--- a/packages/vue/src/components/FOutputField/FOutputField.spec.ts
+++ b/packages/vue/src/components/FOutputField/FOutputField.spec.ts
@@ -1,4 +1,4 @@
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import FOutputField from "./FOutputField.vue";
 

--- a/packages/vue/src/components/FPaginateDataset/FPaginateDataset.spec.ts
+++ b/packages/vue/src/components/FPaginateDataset/FPaginateDataset.spec.ts
@@ -1,5 +1,5 @@
 import { nextTick, provide } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import {
     type SortFilterDatasetEventCallback,

--- a/packages/vue/src/components/FPaginator/FPaginator.spec.ts
+++ b/packages/vue/src/components/FPaginator/FPaginator.spec.ts
@@ -1,5 +1,5 @@
 import { nextTick } from "vue";
-import { DOMWrapper, VueWrapper, mount } from "@vue/test-utils";
+import { type DOMWrapper, type VueWrapper, mount } from "@vue/test-utils";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { FPaginatorSelectors } from "../../selectors";
 import FPaginateDataset from "../FPaginateDataset/FPaginateDataset.vue";

--- a/packages/vue/src/components/FRadioField/FRadioField.spec.ts
+++ b/packages/vue/src/components/FRadioField/FRadioField.spec.ts
@@ -1,5 +1,5 @@
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 import { injectionKeys as fieldsetInjectionKeys } from "../FFieldset/use-fieldset";
 import FRadioField from "./FRadioField.vue";

--- a/packages/vue/src/components/FResizePane/FResizePane.ce.spec.ts
+++ b/packages/vue/src/components/FResizePane/FResizePane.ce.spec.ts
@@ -3,9 +3,9 @@ import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
 import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+    type LayoutAreaAttachPanel,
+    type LayoutAreaDirection,
     type UseAreaData,
-    LayoutAreaAttachPanel,
-    LayoutAreaDirection,
 } from "../FPageLayout";
 import FResizePane from "./FResizePane.ce.vue";
 

--- a/packages/vue/src/components/FSelectField/FSelectField.spec.ts
+++ b/packages/vue/src/components/FSelectField/FSelectField.spec.ts
@@ -1,7 +1,7 @@
 import "html-validate/vitest";
 import { defineComponent, h } from "vue";
 import { type ValidatableHTMLElement, type ValidityEvent } from "@fkui/logic";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { describe, expect, it, vi } from "vitest";
 import FSelectField from "./FSelectField.vue";

--- a/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.spec.ts
+++ b/packages/vue/src/components/FSortFilterDataset/FSortFilterDataset.spec.ts
@@ -1,11 +1,11 @@
 import "html-validate/vitest";
 import { defineComponent, nextTick } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 import FSortFilterDataset from "./FSortFilterDataset.vue";
 import {
+    type FSortFilterDatasetInterface,
     FSortFilterDatasetInjected,
-    FSortFilterDatasetInterface,
 } from "./f-sort-filter-dataset-interface";
 import { type SortOrder } from "./sort-order";
 

--- a/packages/vue/src/components/FTableColumn/FTableColumn.spec.ts
+++ b/packages/vue/src/components/FTableColumn/FTableColumn.spec.ts
@@ -1,5 +1,5 @@
 import { provide, ref } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import FTableColumn from "./FTableColumn.vue";
 import "html-validate/vitest";

--- a/packages/vue/src/components/FTableColumn/f-table-column-data.spec.ts
+++ b/packages/vue/src/components/FTableColumn/f-table-column-data.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-    FTableColumnData,
+    type FTableColumnData,
     FTableColumnSize,
     FTableColumnSort,
     FTableColumnType,

--- a/packages/vue/src/components/FTextField/FTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/FTextField.spec.ts
@@ -7,7 +7,7 @@ import {
     ValidationService,
 } from "@fkui/logic";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { describe, expect, it, vi } from "vitest";
 import { ValidationPlugin } from "../../plugins";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FEmailTextField/FEmailTextField.spec.ts
@@ -8,7 +8,7 @@ import {
     ValidationService,
 } from "@fkui/logic";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { describe, expect, it, vi } from "vitest";
 import { ValidationPlugin } from "../../../../plugins";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FNumericTextField/FNumericTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FNumericTextField/FNumericTextField.spec.ts
@@ -1,6 +1,6 @@
 import "html-validate/vitest";
 import { defineComponent } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import { ValidationPlugin } from "../../../../plugins";
 import FNumericTextField from "./FNumericTextField.vue";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPercentTextField/FPercentTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPercentTextField/FPercentTextField.spec.ts
@@ -1,5 +1,5 @@
 import "html-validate/vitest";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import { ValidationPlugin } from "../../../../plugins";
 import FPercentTextField from "./FPercentTextField.vue";

--- a/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.spec.ts
+++ b/packages/vue/src/components/FTextField/extendedTextFields/FPhoneTextField/FPhoneTextField.spec.ts
@@ -8,7 +8,7 @@ import {
     ValidationService,
 } from "@fkui/logic";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { describe, expect, it, vi } from "vitest";
 import { ValidationPlugin } from "../../../../plugins";

--- a/packages/vue/src/components/FTextareaField/FTextareaField.spec.ts
+++ b/packages/vue/src/components/FTextareaField/FTextareaField.spec.ts
@@ -5,7 +5,7 @@ import {
     type ValidityEvent,
 } from "@fkui/logic";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { describe, expect, it, vi } from "vitest";
 import FTextareaField from "./FTextareaField.vue";

--- a/packages/vue/src/components/FTooltip/FTooltip.spec.ts
+++ b/packages/vue/src/components/FTooltip/FTooltip.spec.ts
@@ -1,4 +1,4 @@
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import {
     FileSystemConfigLoader,
     HtmlValidate,

--- a/packages/vue/src/components/FValidationForm/FValidationForm.spec.ts
+++ b/packages/vue/src/components/FValidationForm/FValidationForm.spec.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import "html-validate/vitest";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import {
     FileSystemConfigLoader,
     HtmlValidate,

--- a/packages/vue/src/components/FValidationGroup/FValidationGroup.spec.ts
+++ b/packages/vue/src/components/FValidationGroup/FValidationGroup.spec.ts
@@ -1,7 +1,7 @@
 import "html-validate/vitest";
 import { defineComponent } from "vue";
 import { type ValidatableHTMLElement } from "@fkui/logic";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import {
     FileSystemConfigLoader,

--- a/packages/vue/src/components/FValidationGroup/form-utils.spec.ts
+++ b/packages/vue/src/components/FValidationGroup/form-utils.spec.ts
@@ -1,7 +1,7 @@
 import { defineComponent } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ComponentValidityEvent, FormErrorList } from "../../types";
+import { type ComponentValidityEvent, type FormErrorList } from "../../types";
 import { cleanUpElements } from "./form-utils";
 
 type ComponentReference = Record<string, FormErrorList>;

--- a/packages/vue/src/components/FWizard/f-wizard-api.spec.ts
+++ b/packages/vue/src/components/FWizard/f-wizard-api.spec.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { FWizardStepDefinition, addStep, removeStep } from "./f-wizard-api";
+import {
+    type FWizardStepDefinition,
+    addStep,
+    removeStep,
+} from "./f-wizard-api";
 
 let steps: FWizardStepDefinition[];
 

--- a/packages/vue/src/config/context.spec.ts
+++ b/packages/vue/src/config/context.spec.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { MaybeWithFKUIContext, getRunningContext } from "./context";
+import { type MaybeWithFKUIContext, getRunningContext } from "./context";
 
 it("should throw error if calling instance is without FKUI context", () => {
     expect.assertions(1);

--- a/packages/vue/src/internal-components/IAnimateExpand/IAnimateExpand.spec.ts
+++ b/packages/vue/src/internal-components/IAnimateExpand/IAnimateExpand.spec.ts
@@ -1,5 +1,5 @@
 import "html-validate/vitest";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import IAnimateExpand from "./IAnimateExpand.vue";

--- a/packages/vue/src/internal-components/IPopup/IPopup.spec.ts
+++ b/packages/vue/src/internal-components/IPopup/IPopup.spec.ts
@@ -2,7 +2,7 @@ import "html-validate/vitest";
 import "@fkui/test-utils/vitest";
 import { defineComponent } from "vue";
 import { createPlaceholderInDocument } from "@fkui/test-utils/vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import IPopup from "./IPopup.vue";

--- a/packages/vue/src/internal-components/IPopup/i-popup-utils.spec.ts
+++ b/packages/vue/src/internal-components/IPopup/i-popup-utils.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { Rect } from "../../utils";
+import { type Rect } from "../../utils";
 import {
-    Candidate,
+    type Candidate,
     CandidateOrder,
     Placement,
     SpacingDirection,

--- a/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.spec.ts
+++ b/packages/vue/src/internal-components/IPopupMenu/IPopupMenu.spec.ts
@@ -1,6 +1,6 @@
 import "html-validate/vitest";
 import { defineComponent } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import IPopupMenu from "./IPopupMenu.vue";

--- a/packages/vue/src/internal-components/IPopupMenu/ipopupmenu-logic.spec.ts
+++ b/packages/vue/src/internal-components/IPopupMenu/ipopupmenu-logic.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { type MenuItem } from "../../components";
 import { MenuAction } from "../../types";
 import {
-    MenuActionTarget,
+    type MenuActionTarget,
     doMenuAction,
     getNewItemIndexFromMenuAction,
 } from "./ipopupmenu-logic";

--- a/packages/vue/src/plugins/format/format-plugin.spec.ts
+++ b/packages/vue/src/plugins/format/format-plugin.spec.ts
@@ -1,6 +1,6 @@
 import { defineComponent } from "vue";
 import { FDate } from "@fkui/date";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import { FormatPlugin } from "./format-plugin";
 

--- a/packages/vue/src/plugins/test/test-plugin.spec.ts
+++ b/packages/vue/src/plugins/test/test-plugin.spec.ts
@@ -1,5 +1,5 @@
 import { defineComponent, h, resolveDirective, withDirectives } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { expect, it, vi } from "vitest";
 import { FTextField } from "../../components/FTextField";
 import { TestPlugin } from "./test-plugin";

--- a/packages/vue/src/plugins/validation/validation-plugin.spec.ts
+++ b/packages/vue/src/plugins/validation/validation-plugin.spec.ts
@@ -4,11 +4,11 @@ import {
     type ValidatorConfigs,
     ValidationService,
 } from "@fkui/logic";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FCheckboxField, FFieldset, FTextField } from "../../components";
-import { ComponentValidityEvent } from "../../types";
+import { type ComponentValidityEvent } from "../../types";
 import { dispatchComponentValidityEvent } from "../../utils";
 import { ValidationPlugin } from "./validation-plugin";
 

--- a/packages/vue/src/utils/dataset/to-dataset.spec.ts
+++ b/packages/vue/src/utils/dataset/to-dataset.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DatasetElementMetadata } from "./dataset-element-metadata";
+import { type DatasetElementMetadata } from "./dataset-element-metadata";
 import { getDatasetMetadata } from "./get-dataset-metadata";
 import { isDataset } from "./is-dataset";
 import { toDataset } from "./to-dataset";

--- a/packages/vue/src/utils/form-modal/form-modal.spec.ts
+++ b/packages/vue/src/utils/form-modal/form-modal.spec.ts
@@ -1,5 +1,5 @@
 import { expect, it, vi } from "vitest";
-import { MaybeWithFKUIContext } from "../../config";
+import { type MaybeWithFKUIContext } from "../../config";
 import { type MaybeComponent } from "../maybe-component";
 import * as openModalModule from "../open-modal/open-modal";
 import { formModal } from "./form-modal";

--- a/packages/vue/src/utils/get-input-element.spec.ts
+++ b/packages/vue/src/utils/get-input-element.spec.ts
@@ -1,4 +1,4 @@
-import { VueWrapper, shallowMount } from "@vue/test-utils";
+import { type VueWrapper, shallowMount } from "@vue/test-utils";
 import { expect, it } from "vitest";
 import "html-validate/vitest";
 import { FLabel } from "../components/FLabel";

--- a/packages/vue/src/utils/list-utils.spec.ts
+++ b/packages/vue/src/utils/list-utils.spec.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { UnknownItem } from "../types";
+import { type UnknownItem } from "../types";
 import {
     handleKeyboardFocusNavigation,
     includeItem,

--- a/packages/vue/src/utils/mount-component/mount-component.spec.ts
+++ b/packages/vue/src/utils/mount-component/mount-component.spec.ts
@@ -1,6 +1,6 @@
 import { defineComponent, h } from "vue";
 import { beforeEach, expect, it } from "vitest";
-import { MaybeWithFKUIContext } from "../../config";
+import { type MaybeWithFKUIContext } from "../../config";
 import { mountComponent } from "./mount-component";
 
 const callingInstance = { $fkui: {} } as MaybeWithFKUIContext;

--- a/packages/vue/src/utils/open-modal/open-modal.spec.ts
+++ b/packages/vue/src/utils/open-modal/open-modal.spec.ts
@@ -1,7 +1,7 @@
 import { type VNodeArrayChildren, defineComponent, h } from "vue";
 import flushPromises from "flush-promises";
 import { expect, it } from "vitest";
-import { MaybeWithFKUIContext } from "../../config";
+import { type MaybeWithFKUIContext } from "../../config";
 import { openModal } from "./open-modal";
 
 const callingInstance = { $fkui: {} } as MaybeWithFKUIContext;

--- a/packages/vue/src/utils/parent-by-name/find-parent-by-name.spec.ts
+++ b/packages/vue/src/utils/parent-by-name/find-parent-by-name.spec.ts
@@ -1,5 +1,5 @@
 import { type ComponentPublicInstance, defineComponent } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it } from "vitest";
 import { findParentByName } from "./find-parent-by-name";
 

--- a/packages/vue/src/utils/parent-by-name/get-parent-by-name.spec.ts
+++ b/packages/vue/src/utils/parent-by-name/get-parent-by-name.spec.ts
@@ -1,5 +1,5 @@
 import { type ComponentPublicInstance, defineComponent } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it } from "vitest";
 import { getParentByName } from "./get-parent-by-name";
 

--- a/packages/vue/src/utils/parent-by-name/has-parent-by-name.spec.ts
+++ b/packages/vue/src/utils/parent-by-name/has-parent-by-name.spec.ts
@@ -1,5 +1,5 @@
 import { type ComponentPublicInstance, defineComponent } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it } from "vitest";
 import { hasParentByName } from "./has-parent-by-name";
 

--- a/packages/vue/src/utils/render-slot-text.spec.ts
+++ b/packages/vue/src/utils/render-slot-text.spec.ts
@@ -1,5 +1,5 @@
 import { defineComponent } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import { FBadge as SfcComponent } from "../components";
 import { type RenderSlotOptions, renderSlotText } from "./render-slot-text";

--- a/packages/vue/src/utils/vue-ref-utils.spec.ts
+++ b/packages/vue/src/utils/vue-ref-utils.spec.ts
@@ -1,5 +1,5 @@
 import { defineComponent } from "vue";
-import { VueWrapper, mount } from "@vue/test-utils";
+import { type VueWrapper, mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import {
     findElementFromVueRef,


### PR DESCRIPTION
breaking this commit out from #1534 (to fix `@typescript-eslint/consistent-type-imports`).