### PR TITLE
fix: add missing TranslationMixin to FFileItem (refs SFKUI-6500)

### DIFF
--- a/packages/vue/src/components/FDataTable/FDataTable.spec.ts
+++ b/packages/vue/src/components/FDataTable/FDataTable.spec.ts
@@ -2,7 +2,6 @@ import "html-validate/vitest";
 import { defineComponent } from "vue";
 import { mount } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { TranslationPlugin } from "../../plugins";
 import { type FSortFilterDatasetMountCallback } from "../FSortFilterDataset";
 import { FTableColumn } from "../FTableColumn";
 import FDataTable from "./FDataTable.vue";
@@ -33,9 +32,6 @@ describe("should match snapshot", () => {
                     { a: 3, b: 4 },
                 ],
             };
-        },
-        global: {
-            plugins: [TranslationPlugin],
         },
     };
 

--- a/packages/vue/src/components/FFileItem/FFileItem.spec.ts
+++ b/packages/vue/src/components/FFileItem/FFileItem.spec.ts
@@ -1,9 +1,6 @@
-import { config, shallowMount } from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
-import { TranslationPlugin } from "../../plugins";
 import FFileItem from "./FFileItem.vue";
-
-config.global.plugins = [TranslationPlugin];
 
 describe("FileItem", () => {
     it("should match snapshot with slots", () => {

--- a/packages/vue/src/components/FFileItem/FFileItem.vue
+++ b/packages/vue/src/components/FFileItem/FFileItem.vue
@@ -2,6 +2,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import { ElementIdService, isSet } from "@fkui/logic";
+import { TranslationMixin } from "../../plugins/index.js";
 import FIcon from "../FIcon/FIcon.vue";
 import { type IconName } from "./icon-name";
 
@@ -20,6 +21,7 @@ const iconMap: Record<string, IconName> = {
 export default defineComponent({
     name: "FFileItem",
     components: { FIcon },
+    mixins: [TranslationMixin],
     inheritAttrs: false,
     props: {
         /**

--- a/packages/vue/src/selectors/FCrudDataset.selectors.spec.ts
+++ b/packages/vue/src/selectors/FCrudDataset.selectors.spec.ts
@@ -2,10 +2,9 @@ import { defineComponent } from "vue";
 import { config, mount } from "@vue/test-utils";
 import { expect, it } from "vitest";
 import { FCrudDataset } from "../components";
-import { TestDirective, TranslationPlugin } from "../plugins";
+import { TestDirective } from "../plugins";
 import { FCrudDatasetSelectors } from "./FCrudDataset.selectors";
 
-config.global.plugins.push(TranslationPlugin);
 config.global.stubs = {
     ...config.global.stubs,
     "f-icon": true,


### PR DESCRIPTION
Så fungerar komponenten utan att konsumenten nyttjar `TranslationPlugin`.