### PR TITLE
docs: remove textarea auto resize fallback details (refs SFKUI-6500)

### DIFF
--- a/docs/components/input/FTextareaField.md
+++ b/docs/components/input/FTextareaField.md
@@ -90,14 +90,6 @@ Du aktiverar automatisk höjd med attributet `auto-resize`.
  >
 ```
 
-Automatisk höjd bygger på webbläsarstöd för `field-sizing`.
-I webbläsare utan stöd växer fältet inte automatiskt när användaren skriver.
-Då visar komponenten minst fyra rader, så att fältet inte blir för litet.
-Om du anger fler än fyra rader visar komponenten det antalet rader i stället.
-Om du anger max antal rader kan det begränsa hur stort fältet visas i äldre webbläsare.
-På desktop kan användaren ändra höjden manuellt när max antal rader inte används.
-På mobila enheter kan fältet i stället upplevas som fast.
-
 Med `auto-resize` visas fyra rader som standard, precis som vid fast höjd. Använd `rows` för att ange ett annat minsta antal rader.
 
 ```diff


### PR DESCRIPTION
Enligt plan så har Firefox stöd för field-sizing sedan Juli 2026 vilket innebär att alla större webbläsare kan hantera vår auto-resize på text-area. Tar bort specifik dokumentation för fallbackbeteende eftersom det då inte längre behövs utan snarare riskerar att väcka frågor.