### PR TITLE
refactor: remove `tertiary` button width inherit (fixes SFKUI-8027)

### DIFF
--- a/packages/design/src/components/button/_button.scss
+++ b/packages/design/src/components/button/_button.scss
@@ -220,7 +220,6 @@ $button--tertiary: (
     }
 
     &--tertiary {
-        font-weight: var(--f-font-weight-medium);
         outline-offset: size.$padding-025;
 
         @include core.make-button-variant(".button", $button--tertiary...);

--- a/packages/design/src/components/button/_button.scss
+++ b/packages/design/src/components/button/_button.scss
@@ -220,7 +220,6 @@ $button--tertiary: (
     }
 
     &--tertiary {
-        width: inherit;
         font-weight: var(--f-font-weight-medium);
         outline-offset: size.$padding-025;
 


### PR DESCRIPTION
Så vitt jag vet så finns det inget fall där vi vill att våra vanliga knappar ska ha samma width som sin container, men UX får ha sista ordet. Misstänker att den bara är en kvarleva från innan beslutet att synka storlekarna mellan knapparna som råkat leva kvar.

Före:
<img width="665" height="618" alt="image" src="https://github.com/user-attachments/assets/1616b630-a150-4870-a226-34a4ee308ebf" />

Efter:
<img width="526" height="587" alt="image" src="https://github.com/user-attachments/assets/20a66358-e5fe-4fd2-a1e5-b4fb24791f1f" />
