### PR TITLE
refactor(docs): remove deprecated import (refs SFKUI-6500)

### DIFF
--- a/docs/src/main.js
+++ b/docs/src/main.js
@@ -1,5 +1,4 @@
 import { config } from "@fkui/vue";
-import "@forsakringskassan/docs-generator/runtime";
 
 function importDefault(m) {
     return m.default ?? m;


### PR DESCRIPTION
fixes `Importing `@forsakringskassan/doc-generator/runtime` is deprecated and will be removed in the next major version`