### PR TITLE
chore: set provenance and access to avoid modified files during release

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,5 @@
+access=public
+provenance=true
 save-exact=true
 strict-allow-scripts=true
 min-release-age=3


### PR DESCRIPTION
### Problembeskrivning

Sen 7d33c56 går det inte längre göra releases i detta repot.

Orsaken är att i [semantic-release-config action](https://github.com/Forsakringskassan/semantic-release-config/blob/main/action.yml#L60-L61) som vi använder via [npm-release.yaml](https://github.com/Forsakringskassan/.github/blob/main/.github/workflows/npm-release.yaml#L47) så sätter vi två inställningar i `.npmrc` filen:

```bash
npm config --location project set access public
npm config --location project set provenance true
```

Nu när `.npmrc` filen är incheckad i repot så räkas därför filen som modified. Det är inte ett direkt problem för semantic-release, den ogillar allmänt dirty working copy men den släpper igenom att denna filen ändrats.

Men `lerna` hanterar inte det utan ger ett fel `EUNCOMMIT` och jag hittar inget sätt att ignorera det felet. Eftersom `lerna` ger det felet i samband med att man försöker publicera paketet så finns det kod i [`semantic-release-lerna`](https://github.com/ext/semantic-release-lerna/blob/master/src/verify-git.js#L4-L9) som ger motsvarande fel fast i `verifyConditions` steget av semantic-release (istället för att man får en halvfärdig release så avbryter den då innan releasen påbörjas).

Först var jag inne på att modifiera den koden så att den ignorerar ändringar i `.npmrc` men lerna ger då `EUNCOMMIT` istället.

Oavsett så är det därför bara ett problem med release i monorepon och fungerar som det är tänkt i andra repon.

### Lösningsförslag

Mitt förslag i denna PR är att vi helt enkelt skriver ner de två config-inställningarna direkt i `.npmrc` filen, då blir det ingen diff när vi kör releasen. Risken är att om vi ändrar våran delade workflow/action så kanske vi får problemet i framtiden med andra inställningar. Men det kanske får bli morgondagens huvudvärk.

### Alternativa lösningar

Vi kan försökta jobba bort att workflow / action sätter inställningar, @MCFK hittade att någon kunde man ersätta med miljövariabel istället men osäker om båda kan hanteras på det sättet.

Vi kan också ta bort den incheckade `.npmrc` men då återinför vi nog problemen vi har med karantän (har inte hört att någon haft problem med detta repot sen dess). Trist när det fungerar med andra repon och inte med monorepon då bara.

Ser ni några andra varianter?