### PR TITLE
fix: resett FDialogueTree jira SFKUI-7415 (refs SFKUI-8094)

### DIFF
--- a/packages/vue/src/components/FDialogueTree/FDialogueTree.vue
+++ b/packages/vue/src/components/FDialogueTree/FDialogueTree.vue
@@ -105,7 +105,7 @@ export default defineComponent({
 <template>
     <div class="dialogue-tree">
         <template v-if="options.length > 0">
-            <ul :key="currentStep.label" class="dialogue-tree__list" :aria-label="currentStep.label">
+            <ul class="dialogue-tree__list">
                 <li v-for="(option, index) in options" :key="option.label" class="dialogue-tree__list-item">
                     <button :ref="`dialogueButton-${index}`" type="button" @click="onClickedOption(option, index)">
                         <span>{{ option.label }}</span>


### PR DESCRIPTION
jira SFKUI-7415 är en fix för att nvda läste enbart upp första knappen och inte rubrik. Förmodligen har något uppdaterats i FModal för nu läser den upp rubriken 3 ggr. Då jag tar bort det som var första fixen jira 7415 så läser nvda rubriken 2 ggr en känd bugg som finns på git. Om något ändras får vi hålla kolla på det här.

Har försökt men inte hittat en lösninga, kastas bara runt i olika förslag som bara ger andra problem

https://github.com/nvaccess/nvda/issues/19453

https://github.com/nvaccess/nvda/issues/8971