### PR TITLE
refactor: extract shared listbox styling (refs SFKUI-8119)

### DIFF
--- a/packages/design/src/components/combobox/_combobox.scss
+++ b/packages/design/src/components/combobox/_combobox.scss
@@ -1,62 +1,25 @@
 @use "variables" as *;
-@use "../../core/mixins/forcedcolors";
-@use "../../core/size";
+@use "../listbox/listbox";
 
 .popup .popup__wrapper.combobox__listbox {
-    background-color: $combobox-color-background;
-    border: var(--f-border-width-medium) solid $combobox-color-border;
-    border-radius: var(--f-border-radius-medium);
-    box-shadow: var(--f-box-modal-shadow);
-    margin-top: 4px;
-    margin-bottom: 4px;
-    padding: 2px;
-    scrollbar-gutter: stable;
-}
-
-%combobox__listbox__list {
-    margin: 0;
-    padding: 0;
+    @include listbox.surface;
 }
 
 .combobox__listbox__list {
-    @extend %combobox__listbox__list;
+    @include listbox.list;
 }
 
-%combobox__listbox__option {
-    color: $combobox-color-text;
-    cursor: pointer;
-    list-style-type: none;
-    padding: size.$padding-075;
-    white-space: nowrap;
-    box-sizing: border-box;
-    margin-right: size.$margin-050;
+.combobox__listbox__option {
+    @include listbox.option;
 
     // .is-hover only for screenshot selector
     &.is-hover,
     &:hover:not(&--highlight) {
-        background-color: $combobox-color-background-hover;
-        color: $combobox-color-text-hover;
-        @media (forced-colors: active) {
-            outline-offset: -2px;
-            margin-right: size.$margin-150;
-        }
-        @include forcedcolors.hover-indicator(outline, 2px);
+        @include listbox.option-hover;
     }
 
     &--highlight {
-        background-color: $combobox-color-background-selected;
-        color: $combobox-color-text-selected;
-        font-weight: var(--f-font-weight-medium);
-
-        @include forcedcolors.selected-indicator;
-    }
-}
-
-.combobox__listbox__option {
-    @extend %combobox__listbox__option;
-
-    &--highlight {
-        @extend %combobox__listbox__option--highlight;
+        @include listbox.option-selected;
     }
 }
 

--- a/packages/design/src/components/combobox/_variables.scss
+++ b/packages/design/src/components/combobox/_variables.scss
@@ -1,9 +1,2 @@
-$combobox-color-background-hover: var(--fkds-color-select-background-primary-hover) !default;
-$combobox-color-background-selected: var(--fkds-color-select-background-primary-default) !default;
-$combobox-color-background: var(--fkds-color-background-primary) !default;
-$combobox-color-text-hover: var(--fkds-color-text-primary) !default;
-$combobox-color-text-selected: var(--fkds-color-text-inverted) !default;
-$combobox-color-text: var(--fkds-color-text-primary) !default;
-$combobox-color-border: var(--fkds-color-border-primary) !default;
 $combobox-f-icon-arrow-down-color-content-default: var(--fkds-color-action-text-primary-default) !default;
 $combobox-f-icon-arrow-down-color-content-disabled: var(--fkds-color-text-disabled) !default;

--- a/packages/design/src/components/listbox/_listbox.scss
+++ b/packages/design/src/components/listbox/_listbox.scss
@@ -1,0 +1,51 @@
+@use "variables" as *;
+@use "../../core/mixins/forcedcolors";
+@use "../../core/size";
+
+// Internal mixins, not part of the public @fkui/design Sass API.
+
+@mixin surface {
+    background-color: $listbox-color-background;
+    border: var(--f-border-width-medium) solid $listbox-color-border;
+    border-radius: var(--f-border-radius-medium);
+    box-shadow: var(--f-box-modal-shadow);
+    margin-top: 4px;
+    margin-bottom: 4px;
+    padding: 2px;
+    scrollbar-gutter: stable;
+}
+
+@mixin list {
+    margin: 0;
+    padding: 0;
+}
+
+@mixin option {
+    color: $listbox-option-color-text;
+    cursor: pointer;
+    list-style-type: none;
+    padding: size.$padding-075;
+    white-space: nowrap;
+    box-sizing: border-box;
+    margin-right: size.$margin-050;
+}
+
+@mixin option-hover {
+    background-color: $listbox-option-color-background-hover;
+    color: $listbox-option-color-text-hover;
+
+    @media (forced-colors: active) {
+        outline-offset: -2px;
+        margin-right: size.$margin-150;
+    }
+
+    @include forcedcolors.hover-indicator(outline, 2px);
+}
+
+@mixin option-selected {
+    background-color: $listbox-option-color-background-selected;
+    color: $listbox-option-color-text-selected;
+    font-weight: var(--f-font-weight-medium);
+
+    @include forcedcolors.selected-indicator;
+}

--- a/packages/design/src/components/listbox/_variables.scss
+++ b/packages/design/src/components/listbox/_variables.scss
@@ -1,0 +1,7 @@
+$listbox-option-color-background-hover: var(--fkds-color-select-background-primary-hover) !default;
+$listbox-option-color-background-selected: var(--fkds-color-select-background-primary-default) !default;
+$listbox-color-background: var(--fkds-color-background-primary) !default;
+$listbox-option-color-text-hover: var(--fkds-color-text-primary) !default;
+$listbox-option-color-text-selected: var(--fkds-color-text-inverted) !default;
+$listbox-option-color-text: var(--fkds-color-text-primary) !default;
+$listbox-color-border: var(--fkds-color-border-primary) !default;

--- a/packages/design/src/internal-components/calendar/_calendar.scss
+++ b/packages/design/src/internal-components/calendar/_calendar.scss
@@ -1,4 +1,4 @@
-@use "../../components/combobox/combobox";
+@use "../../components/listbox/listbox";
 
 .calendar {
     &__wrapper {
@@ -11,16 +11,21 @@
         position: relative;
 
         &__listbox {
-            @extend %combobox__listbox__list;
+            @include listbox.list;
         }
 
         &__year {
-            @extend %combobox__listbox__option;
+            @include listbox.option;
 
             margin: 5px;
 
+            &.is-hover,
+            &:hover:not(&--highlight) {
+                @include listbox.option-hover;
+            }
+
             &--highlight {
-                @extend %combobox__listbox__option--highlight;
+                @include listbox.option-selected;
             }
         }
     }


### PR DESCRIPTION
## Uppdatering

Lösningen har förenklats efter vidare granskning:

- listboxens mixins och variabler hålls interna,
- färger styrs med semantiska tokens,
- komboboxens listboxrelaterade Sass-variabler och det indirekta Sass-beroendet har tagits bort,
- redundanta index- och testfiler har tagits bort.

Genererad CSS, design och beteende är oförändrade.

Den ursprungliga beskrivningen ligger kvar nedan som bakgrund.

**Bakgrund**
Webbläsarstöd för `appearance: base-select` för anpassningsbara `<select>` gör att vi nu på ett enkelt sätt, via progressive enhancement, kan ge dropplistan samma design som komboboxen. Tidigare hade detta krävt en egen implementation av interaktion och tillgänglighet. Chrome har stöd och Safari får det i nästa version.

**Nuläge**
Listboxdesignen ägs av komboboxen och återanvänds av kalendern genom komboboxens interna selektorer. För att även kunna använda listboxdesignen i `FSelectField` blir det bättre om den är komponentoberoende.

**Ändringar**
Listboxdesignen har flyttats till gemensamma mixins i `@fkui/design`. Komboboxen och kalendern använder nu dessa mixins.
Detta är en ren refaktorering:
- design och beteende är oförändrade,
- inget publikt Vue-API ändras,
- befintliga Sass-variabler för komboboxen stöds fortfarande (för ren refaktorering, ev deprekering görs separat).

Refaktoreringen förbereder för att ge listan i `FSelectField` samma design i ett senare steg.