### PR TITLE
fix: set tooltip header text color (refs SFKUI-6500)

### DIFF
--- a/packages/design/src/components/tooltip/_tooltip.scss
+++ b/packages/design/src/components/tooltip/_tooltip.scss
@@ -113,6 +113,7 @@ $inner-border:
     }
 
     &__header {
+        color: $tooltip-header-color-text-default;
         font-size: var(--f-font-size-large);
         font-weight: var(--f-font-weight-bold);
         line-height: var(--f-line-height-medium);

--- a/packages/design/src/components/tooltip/_variables.scss
+++ b/packages/design/src/components/tooltip/_variables.scss
@@ -1,3 +1,4 @@
 $tooltip-color-background: var(--fkds-color-feedback-background-info) !default;
 $tooltip-color-border: var(--fkds-color-feedback-border-info) !default;
 $tooltip-color-text-default: var(--fkds-color-text-primary) !default;
+$tooltip-header-color-text-default: var(--fkds-color-text-primary) !default;


### PR DESCRIPTION
Åtgärdar att rubriken i tooltip saknar explicit textfärg, vilket gör att den inte syns korrekt i mörkt tema.