### PR TITLE
fix: shadow DOM selection in form components

### DIFF
--- a/packages/vue/src/components/FErrorList/FErrorList.vue
+++ b/packages/vue/src/components/FErrorList/FErrorList.vue
@@ -44,7 +44,7 @@ export default defineComponent({
     methods: {
         async onClickItem(item: ErrorItem) {
             await this.beforeNavigate(item);
-            focusError(item);
+            focusError(item, this.$el.getRootNode() as Document | ShadowRoot);
         },
     },
 });

--- a/packages/vue/src/components/FErrorList/focus-error.spec.ts
+++ b/packages/vue/src/components/FErrorList/focus-error.spec.ts
@@ -24,7 +24,7 @@ it("should scroll and move focus to element (by id)", () => {
         title: "Mock error",
         id: mockElement.id,
     };
-    focusError(error);
+    focusError(error, document);
     expect(scrollTo).toHaveBeenCalledWith(mockElement, expect.any(Number));
     expect(focus).toHaveBeenCalledWith(mockElement);
 });
@@ -37,7 +37,7 @@ it("should prefer to focus on focusElementId if given", () => {
         id: mockElement.id,
         focusElementId: mockInput.id,
     };
-    focusError(error);
+    focusError(error, document);
     expect(scrollTo).toHaveBeenCalledWith(mockElement, expect.any(Number));
     expect(focus).toHaveBeenCalledWith(mockInput);
 });
@@ -49,7 +49,7 @@ it("should throw error when id element is missing", () => {
         id: "missing",
     };
     expect(() => {
-        focusError(error);
+        focusError(error, document);
     }).toThrow(`Can not find element with id "missing"`);
 });
 
@@ -60,6 +60,6 @@ it("should fallback on id when focusElementId is missing", () => {
         id: mockElement.id,
         focusElementId: "missing",
     };
-    focusError(error);
+    focusError(error, document);
     expect(focus).toHaveBeenCalledWith(mockElement);
 });

--- a/packages/vue/src/components/FErrorList/focus-error.ts
+++ b/packages/vue/src/components/FErrorList/focus-error.ts
@@ -1,15 +1,13 @@
 import { focus, scrollTo } from "@fkui/logic";
 import { type ErrorItem } from "../../types";
 
-export function focusError(item: ErrorItem): void {
-    const element = document.querySelector(`#${String(item.id)}`);
+export function focusError(item: ErrorItem, root: Document | ShadowRoot): void {
+    const element = root.querySelector(`#${String(item.id)}`);
     if (!element) {
         throw new Error(`Can not find element with id "${String(item.id)}"`);
     }
 
-    const focusElement = document.querySelector(
-        `#${String(item.focusElementId)}`,
-    );
+    const focusElement = root.querySelector(`#${String(item.focusElementId)}`);
 
     /* eslint-disable-next-line @typescript-eslint/no-floating-promises -- technical debt */
     scrollTo(element, window.innerHeight * 0.25);

--- a/packages/vue/src/components/FTextareaField/FTextareaField.vue
+++ b/packages/vue/src/components/FTextareaField/FTextareaField.vue
@@ -2,7 +2,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import { type ValidityEvent, ElementIdService, ValidationService, isSet } from "@fkui/logic";
-import { dispatchComponentValidityEvent, renderSlotText } from "../../utils";
+import { dispatchComponentValidityEvent, findHTMLElementFromVueRef, renderSlotText } from "../../utils";
 import { FLabel } from "../FLabel";
 
 export default defineComponent({
@@ -187,11 +187,10 @@ export default defineComponent({
 
         this.updateTextareaHeightVariables();
 
-        void this.$nextTick(async () => {
-            if (this.$refs.textarea) {
-                await ValidationService.validateElement(this.$refs.textarea as HTMLElement);
-            }
-        });
+        const element = findHTMLElementFromVueRef(this.$refs.textarea);
+        if (element) {
+            return ValidationService.validateElement(element);
+        }
     },
     updated() {
         this.updateTextareaHeightVariables();
@@ -285,7 +284,6 @@ export default defineComponent({
                 </slot>
             </template>
         </f-label>
-
         <f-label v-if="softLimit" :for="id" aria-live="polite">
             <template #description="{ descriptionClass }">
                 <span v-if="showCharactersLeftWarning" :class="descriptionClass">

--- a/packages/vue/src/components/FTextareaField/FTextareaField.vue
+++ b/packages/vue/src/components/FTextareaField/FTextareaField.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
-import { type ValidityEvent, ElementIdService, isSet } from "@fkui/logic";
+import { type ValidityEvent, ElementIdService, ValidationService, isSet } from "@fkui/logic";
 import { dispatchComponentValidityEvent, renderSlotText } from "../../utils";
 import { FLabel } from "../FLabel";
 
@@ -186,6 +186,12 @@ export default defineComponent({
         }
 
         this.updateTextareaHeightVariables();
+
+        void this.$nextTick(async () => {
+            if (this.$refs.textarea) {
+                await ValidationService.validateElement(this.$refs.textarea as HTMLElement);
+            }
+        });
     },
     updated() {
         this.updateTextareaHeightVariables();
@@ -235,6 +241,12 @@ export default defineComponent({
         },
         onPendingValidity(): void {
             this.validityMode = "INITIAL";
+        },
+        async onValidationConfigUpdate(): Promise<void> {
+            await this.$nextTick();
+            if (this.$refs.textarea) {
+                await ValidationService.validateElement(this.$refs.textarea as HTMLElement);
+            }
         },
     },
 });
@@ -290,6 +302,7 @@ export default defineComponent({
             @input="onInput"
             @validity="onValidity"
             @pending-validity="onPendingValidity"
+            @validation-config-update="onValidationConfigUpdate"
         ></textarea>
     </div>
 </template>

--- a/packages/vue/src/components/FValidationForm/FValidationForm.vue
+++ b/packages/vue/src/components/FValidationForm/FValidationForm.vue
@@ -140,8 +140,7 @@ export default defineComponent({
                 focus(this.$refs.errors as HTMLElement);
             } else {
                 const firstError = this.validity.componentsWithError[0];
-                /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- technical debt */
-                const element = this.$el.querySelector(`#${firstError.focusElementId}`)!;
+                const element = this.$el.querySelector(`#${firstError.focusElementId}`);
                 focus(element);
             }
 

--- a/packages/vue/src/components/FValidationForm/FValidationForm.vue
+++ b/packages/vue/src/components/FValidationForm/FValidationForm.vue
@@ -128,8 +128,8 @@ export default defineComponent({
     },
     methods: {
         async hasFormErrors(): Promise<boolean> {
-            ValidationService.setSubmitted(this.id);
-            await ValidationService.validateAllElements(this.id);
+            ValidationService.setSubmitted(this.$el);
+            await ValidationService.validateAllElements(this.$el);
             await this.$nextTick();
             await new Promise((resolve) => window.setTimeout(resolve, 0));
 
@@ -141,7 +141,7 @@ export default defineComponent({
             } else {
                 const firstError = this.validity.componentsWithError[0];
                 /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- technical debt */
-                const element = document.querySelector(`#${firstError.focusElementId}`)!;
+                const element = this.$el.querySelector(`#${firstError.focusElementId}`)!;
                 focus(element);
             }
 


### PR DESCRIPTION
Adjust the handling of focus and error highlighting when components are rendered in a shadow DOM. Updated FErrorList, FTextareaField, and FValidationForm, as well as related test and helper files, to ensure correct behavior.

closes #1595

