### PR TITLE
docs: fix sandbox importmap after lib to dist rename (refs SFKUI-6500)

### DIFF
--- a/docs/playground/import-map.json
+++ b/docs/playground/import-map.json
@@ -1,7 +1,7 @@
 {
     "imports": {
-        "@fkui/date": "https://unpkg.com/@fkui/date@latest/lib/esm/index.js",
-        "@fkui/logic": "https://unpkg.com/@fkui/logic@latest/lib/esm/index.js",
+        "@fkui/date": "https://unpkg.com/@fkui/date@latest/dist/esm/index.js",
+        "@fkui/logic": "https://unpkg.com/@fkui/logic@latest/dist/esm/index.js",
         "@fkui/vue": "https://unpkg.com/@fkui/vue@latest/dist/esm/index.esm.js",
         "@fkui/icon-lib-default/dist/f/injectSpritesheet": "https://unpkg.com/@fkui/icon-lib-default@latest/dist/f/injectSpritesheet",
         "@fkui/vue-labs": "https://unpkg.com/@fkui/vue-labs@latest/dist/esm/index.esm.js",


### PR DESCRIPTION
In d85b6f1 the folders where renamed from `lib` to `dist`.