### PR TITLE
Docs/Radio button improvements

### DIFF
--- a/docs/components/input/FRadioField.md
+++ b/docs/components/input/FRadioField.md
@@ -7,31 +7,43 @@ component:
     - FRadioField
 ---
 
-Använd radioknappar för att låta en användare välja ett alternativ i en lista.
+Använd radioknappar när användaren ska välja ett av ett fåtal fördefinierade alternativ. Alla alternativ visas samtidigt, vilket gör dem enkla att överblicka och jämföra.
 
 ```import live-example test-id=live
 FRadioFieldLiveExample.vue
 ```
 
-Saknar du `FRadioGroup`-komponenten? Den är deprekerad, för detaljer se {@link migrating-to-fieldset migreringsguide }.
+## Radioknappar eller dropplista
 
-## Radioknappar vs Dropplista
+Radioknappar tar mer plats än en dropplista men låter användaren se alternativen utan att först öppna en lista. En {@link FSelectField dropplista} passar bättre när alternativen är många eller när antalet är dynamiskt och kan öka.
 
-En dropplista bör användas om antalet alternativ är relativt stort eller är om antalet är dynamiskt och därmed kan öka i antal .
+## Användning
+
+### Placering
+
+Visa radioknappar vertikalt som standard. Horisontell placering kan användas när det finns två alternativ med korta texter, till exempel ja och nej. På mindre skärmar visas alternativen vertikalt.
+
+### Förvalt alternativ
+
+Förvälj bara ett alternativ när det finns ett rimligt standardval. Låt annars användaren göra ett aktivt val, särskilt när valet får viktiga konsekvenser.
+
+### Inaktiverade alternativ
+
+Undvik inaktiverade alternativ. De kan vara svåra att uppfatta och ger inte användaren någon förklaring till varför de inte går att välja.
+
+## Migrera från FRadioGroup
+
+`FRadioGroup` och `FRadioGroupField` har tagits bort och ersatts av `FFieldset` respektive `FRadioField`. Se {@link migrating-to-fieldset migreringsguiden} för information om hur du uppdaterar din kod.
 
 ## Props, Events & Slots
 
 ### FFieldset
-
-Ersätter `FRadioGroup`.
 
 :::api
 vue:FFieldset
 :::
 
 ### FRadioField
-
-Ersätter `FRadioGroupField`.
 
 :::api
 vue:FRadioField

--- a/docs/components/input/FRadioField.md
+++ b/docs/components/input/FRadioField.md
@@ -31,6 +31,30 @@ Förvälj bara ett alternativ när det finns ett rimligt standardval. Låt annar
 
 Undvik inaktiverade alternativ. De kan vara svåra att uppfatta och ger inte användaren någon förklaring till varför de inte går att välja.
 
+## Varianter
+
+Radioknappar kan kompletteras med texter som förtydligar alternativen och med en ram som skapar tydligare visuell avgränsning mellan alternativen. Vad som passar beror på hur mycket stöd användaren behöver för att göra sitt val. Text och ram kan kombineras på olika sätt. Här visas två vanliga varianter.
+
+### Utvidgad text
+
+Använd utvidgad text när ett alternativ behöver förklaras eller förtydligas. Håll alternativets huvudsakliga text kort och placera förklaringen på en egen rad. Det gör alternativen lättare att överblicka och skapar en tydlig visuell hierarki mellan alternativet och den kompletterande informationen.
+
+Texten ska vara kort och beskriva det enskilda alternativet. Information som gäller hela frågan ska i stället placeras som hjälptext vid frågan.
+
+```import test-id=details-always
+FRadioFieldDetailsAlwaysExample.vue
+```
+
+### Inramade alternativ med expanderbar text
+
+Använd inramade alternativ med expanderbar text när varje val behöver framträda som en egen tydlig och klickbar yta och den kompletterande informationen blir relevant först efter valet. Ramen gör det tydligare vilken text som hör till respektive alternativ när innehållet visas.
+
+Dölj inte information som användaren behöver för att kunna välja.
+
+```import test-id=border-expandable
+FRadioFieldBorderExpandableExample.vue
+```
+
 ## Migrera från FRadioGroup
 
 `FRadioGroup` och `FRadioGroupField` har tagits bort och ersatts av `FFieldset` respektive `FRadioField`. Se {@link migrating-to-fieldset migreringsguiden} för information om hur du uppdaterar din kod.

--- a/docs/components/input/FRadioField.md
+++ b/docs/components/input/FRadioField.md
@@ -7,57 +7,81 @@ component:
     - FRadioField
 ---
 
-Använd radioknappar när användaren ska välja ett av ett fåtal fördefinierade alternativ. Alla alternativ visas samtidigt, vilket gör dem enkla att överblicka och jämföra.
+Använd radioknappar när användaren ska välja ett av ett fåtal fördefinierade alternativ.
+Alla alternativ visas samtidigt, vilket gör dem enkla att överblicka och jämföra.
 
-```import live-example test-id=live
+```import live-example
 FRadioFieldLiveExample.vue
 ```
 
 ## Radioknappar eller dropplista
 
-Radioknappar tar mer plats än en dropplista men låter användaren se alternativen utan att först öppna en lista. En {@link FSelectField dropplista} passar bättre när alternativen är många eller när antalet är dynamiskt och kan öka.
+Radioknappar tar mer plats än en dropplista men låter användaren se alternativen utan att först öppna en lista.
+En {@link FSelectField dropplista} passar bättre när alternativen är många eller när antalet är dynamiskt och kan öka.
 
 ## Användning
 
 ### Placering
 
-Visa radioknappar vertikalt som standard. Horisontell placering kan användas när det finns två alternativ med korta texter, till exempel ja och nej. På mindre skärmar visas alternativen vertikalt.
+Visa radioknappar vertikalt som standard.
+Horisontell placering kan användas när det finns två alternativ med korta texter, till exempel ja och nej.
+På mindre skärmar visas alternativen vertikalt.
 
 ### Förvalt alternativ
 
-Förvälj bara ett alternativ när det finns ett rimligt standardval. Låt annars användaren göra ett aktivt val, särskilt när valet får viktiga konsekvenser.
+Förvälj bara ett alternativ när det finns ett rimligt standardval.
+Låt annars användaren göra ett aktivt val, särskilt när valet får viktiga konsekvenser.
 
 ### Inaktiverade alternativ
 
-Undvik inaktiverade alternativ. De kan vara svåra att uppfatta och ger inte användaren någon förklaring till varför de inte går att välja.
+Undvik inaktiverade alternativ.
+De kan vara svåra att uppfatta och ger inte användaren någon förklaring till varför de inte går att välja.
 
 ## Varianter
 
-Radioknappar kan kompletteras med texter som förtydligar alternativen och med en ram som skapar tydligare visuell avgränsning mellan alternativen. Vad som passar beror på hur mycket stöd användaren behöver för att göra sitt val. Text och ram kan kombineras på olika sätt. Här visas två vanliga varianter.
+Radioknappar kan kompletteras med texter som förtydligar alternativen och med en ram som skapar tydligare visuell avgränsning mellan alternativen.
+Vad som passar beror på hur mycket stöd användaren behöver för att göra sitt val.
+Text och ram kan kombineras på olika sätt.
+Här visas två vanliga varianter.
 
 ### Utvidgad text
 
-Använd utvidgad text när ett alternativ behöver förklaras eller förtydligas. Håll alternativets huvudsakliga text kort och placera förklaringen på en egen rad. Det gör alternativen lättare att överblicka och skapar en tydlig visuell hierarki mellan alternativet och den kompletterande informationen.
+Använd utvidgad text när ett alternativ behöver förklaras eller förtydligas.
+Håll alternativets huvudsakliga text kort och placera förklaringen på en egen rad.
+Det gör alternativen lättare att överblicka och skapar en tydlig visuell hierarki mellan alternativet och den kompletterande informationen.
 
-Texten ska vara kort och beskriva det enskilda alternativet. Information som gäller hela frågan ska i stället placeras som hjälptext vid frågan.
+Texten ska vara kort och beskriva det enskilda alternativet.
+Information som gäller hela frågan ska i stället placeras som hjälptext vid frågan.
 
-```import test-id=details-always
+```diff
+-<f-fieldset name="illness">
++<f-fieldset name="illness" show-details="always">
+```
+
+```import
 FRadioFieldDetailsAlwaysExample.vue
 ```
 
 ### Inramade alternativ med expanderbar text
 
-Använd inramade alternativ med expanderbar text när varje val behöver framträda som en egen tydlig och klickbar yta och den kompletterande informationen blir relevant först efter valet. Ramen gör det tydligare vilken text som hör till respektive alternativ när innehållet visas.
+Använd inramade alternativ med expanderbar text när varje val behöver framträda som en egen tydlig och klickbar yta och den kompletterande informationen blir relevant först efter valet.
+Ramen gör det tydligare vilken text som hör till respektive alternativ när innehållet visas.
 
 Dölj inte information som användaren behöver för att kunna välja.
 
-```import test-id=border-expandable
+```diff
+-<f-fieldset name="payment-plan">
++<f-fieldset name="payment-plan" border show-details="when-selected">
+```
+
+```import
 FRadioFieldBorderExpandableExample.vue
 ```
 
 ## Migrera från FRadioGroup
 
-`FRadioGroup` och `FRadioGroupField` har tagits bort och ersatts av `FFieldset` respektive `FRadioField`. Se {@link migrating-to-fieldset migreringsguiden} för information om hur du uppdaterar din kod.
+`FRadioGroup` och `FRadioGroupField` har tagits bort och ersatts av `FFieldset` respektive `FRadioField`.
+Se {@link migrating-to-fieldset migreringsguiden} för information om hur du uppdaterar din kod.
 
 ## Props, Events & Slots
 

--- a/packages/vue/src/components/FFieldset/FFieldset.vue
+++ b/packages/vue/src/components/FFieldset/FFieldset.vue
@@ -273,6 +273,11 @@ export default defineComponent({
             -->
             <slot name="description" :description-class :format-description-class></slot>
 
+            <!--
+                @slot Optional slot for displaying one or more error messages.
+                @binding {boolean} hasError Set to true when a validation error is present.
+                @binding {string} validationMessage Descriptive validation error message for the current error.
+            -->
             <slot name="error-message" v-bind="{ hasError, validationMessage: validity.validationMessage }">
                 <template v-if="hasError">
                     <span class="label__message label__message--error">
@@ -310,9 +315,9 @@ export default defineComponent({
                 <slot name="description" :description-class :format-description-class></slot>
 
                 <!--
-                    @slot Slot for displaying single or several error messages.
-                    @binding {boolean} hasError Set to true when a validation error is present
-                    @binding {string} validationMessage Descriptive validation error message for current error
+                    @slot Optional slot for displaying one or more error messages.
+                    @binding {boolean} hasError Set to true when a validation error is present.
+                    @binding {string} validationMessage Descriptive validation error message for the current error.
                 -->
                 <slot name="error-message" v-bind="{ hasError, validationMessage: validity.validationMessage }">
                     <template v-if="hasError">

--- a/packages/vue/src/components/FFieldset/FFieldset.vue
+++ b/packages/vue/src/components/FFieldset/FFieldset.vue
@@ -87,7 +87,7 @@ export default defineComponent({
         /**
          * Sets visibility behaviour for details slot in selectable child items. By default details slot is not rendered.
          *
-         * * `never` (default) - Never show item details.
+         * - `never` (default) - Never show item details.
          * - `when-selected` - Show item details when selected.
          * - `always` - Always show item details.
          */

--- a/packages/vue/src/components/FRadioField/FRadioField.vue
+++ b/packages/vue/src/components/FRadioField/FRadioField.vue
@@ -31,14 +31,15 @@ export default defineComponent({
             default: () => ElementIdService.generateElementId(),
         },
         /**
-         * The value for the input checked attribute.
+         * Current value selected in the radio button group.
+         * The radio button is checked when this value strictly equals the `value` prop.
          */
         modelValue: {
             type: anyType,
             default: () => undefined,
         },
         /**
-         * The value for the input.
+         * The value represented by this radio button.
          */
         value: {
             type: anyType,
@@ -47,9 +48,9 @@ export default defineComponent({
     },
     emits: [
         /**
-         * Emitted when the value of the radiobutton changes.
+         * Emitted when the radio button is selected.
          *
-         * @type {anyType}
+         * @param {anyType} value - Value of the selected radio button.
          */
         "change",
         /**
@@ -185,7 +186,7 @@ export default defineComponent({
             <slot></slot>
             <template v-if="$slots.details">
                 <span v-if="showDetails === 'always'" class="radio-button__details">
-                    <!-- @slot Slot for details, should only contain short text -->
+                    <!-- @slot Slot for additional information about the option. -->
                     <slot name="details"></slot>
                 </span>
                 <transition
@@ -195,7 +196,10 @@ export default defineComponent({
                     @leave="leave"
                 >
                     <span v-if="value === modelValue" class="radio-button__details">
-                        <!-- @slot Slot for details, should only contain short text-->
+                        <!--
+                            @slot Slot for additional information about the option.
+                            @binding {number} height The height of the expanded details content.
+                        -->
                         <slot name="details" :height></slot>
                     </span>
                 </transition>

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldBorderExpandableExample.cy.ts
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldBorderExpandableExample.cy.ts
@@ -1,0 +1,31 @@
+import { FRadioGroupPageObject } from "../../../cypress";
+import Example from "./FRadioFieldBorderExpandableExample.vue";
+
+describe("FRadioFieldBorderExpandableExample", () => {
+    const fieldset = new FRadioGroupPageObject(".fieldset");
+    const firstAlternative = fieldset.radioButton(".radio-button:nth(0)");
+    const secondAlternative = fieldset.radioButton(".radio-button:nth(1)");
+    const thirdAlternative = fieldset.radioButton(".radio-button:nth(2)");
+
+    beforeEach(() => {
+        cy.mount(Example);
+    });
+
+    it("should only expand details within the selected bordered alternative", () => {
+        fieldset.el().should("have.class", "radio-button-group--border");
+        fieldset.numberOfOptions().should("equal", 3);
+        firstAlternative.details().should("not.exist");
+        secondAlternative.details().should("not.exist");
+        thirdAlternative.details().should("not.exist");
+
+        firstAlternative.select();
+        firstAlternative.details().should("be.visible");
+        secondAlternative.details().should("not.exist");
+        thirdAlternative.details().should("not.exist");
+
+        secondAlternative.select();
+        firstAlternative.details().should("not.exist");
+        secondAlternative.details().should("be.visible");
+        thirdAlternative.details().should("not.exist");
+    });
+});

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldBorderExpandableExample.vue
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldBorderExpandableExample.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { FFieldset, FRadioField } from "@fkui/vue";
+
+const paymentPlan = ref<string>();
+</script>
+
+<template>
+    <div class="row">
+        <div class="col col--md-9">
+            <f-fieldset name="payment-plan" border show-details="when-selected">
+                <template #label> Välj en avbetalningsplan </template>
+                <template #description="{ descriptionClass }">
+                    <span :class="descriptionClass"> Alla belopp är inklusive ränta. </span>
+                </template>
+                <f-radio-field v-model="paymentPlan" value="525-12">
+                    525 kronor per månad i 12 månader
+                    <template #details> Du kommer att betala tillbaka 6 300 kronor. </template>
+                </f-radio-field>
+                <f-radio-field v-model="paymentPlan" value="570-11">
+                    570 kronor per månad i 11 månader
+                    <template #details> Du kommer att betala tillbaka 6 270 kronor. </template>
+                </f-radio-field>
+                <f-radio-field v-model="paymentPlan" value="625-10">
+                    625 kronor per månad i 10 månader
+                    <template #details> Du kommer att betala tillbaka 6 250 kronor. </template>
+                </f-radio-field>
+            </f-fieldset>
+        </div>
+    </div>
+</template>

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldBorderExpandableExample.vue
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldBorderExpandableExample.vue
@@ -6,26 +6,22 @@ const paymentPlan = ref<string>();
 </script>
 
 <template>
-    <div class="row">
-        <div class="col col--md-9">
-            <f-fieldset name="payment-plan" border show-details="when-selected">
-                <template #label> Välj en avbetalningsplan </template>
-                <template #description="{ descriptionClass }">
-                    <span :class="descriptionClass"> Alla belopp är inklusive ränta. </span>
-                </template>
-                <f-radio-field v-model="paymentPlan" value="525-12">
-                    525 kronor per månad i 12 månader
-                    <template #details> Du kommer att betala tillbaka 6 300 kronor. </template>
-                </f-radio-field>
-                <f-radio-field v-model="paymentPlan" value="570-11">
-                    570 kronor per månad i 11 månader
-                    <template #details> Du kommer att betala tillbaka 6 270 kronor. </template>
-                </f-radio-field>
-                <f-radio-field v-model="paymentPlan" value="625-10">
-                    625 kronor per månad i 10 månader
-                    <template #details> Du kommer att betala tillbaka 6 250 kronor. </template>
-                </f-radio-field>
-            </f-fieldset>
-        </div>
-    </div>
+    <f-fieldset name="payment-plan" border show-details="when-selected">
+        <template #label> Välj en avbetalningsplan </template>
+        <template #description="{ descriptionClass }">
+            <span :class="descriptionClass"> Alla belopp är inklusive ränta. </span>
+        </template>
+        <f-radio-field v-model="paymentPlan" value="525-12">
+            525 kronor per månad i 12 månader
+            <template #details> Du kommer att betala tillbaka 6 300 kronor. </template>
+        </f-radio-field>
+        <f-radio-field v-model="paymentPlan" value="570-11">
+            570 kronor per månad i 11 månader
+            <template #details> Du kommer att betala tillbaka 6 270 kronor. </template>
+        </f-radio-field>
+        <f-radio-field v-model="paymentPlan" value="625-10">
+            625 kronor per månad i 10 månader
+            <template #details> Du kommer att betala tillbaka 6 250 kronor. </template>
+        </f-radio-field>
+    </f-fieldset>
 </template>

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldDetailsAlwaysExample.cy.ts
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldDetailsAlwaysExample.cy.ts
@@ -1,0 +1,21 @@
+import { FRadioGroupPageObject } from "../../../cypress";
+import Example from "./FRadioFieldDetailsAlwaysExample.vue";
+
+describe("FRadioFieldDetailsAlwaysExample", () => {
+    const fieldset = new FRadioGroupPageObject(".fieldset");
+
+    beforeEach(() => {
+        cy.mount(Example);
+    });
+
+    it("should display details for all alternatives", () => {
+        fieldset
+            .radioButton(".radio-button:nth(0)")
+            .details()
+            .should("be.visible");
+        fieldset
+            .radioButton(".radio-button:nth(1)")
+            .details()
+            .should("be.visible");
+    });
+});

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldDetailsAlwaysExample.vue
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldDetailsAlwaysExample.vue
@@ -6,19 +6,15 @@ const illness = ref<string>();
 </script>
 
 <template>
-    <div class="row">
-        <div class="col col--md-9">
-            <f-fieldset name="illness" show-details="always">
-                <template #label> Vad hade barnet? </template>
-                <f-radio-field v-model="illness" value="temporary">
-                    Tillfällig sjukdom
-                    <template #details> som förkylning eller brutet ben </template>
-                </f-radio-field>
-                <f-radio-field v-model="illness" value="long-term">
-                    Långvarig sjukdom
-                    <template #details> som diabetes eller astma </template>
-                </f-radio-field>
-            </f-fieldset>
-        </div>
-    </div>
+    <f-fieldset name="illness" show-details="always">
+        <template #label> Vad hade barnet? </template>
+        <f-radio-field v-model="illness" value="temporary">
+            Tillfällig sjukdom
+            <template #details> som förkylning eller brutet ben </template>
+        </f-radio-field>
+        <f-radio-field v-model="illness" value="long-term">
+            Långvarig sjukdom
+            <template #details> som diabetes eller astma </template>
+        </f-radio-field>
+    </f-fieldset>
 </template>

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldDetailsAlwaysExample.vue
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldDetailsAlwaysExample.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { FFieldset, FRadioField } from "@fkui/vue";
+
+const illness = ref<string>();
+</script>
+
+<template>
+    <div class="row">
+        <div class="col col--md-9">
+            <f-fieldset name="illness" show-details="always">
+                <template #label> Vad hade barnet? </template>
+                <f-radio-field v-model="illness" value="temporary">
+                    Tillfällig sjukdom
+                    <template #details> som förkylning eller brutet ben </template>
+                </f-radio-field>
+                <f-radio-field v-model="illness" value="long-term">
+                    Långvarig sjukdom
+                    <template #details> som diabetes eller astma </template>
+                </f-radio-field>
+            </f-fieldset>
+        </div>
+    </div>
+</template>

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.cy.ts
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.cy.ts
@@ -1,6 +1,4 @@
 import { FRadioGroupPageObject } from "../../../cypress";
-import FRadioFieldBorderExpandableExample from "./FRadioFieldBorderExpandableExample.vue";
-import FRadioFieldDetailsAlwaysExample from "./FRadioFieldDetailsAlwaysExample.vue";
 import Example from "./FRadioFieldLiveExample.vue";
 
 describe("FRadioFieldLiveExample", () => {
@@ -39,55 +37,5 @@ describe("FRadioFieldLiveExample", () => {
                 .isSelected()
                 .should("equal", false);
         });
-    });
-});
-
-describe("FRadioFieldDetailsAlwaysExample", () => {
-    const fieldset = new FRadioGroupPageObject(".fieldset");
-
-    beforeEach(() => {
-        cy.mount(FRadioFieldDetailsAlwaysExample);
-    });
-
-    it("should display details for all alternatives", () => {
-        cy.get(".col").should("have.class", "col--md-9");
-        fieldset
-            .radioButton(".radio-button:nth(0)")
-            .details()
-            .should("be.visible");
-        fieldset
-            .radioButton(".radio-button:nth(1)")
-            .details()
-            .should("be.visible");
-    });
-});
-
-describe("FRadioFieldBorderExpandableExample", () => {
-    const fieldset = new FRadioGroupPageObject(".fieldset");
-    const firstAlternative = fieldset.radioButton(".radio-button:nth(0)");
-    const secondAlternative = fieldset.radioButton(".radio-button:nth(1)");
-    const thirdAlternative = fieldset.radioButton(".radio-button:nth(2)");
-
-    beforeEach(() => {
-        cy.mount(FRadioFieldBorderExpandableExample);
-    });
-
-    it("should only expand details within the selected bordered alternative", () => {
-        cy.get(".col").should("have.class", "col--md-9");
-        fieldset.el().should("have.class", "radio-button-group--border");
-        fieldset.numberOfOptions().should("equal", 3);
-        firstAlternative.details().should("not.exist");
-        secondAlternative.details().should("not.exist");
-        thirdAlternative.details().should("not.exist");
-
-        firstAlternative.select();
-        firstAlternative.details().should("be.visible");
-        secondAlternative.details().should("not.exist");
-        thirdAlternative.details().should("not.exist");
-
-        secondAlternative.select();
-        firstAlternative.details().should("not.exist");
-        secondAlternative.details().should("be.visible");
-        thirdAlternative.details().should("not.exist");
     });
 });

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.cy.ts
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.cy.ts
@@ -1,4 +1,6 @@
 import { FRadioGroupPageObject } from "../../../cypress";
+import FRadioFieldBorderExpandableExample from "./FRadioFieldBorderExpandableExample.vue";
+import FRadioFieldDetailsAlwaysExample from "./FRadioFieldDetailsAlwaysExample.vue";
 import Example from "./FRadioFieldLiveExample.vue";
 
 describe("FRadioFieldLiveExample", () => {
@@ -46,5 +48,55 @@ describe("FRadioFieldLiveExample", () => {
                 .isSelected()
                 .should("equal", false);
         });
+    });
+});
+
+describe("FRadioFieldDetailsAlwaysExample", () => {
+    const fieldset = new FRadioGroupPageObject(".fieldset");
+
+    beforeEach(() => {
+        cy.mount(FRadioFieldDetailsAlwaysExample);
+    });
+
+    it("should display details for all alternatives", () => {
+        cy.get(".col").should("have.class", "col--md-9");
+        fieldset
+            .radioButton(".radio-button:nth(0)")
+            .details()
+            .should("be.visible");
+        fieldset
+            .radioButton(".radio-button:nth(1)")
+            .details()
+            .should("be.visible");
+    });
+});
+
+describe("FRadioFieldBorderExpandableExample", () => {
+    const fieldset = new FRadioGroupPageObject(".fieldset");
+    const firstAlternative = fieldset.radioButton(".radio-button:nth(0)");
+    const secondAlternative = fieldset.radioButton(".radio-button:nth(1)");
+    const thirdAlternative = fieldset.radioButton(".radio-button:nth(2)");
+
+    beforeEach(() => {
+        cy.mount(FRadioFieldBorderExpandableExample);
+    });
+
+    it("should only expand details within the selected bordered alternative", () => {
+        cy.get(".col").should("have.class", "col--md-9");
+        fieldset.el().should("have.class", "radio-button-group--border");
+        fieldset.numberOfOptions().should("equal", 3);
+        firstAlternative.details().should("not.exist");
+        secondAlternative.details().should("not.exist");
+        thirdAlternative.details().should("not.exist");
+
+        firstAlternative.select();
+        firstAlternative.details().should("be.visible");
+        secondAlternative.details().should("not.exist");
+        thirdAlternative.details().should("not.exist");
+
+        secondAlternative.select();
+        firstAlternative.details().should("not.exist");
+        secondAlternative.details().should("be.visible");
+        thirdAlternative.details().should("not.exist");
     });
 });

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.cy.ts
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.cy.ts
@@ -7,9 +7,9 @@ describe("FRadioFieldLiveExample", () => {
     const fieldset = new FRadioGroupPageObject(
         ".live-example__example fieldset",
     );
-    enum barnover18 {
-        Ja = ".radio-button:nth(0)",
-        Nej = ".radio-button:nth(1)",
+    enum Answer {
+        Yes = ".radio-button:nth(0)",
+        No = ".radio-button:nth(1)",
     }
 
     describe("Basic functionality in FRadioFieldLiveExample", () => {
@@ -23,28 +23,19 @@ describe("FRadioFieldLiveExample", () => {
             fieldset.numberOfOptions().should("equal", 2);
 
             fieldset
-                .radioButton(barnover18.Ja)
+                .radioButton(Answer.Yes)
                 .isSelected()
                 .should("equal", false);
-            fieldset
-                .radioButton(barnover18.Nej)
-                .isSelected()
-                .should("equal", false);
+            fieldset.radioButton(Answer.No).isSelected().should("equal", false);
 
-            fieldset.radioButton(barnover18.Ja).select();
-            fieldset
-                .radioButton(barnover18.Ja)
-                .isSelected()
-                .should("equal", true);
-            fieldset.radioButton(barnover18.Nej).select();
+            fieldset.radioButton(Answer.Yes).select();
+            fieldset.radioButton(Answer.Yes).isSelected().should("equal", true);
+            fieldset.radioButton(Answer.No).select();
+
+            fieldset.radioButton(Answer.No).isSelected().should("equal", true);
 
             fieldset
-                .radioButton(barnover18.Nej)
-                .isSelected()
-                .should("equal", true);
-
-            fieldset
-                .radioButton(barnover18.Ja)
+                .radioButton(Answer.Yes)
                 .isSelected()
                 .should("equal", false);
         });

--- a/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.vue
+++ b/packages/vue/src/components/FRadioField/examples/FRadioFieldLiveExample.vue
@@ -1,25 +1,20 @@
 <!-- eslint-disable vue/component-api-style -- technical debt: should be migrated from options to composition api -->
 <script lang="ts">
 import { defineComponent } from "vue";
-import { DateFormat, FDate } from "@fkui/date";
 import { LiveExample } from "@forsakringskassan/docs-live-example";
-import { FCheckboxField, FFieldset, FRadioField, FSelectField, FTooltip } from "@fkui/vue";
-
-const todaysDate = FDate.now().toString(DateFormat.ISO8601);
+import { FCheckboxField, FFieldset, FRadioField, FTooltip } from "@fkui/vue";
 
 export default defineComponent({
     name: "FRadioFieldLiveExample",
-    components: { LiveExample, FCheckboxField, FFieldset, FRadioField, FSelectField },
+    components: { LiveExample, FCheckboxField, FFieldset, FRadioField },
     data() {
         return {
             isHorizontal: false,
-            isBorder: false,
             isPreselected: false,
             isDisabled: false,
             isRequired: false,
             tooltipVisible: false,
             descriptionVisible: false,
-            showDetails: "never",
         };
     },
     computed: {
@@ -38,15 +33,10 @@ export default defineComponent({
         tooltip(): string {
             const template = /* HTML */ `
                 <template #tooltip>
-                    <f-tooltip
-                        screen-reader-text="Läs mer om Bor det barn som har fyllt 18 år i bostaden?"
-                        header-tag="h2"
-                    >
-                        <template #header> Bor det barn som har fyllt 18 år i bostaden? </template>
+                    <f-tooltip screen-reader-text="Läs mer om ersättning från utlandet">
                         <template #body>
-                            Här svarar du på om du har ett eller flera barn som fyllt 18 i din
-                            bostad. Alla personer som fyllt 18 idag (${todaysDate}) eller tidigare
-                            på året beräknas med i denna grupp.
+                            Om du redan får ersättning från ett annat land för samma period kan du
+                            inte få full ersättning från Sverige.
                         </template>
                     </f-tooltip>
                 </template>
@@ -57,41 +47,23 @@ export default defineComponent({
             const template = /* HTML */ `
                 <template #description="{ descriptionClass }">
                     <span :class="descriptionClass">
-                        Här svarar du på om du har ett eller flera barn som fyllt 18 i din bostad.
+                        Till exempel a-kassa, sjukpenning eller föräldrapenning från något annat
+                        land än Sverige.
                     </span>
                 </template>
             `;
             return this.descriptionVisible ? template : "";
         },
-        showDetailsAttr(): string {
-            if (this.showDetails === "never") {
-                return "";
-            }
-            return `show-details="${this.showDetails}"`;
-        },
-        details(): string {
-            const template = /* HTML */ `
-                <template #details>
-                    Här svarar du på om du har ett eller flera barn som fyllt 18 i din bostad.
-                </template>
-            `;
-            return this.showDetails !== "never" ? template : "";
-        },
         radioFields(): string {
             return /* HTML */ `
-                <f-radio-field v-model="modelValue" :value="true">
-                    Ja, det bor barn över 18 år där ${this.details}
-                </f-radio-field>
+                <f-radio-field v-model="modelValue" :value="true"> Ja </f-radio-field>
                 <f-radio-field v-model="modelValue" :value="false" ${this.disabled}>
-                    Nej, inga barn över 18 år bor där ${this.details}
+                    Nej
                 </f-radio-field>
             `;
         },
         horizontal(): string {
             return this.isHorizontal ? "horizontal" : "";
-        },
-        border(): string {
-            return this.isBorder ? "border" : "";
         },
         disabled(): string {
             return this.isDisabled ? "disabled" : "";
@@ -101,23 +73,12 @@ export default defineComponent({
         },
         template(): string {
             return /* HTML */ `
-                <f-fieldset
-                    name="barn-over-18"
-                    ${this.horizontal}
-                    ${this.required}
-                    ${this.border}
-                    ${this.showDetailsAttr}
-                >
-                    <template #label> Bor det barn som har fyllt 18 år i bostaden? </template>
+                <f-fieldset name="ersattning-fran-utlandet" ${this.horizontal} ${this.required}>
+                    <template #label> Får du ersättning från utlandet? </template>
                     ${this.tooltip} ${this.description}
                     <template #default> ${this.radioFields} </template>
                 </f-fieldset>
             `;
-        },
-    },
-    methods: {
-        onHorizontalChange() {
-            this.isBorder = this.isHorizontal ? false : this.isBorder;
         },
     },
 });
@@ -125,37 +86,35 @@ export default defineComponent({
 
 <template>
     <live-example :components :template :livedata>
-        <f-fieldset name="radio-orientation" @change="onHorizontalChange">
+        <f-fieldset name="radio-orientation">
             <template #label> Placering </template>
-            <f-radio-field v-model="isHorizontal" :value="false">
-                Vertikalt (standard)</f-radio-field
-            >
+            <f-radio-field v-model="isHorizontal" :value="false"> Vertikalt </f-radio-field>
             <f-radio-field v-model="isHorizontal" :value="true"> Horisontellt </f-radio-field>
         </f-fieldset>
 
-        <f-checkbox-field v-if="!isHorizontal" v-model="isBorder" :value="true">
-            Ram
-        </f-checkbox-field>
-        <f-checkbox-field v-model="isPreselected" :value="true">
-            Förvald radioknapp
-        </f-checkbox-field>
-        <f-checkbox-field v-model="isDisabled" :value="true">
-            Inaktiverad radioknapp
-        </f-checkbox-field>
-        <f-checkbox-field v-model="isRequired" :value="true"> Obligatoriskt val </f-checkbox-field>
+        <f-fieldset name="radio-options">
+            <template #label> Egenskaper </template>
+            <f-checkbox-field v-model="isPreselected" :value="true">
+                Förvald radioknapp
+            </f-checkbox-field>
+            <f-checkbox-field v-model="isDisabled" :value="true">
+                Inaktiverad radioknapp
+            </f-checkbox-field>
+        </f-fieldset>
 
         <f-fieldset name="radio-label">
-            <template #label> Etiketten </template>
+            <template #label> Etikett </template>
             <f-checkbox-field v-model="tooltipVisible" :value="true"> Tooltip </f-checkbox-field>
             <f-checkbox-field v-model="descriptionVisible" :value="true">
                 Hjälptext
             </f-checkbox-field>
-            <f-select-field v-model="showDetails">
-                <template #label> Utökad etikett </template>
-                <option value="never">Nej</option>
-                <option value="always">Utvidgad text</option>
-                <option value="when-selected">Expanderbar text</option>
-            </f-select-field>
+        </f-fieldset>
+
+        <f-fieldset name="radio-validation">
+            <template #label> Validering </template>
+            <f-checkbox-field v-model="isRequired" :value="true">
+                Obligatoriskt val
+            </f-checkbox-field>
         </f-fieldset>
     </live-example>
 </template>


### PR DESCRIPTION
Förslag till utökad och förbättrad dokumentation för radioknapp.

Sammanfattningsvis bygger upplägget på att det generella liveexemplet endast innehåller relevanta och meningsfulla inställningar. Varianter som behöver ett tydligare sammanhang visas i separata, konkreta exempel. Detta kompletteras med tydligare vägledning om komponentens användning och tillhörande designmönster. Samma princip kan användas när dokumentationen för andra komponenter vidareutvecklas.

Viktigaste förbättringar:
- Ett renodlat generellt liveexempel som endast visar relevanta och meningsfulla inställningar.
- Två separata exempel för vanliga varianter:
  - kompletterande text som alltid visas
  - inramade alternativ med expanderbar text
- Tydligare vägledning om när radioknappar, olika placeringar, förvalda alternativ och inaktiverade alternativ bör användas.
- Beskrivning av hur kompletterande text och ram kan användas och kombineras.
- Tydligare migreringsinformation med länk till migreringsguiden.
- Korrigerade och förtydligade tekniska beskrivningar av props, events och slots.
- Utökade Cypress-komponenttester som täcker samtliga körbara exempel på sidan.

Ändringarna påverkar endast dokumentation, liveexempel och API-kommentarer. Ingen komponentfunktionalitet, publik API-signatur eller komponentstyling har ändrats.