### PR TITLE
ci: ignore artifact size workflow for forks (refs SFKUI-6500)

### DIFF
--- a/.github/workflows/artifact-size.yml
+++ b/.github/workflows/artifact-size.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
     analyze-base:
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         name: Analyze (base)
         runs-on: ubuntu-latest
         steps:
@@ -33,6 +34,7 @@ jobs:
                   artifact-name: base-size
 
     analyze-current:
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         name: Analyze (current)
         runs-on: ubuntu-latest
         steps:
@@ -57,6 +59,7 @@ jobs:
                   artifact-name: current-size
 
     compare:
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         name: Compare
         permissions:
             contents: read


### PR DESCRIPTION
Byggen i #1622 går inte igenom då artifact-size workflow kräver att man har åtkomst till original repot. Övertygad om att det där går att lösa men vi kan börja med att stänga av det (likt hur vi gjort för andra workflows)