### PR TITLE
feat: deprecate ICalenderNavbarPageObject.text() (refs SFKUI-8092)

### DIFF
--- a/etc/vue-cypress.api.md
+++ b/etc/vue-cypress.api.md
@@ -853,8 +853,10 @@ export class ICalendarNavbarPageObject implements BasePageObject {
     prevButton(): DefaultCypressChainable;
     // (undocumented)
     selector: string;
-    // (undocumented)
+    // @deprecated (undocumented)
     text(): DefaultCypressChainable;
+    // (undocumented)
+    title(): DefaultCypressChainable;
     // @internal (undocumented)
     yearSelectorButton(): DefaultCypressChainable;
 }

--- a/packages/vue/src/components/FCalendar/FCalendar.cy.ts
+++ b/packages/vue/src/components/FCalendar/FCalendar.cy.ts
@@ -44,50 +44,50 @@ describe("FCalendar default", () => {
     it("FCalendar", () => {
         calendar.el().scrollIntoView();
         calendar.navigationBar
-            .text()
+            .title()
             .should("have.trimmedText", "Oktober 2022");
         calendar.navigationBar.nextButton().click();
         calendar.navigationBar
-            .text()
+            .title()
             .should("have.trimmedText", "November 2022");
 
         calendar.weekNumbers().eq(2).should("have.trimmedText", "46");
         calendar.headerCells().eq(0).should("have.trimmedText", "mån");
         calendar.headerCells().eq(-1).should("have.trimmedText", "sön");
         calendar.navigateTo(2022, 6);
-        calendar.navigationBar.text().should("have.trimmedText", "Juli 2022");
+        calendar.navigationBar.title().should("have.trimmedText", "Juli 2022");
         calendar.navigateTo(2022, 8);
         calendar.navigationBar
-            .text()
+            .title()
             .should("have.trimmedText", "September 2022");
 
         calendar.navigateTo(2023, 2);
-        calendar.navigationBar.text().should("have.trimmedText", "Mars 2023");
+        calendar.navigationBar.title().should("have.trimmedText", "Mars 2023");
 
         calendar.navigateTo(2024, 4);
-        calendar.navigationBar.text().should("have.trimmedText", "Maj 2024");
+        calendar.navigationBar.title().should("have.trimmedText", "Maj 2024");
 
         calendar.navigateTo(2025, 4);
-        calendar.navigationBar.text().should("have.trimmedText", "Maj 2025");
+        calendar.navigationBar.title().should("have.trimmedText", "Maj 2025");
 
         calendar.navigateTo(2026, 0);
         calendar.navigationBar
-            .text()
+            .title()
             .should("have.trimmedText", "Januari 2026");
 
         calendar.navigateTo(2025, 11);
         calendar.navigationBar
-            .text()
+            .title()
             .should("have.trimmedText", "December 2025");
 
         calendar.navigateTo(2024, 10);
         calendar.navigationBar
-            .text()
+            .title()
             .should("have.trimmedText", "November 2024");
 
         calendar.navigateTo(2023, 11);
         calendar.navigationBar
-            .text()
+            .title()
             .should("have.trimmedText", "December 2023");
 
         calendar.day(1).number().should("have.trimmedText", "1");

--- a/packages/vue/src/cypress/FDatepickerField.pageobject.ts
+++ b/packages/vue/src/cypress/FDatepickerField.pageobject.ts
@@ -51,7 +51,7 @@ export class FDatepickerFieldPageobject implements BasePageObject {
     }
 
     public calendarCaption(): DefaultCypressChainable {
-        return this.calendarNavbar.text();
+        return this.calendarNavbar.title();
     }
 
     /**

--- a/packages/vue/src/cypress/ICalendar/Calendar.pageobject.ts
+++ b/packages/vue/src/cypress/ICalendar/Calendar.pageobject.ts
@@ -37,12 +37,12 @@ export class CalendarPageObject implements BasePageObject {
     }
 
     /**
-     * Get the caption text.
+     * Get the caption title.
      *
      * @internal
      */
     public calendarCaption(): DefaultCypressChainable {
-        return this.navigationBar.text();
+        return this.navigationBar.title();
     }
 
     /**
@@ -86,7 +86,7 @@ export class CalendarPageObject implements BasePageObject {
      */
     public navigateTo(targetYear: number, targetMonth: number): void {
         cy.log(`Navigate to ${monthList[targetMonth]} ${String(targetYear)}`);
-        this.navigationBar.text().then((el) => {
+        this.navigationBar.title().then((el) => {
             let currYear = 2023;
             let currentMonth = 0;
             el.text().replace(

--- a/packages/vue/src/cypress/ICalendarNavbar.pageobject.ts
+++ b/packages/vue/src/cypress/ICalendarNavbar.pageobject.ts
@@ -17,7 +17,14 @@ export class ICalendarNavbarPageObject implements BasePageObject {
         return cy.get(this.selector);
     }
 
+    /**
+     * @deprecated Use title() instead. Deprecated since %version%.
+     */
     public text(): DefaultCypressChainable {
+        return cy.get(`${this.selector} .calendar-navbar__month--title`);
+    }
+
+    public title(): DefaultCypressChainable {
         return cy.get(`${this.selector} .calendar-navbar__month--title`);
     }
 


### PR DESCRIPTION
Use ICalenderNavbarPageObject.title() instead.