### PR TITLE
fix: ´IComboboxDropdown´ add mousedown to li element (refs SFKUI-8129)

### DIFF
--- a/internal/vue-sandbox/src/views/DefaultView.vue
+++ b/internal/vue-sandbox/src/views/DefaultView.vue
@@ -7,8 +7,30 @@ export default defineComponent({
     components: { FTextField },
     data() {
         return {
-            awesomeModel: "",
+            valtLand: "",
+            valdStad: "",
+            land: ["Svalbard och Jan Mayen", "Swaziland", "Sverige"],
+            valtLandsStader: [] as string[],
+            kommuner: {
+                Sverige: ["Karlskrona", "Sundsvall", "Östersund", "Stockholm"],
+            },
         };
+    },
+    methods: {
+        onUpdate(value: string): void {
+            console.log("update", value);
+        },
+        onChangeCities(): void {
+            console.log("onChangeCities");
+        },
+        onUpdateCities(): void {
+            console.log("onUpdateCities");
+        },
+        async onChangeCountry(value: string): Promise<void> {
+            console.log("change :", value);
+            await new Promise((resolve) => setTimeout(resolve, 750));
+            this.valtLandsStader = this.kommuner[value as keyof typeof this.kommuner];
+        },
     },
 });
 </script>
@@ -25,14 +47,25 @@ export default defineComponent({
         </p>
         <hr />
         <f-text-field
-            id="awesome-field"
-            v-model="awesomeModel"
-            v-validation.required.maxLength="{ maxLength: { length: 10 } }"
+            v-model="valtLand"
+            v-validation.allowList="{ allowList: { list: land } }"
+            maxlength="100"
+            :options="land"
+            @change="onChangeCountry"
+            @update:model-value="onUpdate"
         >
-            <template #default> Inmatningsfält. </template>
-            <template #description="{ descriptionClass }">
-                <span :class="descriptionClass"> Lorem ipsum dolor sit amet. </span>
-            </template>
+            <template #default> Välj land </template>
+        </f-text-field>
+        <div>valtLand:{{ valtLand }}</div>
+        <f-text-field
+            v-model="valdStad"
+            v-validation.allowList="{ allowList: { list: valtLandsStader } }"
+            maxlength="100"
+            :options="valtLandsStader"
+            @change="onChangeCities"
+            @update:model-value="onUpdateCities"
+        >
+            <template #default> Välj stad </template>
         </f-text-field>
     </div>
 </template>

--- a/packages/vue/src/components/FTextField/FTextField.vue
+++ b/packages/vue/src/components/FTextField/FTextField.vue
@@ -269,9 +269,15 @@ export default defineComponent({
         onDropdownSelect(value: string): void {
             this.selectOption(value);
             this.$emit("update:modelValue", value);
+            this.$emit("change", value);
         },
         onDropdownClose(): void {
             this.closeDropdown();
+        },
+        onInputSelect(event: Event): void {
+            const targetEvent = event as CustomEvent<string>;
+            this.$emit("update:modelValue", targetEvent.detail);
+            this.$emit("change", targetEvent.detail);
         },
         getErrorPopupAnchor(): HTMLElement {
             return this.$refs.input as HTMLElement;
@@ -324,7 +330,6 @@ export default defineComponent({
                     newModelValue = this.viewValue;
                 }
                 this.lastModelValue = newModelValue;
-
                 this.$emit("update:modelValue", newModelValue);
                 await this.$nextTick(); // wait for model update before triggering change, blur event
 
@@ -480,6 +485,7 @@ export default defineComponent({
                     :type
                     class="text-field__input"
                     v-bind="$attrs"
+                    @select="onInputSelect"
                     @blur="onBlur"
                     @focus="onFocus"
                     @change="onChange"

--- a/packages/vue/src/internal-components/combobox/IComboboxDropdown.vue
+++ b/packages/vue/src/internal-components/combobox/IComboboxDropdown.vue
@@ -23,7 +23,6 @@ function isOptionActive(item: string): boolean {
 function onOptionClick(value: string): void {
     emit("select", value);
 }
-
 function onListboxClose(): void {
     emit("close");
 }
@@ -60,6 +59,7 @@ watchEffect(async () => {
                     class="combobox__listbox__option"
                     :class="{ 'combobox__listbox__option--highlight': isOptionActive(item) }"
                     @click.stop.prevent="onOptionClick(item)"
+                    @mousedown.stop.prevent
                 >
                     {{ item }}
                 </li>

--- a/packages/vue/src/internal-components/combobox/combobox.cy.ts
+++ b/packages/vue/src/internal-components/combobox/combobox.cy.ts
@@ -517,6 +517,75 @@ describe("Validation", () => {
         );
     });
 
+    describe("ComboBox update model", () => {
+        const TestComponent = defineComponent({
+            name: "TestComponent",
+            template: /* HTML */ `
+                <f-text-field
+                    v-model="valtLand"
+                    v-validation.allowList="{ allowList: { list: land } }"
+                    :options="land"
+                    @change="onChange"
+                    @update:model-value="onUpdate"
+                >
+                    <template #default> Välj land </template>
+                </f-text-field>
+            `,
+            components: {
+                FTextField,
+            },
+            data() {
+                return {
+                    changeEvent: [] as string[],
+                    updateEvent: [] as string[],
+                    valtLand: "",
+                    land: ["Svalbard och Jan Mayen", "Swaziland", "Sverige"],
+                };
+            },
+            methods: {
+                onChange(value: string): void {
+                    this.changeEvent.push(value);
+                },
+                onUpdate(value: string): void {
+                    this.updateEvent.push(value);
+                },
+            },
+        });
+
+        it("should never set valtLand to 'sv' during input and selection", () => {
+            cy.mount(TestComponent).then(({ wrapper }) => {
+                cy.get("input").should("be.visible");
+
+                cy.get("input").realClick();
+                cy.get("input").realType("sv");
+
+                cy.contains("li", "Sverige").should("be.visible").realClick();
+
+                cy.wrap(wrapper.vm).its("valtLand").should("equal", "Sverige");
+                cy.wrap(wrapper.vm)
+                    .its("changeEvent")
+                    .should("deep.equal", ["Sverige"]);
+                cy.wrap(wrapper.vm)
+                    .its("updateEvent")
+                    .should("deep.equal", ["Sverige"]);
+            });
+        });
+
+        it("should set typed value", () => {
+            cy.mount(TestComponent).then(({ wrapper }) => {
+                cy.get("input").should("be.visible").click();
+
+                cy.get("input").type("Norge");
+                cy.get("input").blur();
+
+                cy.wrap(wrapper.vm).its("valtLand").should("equal", "Norge");
+                cy.wrap(wrapper.vm)
+                    .its("changeEvent")
+                    .should("deep.equal", ["Norge"]);
+            });
+        });
+    });
+
     describe("`forced-colors` media feature", () => {
         const defaultMountOptions = {
             props: {

--- a/packages/vue/src/internal-components/combobox/use-combobox.ts
+++ b/packages/vue/src/internal-components/combobox/use-combobox.ts
@@ -274,6 +274,12 @@ export function useCombobox(
             case "Enter":
                 if (dropdownIsOpen.value) {
                     if (activeOption.value) {
+                        inputRef.value?.dispatchEvent(
+                            new CustomEvent<string>("select", {
+                                bubbles: false,
+                                detail: activeOption.value,
+                            }),
+                        );
                         selectOption(activeOption.value);
                         flag = true;
                     }


### PR DESCRIPTION
Innan fix:
 man börjar skriva ett värde och väljer sedan önskat val från listan, det som händer då är att change triggas först och uppdaterar modellen med det påbörjade värdet.  Om konsument gör ett anrop till backend från change så blir det fel. I nästa steg triggas select från klick och uppdatera modellen med det önskade värdet.

