### PR TITLE
fix: only activate hover style on devices that can hover (fixes SFKUI-8163)

### DIFF
--- a/docs/src/docs-theme.scss
+++ b/docs/src/docs-theme.scss
@@ -99,9 +99,11 @@ footer {
 
     .anchor,
     #version button {
-        &:hover {
-            color: palette.$palette-color-fk-black-100;
-            text-decoration-color: palette.$palette-color-fk-black-100;
+        @media (hover: hover) {
+            &:hover {
+                color: palette.$palette-color-fk-black-100;
+                text-decoration-color: palette.$palette-color-fk-black-100;
+            }
         }
     }
 
@@ -130,7 +132,13 @@ footer {
                 @include fkui.focus-indicator;
             }
 
-            &:hover,
+            @media (hover: hover) {
+                &:hover {
+                    background: transparent;
+                    cursor: pointer;
+                }
+            }
+
             &:active {
                 background: transparent;
                 cursor: pointer;

--- a/packages/design/src/components/button/_button.scss
+++ b/packages/design/src/components/button/_button.scss
@@ -233,9 +233,17 @@ $button--tertiary: (
         &--black {
             color: $button-tertiary-muted-color-text-default;
 
-            &:hover,
-            &:active,
             &:focus-visible {
+                color: $button-tertiary-muted-color-text-focus;
+            }
+
+            @media (hover: hover) {
+                &:hover {
+                    color: $button-tertiary-muted-color-text-focus;
+                }
+            }
+
+            &:active {
                 color: $button-tertiary-muted-color-text-focus;
             }
         }
@@ -243,9 +251,19 @@ $button--tertiary: (
         &--inverted {
             color: $button-tertiary-inverted-color-text-default;
 
-            &:hover,
-            &:active,
             &:focus-visible {
+                color: $button-tertiary-inverted-color-text-focus;
+                background-color: $button-tertiary-inverted-color-background-focus;
+            }
+
+            @media (hover: hover) {
+                &:hover {
+                    color: $button-tertiary-inverted-color-text-focus;
+                    background-color: $button-tertiary-inverted-color-background-focus;
+                }
+            }
+
+            &:active {
                 color: $button-tertiary-inverted-color-text-focus;
                 background-color: $button-tertiary-inverted-color-background-focus;
             }

--- a/packages/design/src/components/calendar-day/_calendar-day.scss
+++ b/packages/design/src/components/calendar-day/_calendar-day.scss
@@ -84,12 +84,14 @@ $calendar-highlight-border: var(--f-border-width-small) solid $calendarday-highl
         }
     }
 
-    &:hover:not(&--disabled, &--selected),
-    &--hover:not(&--disabled, &--selected) {
-        background-color: $calendarday-color-background-hover;
-        color: $calendarday-color-text-hover;
+    @media (hover: hover) {
+        &:hover:not(&--disabled, &--selected),
+        &--hover:not(&--disabled, &--selected) {
+            background-color: $calendarday-color-background-hover;
+            color: $calendarday-color-text-hover;
 
-        @include forcedcolors.hover-indicator(border, 2px);
+            @include forcedcolors.hover-indicator(border, 2px);
+        }
     }
 
     &:active:not(&--disabled),

--- a/packages/design/src/components/chip/_chip.scss
+++ b/packages/design/src/components/chip/_chip.scss
@@ -58,12 +58,14 @@ $chip-border-width: var(--f-border-width-medium);
             }
         }
 
-        .#{$item}__label:hover {
-            border-color: $chip-color-border-hover;
-            background-color: $chip-color-background-hover;
-            color: $chip-color-text-hover;
+        @media (hover: hover) {
+            .#{$item}__label:hover {
+                border-color: $chip-color-border-hover;
+                background-color: $chip-color-background-hover;
+                color: $chip-color-text-hover;
 
-            @include forcedcolors.hover-indicator(border, $chip-border-width);
+                @include forcedcolors.hover-indicator(border, $chip-border-width);
+            }
         }
 
         input[type="#{$type}"]:checked + .#{$item}__label {

--- a/packages/design/src/components/combobox/_combobox.scss
+++ b/packages/design/src/components/combobox/_combobox.scss
@@ -12,10 +12,12 @@
 .combobox__listbox__option {
     @include listbox.option;
 
-    // .is-hover only for screenshot selector
-    &.is-hover,
-    &:hover:not(&--highlight) {
-        @include listbox.option-hover;
+    @media (hover: hover) {
+        // .is-hover only for screenshot selector
+        &.is-hover,
+        &:hover:not(&--highlight) {
+            @include listbox.option-hover;
+        }
     }
 
     &--highlight {

--- a/packages/design/src/components/contextmenu/_contextmenu.scss
+++ b/packages/design/src/components/contextmenu/_contextmenu.scss
@@ -30,10 +30,12 @@
                 color: $contextmenu-color-text-active;
             }
 
-            &:hover {
-                color: $contextmenu-color-text-hover;
-                background-color: $contextmenu-color-item-background-hover;
-                @include forcedcolors.hover-indicator(outline, 2px);
+            @media (hover: hover) {
+                &:hover {
+                    color: $contextmenu-color-text-hover;
+                    background-color: $contextmenu-color-item-background-hover;
+                    @include forcedcolors.hover-indicator(outline, 2px);
+                }
             }
 
             // when desktop, long texts expands popup

--- a/packages/design/src/components/datepicker-field/_datepicker-field.scss
+++ b/packages/design/src/components/datepicker-field/_datepicker-field.scss
@@ -30,15 +30,18 @@ $calendar-width: calc(100vw - #{$popup-spacing});
             }
         }
 
-        &:hover {
-            .icon {
-                color: $datepickerfield-f-icon-calendar-color-content-hover;
+        @media (hover: hover) {
+            &:hover {
+                .icon {
+                    color: $datepickerfield-f-icon-calendar-color-content-hover;
 
-                @media (forced-colors: active) {
-                    color: LinkText;
+                    @media (forced-colors: active) {
+                        color: LinkText;
+                    }
                 }
             }
         }
+
         &:disabled .icon {
             color: $datepickerfield-f-icon-calendar-color-content-disabled;
 

--- a/packages/design/src/components/dialogue-tree/_dialogue-tree.scss
+++ b/packages/design/src/components/dialogue-tree/_dialogue-tree.scss
@@ -30,11 +30,13 @@
                 border-top: 1px solid $dialogue-tree-color-border-default;
             }
 
-            // .is-hover only for screenshot selector
-            &.is-hover,
-            &:hover {
-                background-color: $dialogue-tree-color-background-hover;
-                z-index: 1;
+            @media (hover: hover) {
+                // .is-hover only for screenshot selector
+                &.is-hover,
+                &:hover {
+                    background-color: $dialogue-tree-color-background-hover;
+                    z-index: 1;
+                }
             }
 
             button:focus-visible {

--- a/packages/design/src/components/error-list/_error-list.scss
+++ b/packages/design/src/components/error-list/_error-list.scss
@@ -40,8 +40,10 @@
             color: $errorlist-color-text;
         }
 
-        &:hover {
-            text-decoration-thickness: 2px;
+        @media (hover: hover) {
+            &:hover {
+                text-decoration-thickness: 2px;
+            }
         }
     }
 

--- a/packages/design/src/components/expandable-panel/_expandable-panel.scss
+++ b/packages/design/src/components/expandable-panel/_expandable-panel.scss
@@ -55,9 +55,14 @@
             font-weight: var(--f-font-weight-bold);
             line-height: var(--f-line-height-large);
 
-            &:focus-visible,
-            &:hover {
+            &:focus-visible {
                 background-color: $expandablepanel-heading-color-background-hover;
+            }
+
+            @media (hover: hover) {
+                &:hover {
+                    background-color: $expandablepanel-heading-color-background-hover;
+                }
             }
         }
     }

--- a/packages/design/src/components/layout-navigation/_layout-navigation.scss
+++ b/packages/design/src/components/layout-navigation/_layout-navigation.scss
@@ -104,8 +104,10 @@ $layout-navigation-dot-spacing: 4px !default;
                 background-color: $layout-navigation-button-color-background-focus;
             }
 
-            &:hover {
-                background-color: $layout-navigation-button-color-background-hover;
+            @media (hover: hover) {
+                &:hover {
+                    background-color: $layout-navigation-button-color-background-hover;
+                }
             }
 
             &:active {

--- a/packages/design/src/components/layout-secondary/_layout-secondary.scss
+++ b/packages/design/src/components/layout-secondary/_layout-secondary.scss
@@ -35,8 +35,10 @@ $layout-secondary-dot-spacing: 4px !default;
         bottom: 0;
         z-index: $ZINDEX;
 
-        .button--tertiary:hover {
-            background-color: $layout-secondary-button-tertiary-color-background-hover;
+        @media (hover: hover) {
+            .button--tertiary:hover {
+                background-color: $layout-secondary-button-tertiary-color-background-hover;
+            }
         }
 
         &__border {
@@ -58,8 +60,10 @@ $layout-secondary-dot-spacing: 4px !default;
             }
         }
 
-        &__border:hover {
-            background-color: $layout-secondary-resize-handle-color-background-hover;
+        @media (hover: hover) {
+            &__border:hover {
+                background-color: $layout-secondary-resize-handle-color-background-hover;
+            }
         }
 
         &__inner {

--- a/packages/design/src/components/list/_list.scss
+++ b/packages/design/src/components/list/_list.scss
@@ -43,10 +43,6 @@ $list-selectpane-padding: calc(var(--f-list-item-itempane-padding) - 0.2rem);
     &__item {
         @extend %list-item;
 
-        &--hover {
-            @extend %list-item-hover;
-        }
-
         &--active {
             @extend %list-item-active;
         }
@@ -95,14 +91,27 @@ $list-selectpane-padding: calc(var(--f-list-item-itempane-padding) - 0.2rem);
     }
 
     &--hover {
-        .list__item:focus-within,
-        .list__item:hover {
+        .list__item:focus-within {
             cursor: pointer;
             @extend %list-item-hover;
 
             &.list__item {
                 &--active {
                     @extend %list-item-active;
+                }
+            }
+        }
+
+        @media (hover: hover) {
+            .list__item:hover {
+                cursor: pointer;
+
+                &:not(.disabled) {
+                    background: $list-row-color-background-hover;
+                }
+
+                &.list__item--active {
+                    background: $list-row-color-background-active;
                 }
             }
         }

--- a/packages/design/src/components/navigation-menu/_navigation-menu.scss
+++ b/packages/design/src/components/navigation-menu/_navigation-menu.scss
@@ -25,11 +25,13 @@
                 }
             }
 
-            a:hover {
-                color: $navigationmenu-menuitem-color-text-hover;
+            @media (hover: hover) {
+                a:hover {
+                    color: $navigationmenu-menuitem-color-text-hover;
 
-                @media (forced-colors: active) {
-                    color: LinkText;
+                    @media (forced-colors: active) {
+                        color: LinkText;
+                    }
                 }
             }
         }
@@ -59,10 +61,12 @@
             padding: size.$padding-075;
             display: block;
 
-            &:hover {
-                font-weight: var(--f-font-weight-normal);
-                background-color: $navigationmenu-vertical-color-background-hover;
-                @include forcedcolors.hover-indicator(outline, 2px);
+            @media (hover: hover) {
+                &:hover {
+                    font-weight: var(--f-font-weight-normal);
+                    background-color: $navigationmenu-vertical-color-background-hover;
+                    @include forcedcolors.hover-indicator(outline, 2px);
+                }
             }
 
             &--highlight {
@@ -79,11 +83,13 @@
                 }
             }
 
-            &--highlight:hover {
-                background-color: $navigationmenu-vertical-color-background-selected;
-                font-weight: var(--f-font-weight-medium);
-                color: $navigationmenu-vertical-menuitem-color-text-selected;
-                @include forcedcolors.selected-indicator;
+            @media (hover: hover) {
+                &--highlight:hover {
+                    background-color: $navigationmenu-vertical-color-background-selected;
+                    font-weight: var(--f-font-weight-medium);
+                    color: $navigationmenu-vertical-menuitem-color-text-selected;
+                    @include forcedcolors.selected-indicator;
+                }
             }
         }
     }
@@ -109,8 +115,10 @@
                     @include forcedcolors.hover-indicator(border-bottom, 5px);
                 }
 
-                .imenu__list__anchor:hover {
-                    font-weight: var(--f-font-weight-medium);
+                @media (hover: hover) {
+                    .imenu__list__anchor:hover {
+                        font-weight: var(--f-font-weight-medium);
+                    }
                 }
             }
 
@@ -119,9 +127,11 @@
             }
         }
 
-        &__item:not(.imenu__list__item--highlight) .imenu__list__anchor-container:hover {
-            border-bottom: 5px solid $navigationmenu-horizontal-color-border-hover;
-            @include forcedcolors.hover-indicator(border-bottom, 5px);
+        @media (hover: hover) {
+            &__item:not(.imenu__list__item--highlight) .imenu__list__anchor-container:hover {
+                border-bottom: 5px solid $navigationmenu-horizontal-color-border-hover;
+                @include forcedcolors.hover-indicator(border-bottom, 5px);
+            }
         }
 
         &__anchor-container {

--- a/packages/design/src/components/paginator/_paginator.scss
+++ b/packages/design/src/components/paginator/_paginator.scss
@@ -42,9 +42,11 @@ $paginator-width-full: $button-width + $gap-size + $page-width * $number-of-page
             @include forcedcolors.selected-indicator;
         }
 
-        &:hover:enabled:not(&--active) {
-            background-color: var(--fkds-color-action-background-secondary-hover);
-            @include forcedcolors.hover-indicator(border, 2px);
+        @media (hover: hover) {
+            &:hover:enabled:not(&--active) {
+                background-color: var(--fkds-color-action-background-secondary-hover);
+                @include forcedcolors.hover-indicator(border, 2px);
+            }
         }
     }
 

--- a/packages/design/src/components/select-field/_select-field.scss
+++ b/packages/design/src/components/select-field/_select-field.scss
@@ -42,8 +42,10 @@
             border-color: ButtonBorder;
         }
 
-        &:hover {
-            background-color: $selectfield-color-background-hover;
+        @media (hover: hover) {
+            &:hover {
+                background-color: $selectfield-color-background-hover;
+            }
         }
 
         &:focus-visible {

--- a/packages/design/src/components/selectable-item/_selectable-item.scss
+++ b/packages/design/src/components/selectable-item/_selectable-item.scss
@@ -9,6 +9,7 @@
     width: 100%;
     cursor: pointer;
     border-bottom: none;
+
     &:last-child {
         border-bottom: list.$list-border;
     }
@@ -17,21 +18,28 @@
         outline: 2px solid $selectable-item-button-border-color-border-default;
         outline-offset: -2px;
     }
+
     input + label::after {
         top: 0.9rem;
         left: 1rem;
     }
+
     input:checked + label::after {
         top: 0.9rem;
         left: 1rem;
     }
-    &:hover {
-        @extend %list-item-hover;
+
+    @media (hover: hover) {
+        &:hover {
+            background: $selectable-item-color-background-hover;
+        }
     }
+
     label::before {
         top: 0.9rem;
         left: 1rem;
     }
+
     label {
         padding: 1rem;
         padding-left: 3rem;

--- a/packages/design/src/components/selectable-item/_variables.scss
+++ b/packages/design/src/components/selectable-item/_variables.scss
@@ -3,3 +3,4 @@ $selectable-item-color-text-details: var(--fkds-color-text-secondary) !default;
 
 // BORDER
 $selectable-item-button-border-color-border-default: var(--fkds-color-border-primary) !default;
+$selectable-item-color-background-hover: var(--fkds-color-select-background-primary-hover) !default;

--- a/packages/design/src/components/table-ng/_cell.scss
+++ b/packages/design/src/components/table-ng/_cell.scss
@@ -22,8 +22,10 @@ $cell-border-width: 1px;
         outline-offset: -$table-ng-selection-outline;
     }
 
-    &:not(&--menu-open):hover:has(button) {
-        background: $table-ng-cell-color-hover-background;
+    @media (hover: hover) {
+        &:not(&--menu-open):hover:has(button) {
+            background: $table-ng-cell-color-hover-background;
+        }
     }
 
     input,
@@ -75,8 +77,10 @@ $cell-border-width: 1px;
     &--text {
         padding: 0;
 
-        &:hover {
-            background: $table-ng-cell-color-hover-background;
+        @media (hover: hover) {
+            &:hover {
+                background: $table-ng-cell-color-hover-background;
+            }
         }
     }
 
@@ -102,8 +106,11 @@ $cell-border-width: 1px;
                 border-radius: 0;
             }
         }
-        &:hover:has(.table-ng__textedit:focus-visible) {
-            background: transparent;
+
+        @media (hover: hover) {
+            &:hover:has(.table-ng__textedit:focus-visible) {
+                background: transparent;
+            }
         }
     }
 
@@ -116,9 +123,11 @@ $cell-border-width: 1px;
             background: transparent;
         }
 
-        &:hover:not(:has(:focus-visible)) {
-            box-shadow: inset 0 (-$underline-thickness) 0 0 $table-ng-cell-color-underline;
-            border-radius: 0;
+        @media (hover: hover) {
+            &:hover:not(:has(:focus-visible)) {
+                box-shadow: inset 0 (-$underline-thickness) 0 0 $table-ng-cell-color-underline;
+                border-radius: 0;
+            }
         }
     }
 
@@ -141,10 +150,12 @@ $cell-border-width: 1px;
             }
         }
 
-        &.table-ng__cell--error:hover:not(:has(:focus-visible)) {
-            .table-ng__editable {
-                box-shadow: inset 0 (-$underline-thickness) 0 0 $table-ng-cell-color-error;
-                border-radius: 0;
+        @media (hover: hover) {
+            &.table-ng__cell--error:hover:not(:has(:focus-visible)) {
+                .table-ng__editable {
+                    box-shadow: inset 0 (-$underline-thickness) 0 0 $table-ng-cell-color-error;
+                    border-radius: 0;
+                }
             }
         }
 
@@ -177,9 +188,11 @@ $cell-border-width: 1px;
                 }
             }
 
-            &:hover {
-                box-shadow: inset 0 (-$underline-thickness) 0 0 $table-ng-cell-color-underline;
-                border-radius: 0;
+            @media (hover: hover) {
+                &:hover {
+                    box-shadow: inset 0 (-$underline-thickness) 0 0 $table-ng-cell-color-underline;
+                    border-radius: 0;
+                }
             }
         }
     }
@@ -196,9 +209,11 @@ $cell-border-width: 1px;
             accent-color: $table-ng-button-primary-color-background-default;
         }
 
-        &:hover {
-            background: $table-ng-cell-color-hover-background;
-            accent-color: $table-ng-button-primary-color-background-hover;
+        @media (hover: hover) {
+            &:hover {
+                background: $table-ng-cell-color-hover-background;
+                accent-color: $table-ng-button-primary-color-background-hover;
+            }
         }
     }
 
@@ -213,8 +228,11 @@ $cell-border-width: 1px;
             background: inherit;
             color: $table-ng-button-primary-color-background-default;
             cursor: pointer;
-            &:hover {
-                color: $table-ng-button-primary-color-background-hover;
+
+            @media (hover: hover) {
+                &:hover {
+                    color: $table-ng-button-primary-color-background-hover;
+                }
             }
 
             svg {
@@ -231,8 +249,10 @@ $cell-border-width: 1px;
     &--selectable {
         width: var(--f-icon-size-medium);
 
-        &:hover {
-            background: $table-ng-cell-color-hover-background;
+        @media (hover: hover) {
+            &:hover {
+                background: $table-ng-cell-color-hover-background;
+            }
         }
     }
 
@@ -331,8 +351,14 @@ $cell-border-width: 1px;
         color: CanvasText;
     }
 
-    .table-ng__cell--text:hover .table-ng__editable,
-    .table-ng__cell--select:hover .table-ng__editable,
+    @media (hover: hover) {
+        .table-ng__cell--text:hover .table-ng__editable,
+        .table-ng__cell--select:hover .table-ng__editable {
+            box-shadow: inset 0 (-$underline-thickness) 0 0 Highlight;
+            border-radius: 0;
+        }
+    }
+
     .table-ng__cell--text:has(:focus-visible) .table-ng__editable,
     .table-ng__cell--select:focus-within .table-ng__editable {
         box-shadow: inset 0 (-$underline-thickness) 0 0 Highlight;

--- a/packages/design/src/components/table/_table.scss
+++ b/packages/design/src/components/table/_table.scss
@@ -47,9 +47,9 @@ $table-input-offset-horizontal: 0.25rem;
 }
 
 %table-row-hover {
-    background: var(--fkds-color-select-background-primary-hover);
+    background: $table-color-row-background-hover;
     color: $table-color-row-text;
-    outline: 1px solid var(--fkds-color-border-primary);
+    outline: $table-row-outline-hover;
 }
 
 %table-row-focus-within {
@@ -318,22 +318,27 @@ $table-input-offset-horizontal: 0.25rem;
     }
 
     &--hover tbody {
-        .table__row:hover {
-            @extend %table-row-hover;
+        @media (hover: hover) {
+            .table__row:hover {
+                background: $table-color-row-background-hover;
+                color: $table-color-row-text;
+                outline: $table-row-outline-hover;
 
-            // these have higher priority
-            &.table__row {
-                &--active {
-                    @extend %table-row-active;
+                // these have higher priority
+                &.table__row--active {
+                    background: $table-color-row-background-hover;
+                    color: $table-color-row-text;
                 }
             }
         }
     }
 
     &--selectable .table__row {
-        td:hover,
-        th:hover {
-            cursor: pointer;
+        @media (hover: hover) {
+            td:hover,
+            th:hover {
+                cursor: pointer;
+            }
         }
     }
 

--- a/packages/design/src/components/table/_variables.scss
+++ b/packages/design/src/components/table/_variables.scss
@@ -10,5 +10,7 @@ $table-header-border: 2px solid var(--fkds-color-border-primary) !default;
 // Rows
 $table-color-row-background: var(--fkds-color-background-primary) !default;
 $table-color-row-background-alt: var(--fkds-color-background-secondary) !default;
+$table-color-row-background-hover: var(--fkds-color-select-background-primary-hover) !default;
 $table-color-row-text: var(--fkds-color-text-primary) !default;
+$table-row-outline-hover: 1px solid var(--fkds-color-border-primary) !default;
 $table-row-separator: 1px solid var(--fkds-color-border-primary) !default;

--- a/packages/design/src/components/wizard/_wizard-step.scss
+++ b/packages/design/src/components/wizard/_wizard-step.scss
@@ -180,9 +180,11 @@ $icon-size: 30px;
             text-underline-offset: 0.25em;
         }
 
-        #{$anchor-selector}:hover {
-            text-decoration-thickness: 3px;
-            text-underline-offset: 0.25em;
+        @media (hover: hover) {
+            #{$anchor-selector}:hover {
+                text-decoration-thickness: 3px;
+                text-underline-offset: 0.25em;
+            }
         }
 
         #{$success-selector} {

--- a/packages/design/src/core/mixins/_anchor.scss
+++ b/packages/design/src/core/mixins/_anchor.scss
@@ -11,13 +11,15 @@
     text-decoration-thickness: $anchor-underline-width-default;
     text-underline-offset: $anchor-underline-offset-default;
 
-    &:hover {
-        color: $anchor-color-text-standard-default;
-        text-decoration-color: $anchor-color-text-standard-default;
-        text-decoration-thickness: $anchor-underline-width-hover;
+    @media (hover: hover) {
+        &:hover {
+            color: $anchor-color-text-standard-default;
+            text-decoration-color: $anchor-color-text-standard-default;
+            text-decoration-thickness: $anchor-underline-width-hover;
 
-        @media (forced-colors: active) {
-            color: LinkText;
+            @media (forced-colors: active) {
+                color: LinkText;
+            }
         }
     }
 
@@ -41,9 +43,11 @@
     color: $anchor-color-text-discrete-default;
     text-decoration-color: $anchor-color-text-decoration-discrete-default;
 
-    &:hover {
-        color: $anchor-color-text-discrete-default;
-        text-decoration-color: $anchor-color-text-decoration-discrete-default;
+    @media (hover: hover) {
+        &:hover {
+            color: $anchor-color-text-discrete-default;
+            text-decoration-color: $anchor-color-text-decoration-discrete-default;
+        }
     }
 }
 

--- a/packages/design/src/core/mixins/_button.scss
+++ b/packages/design/src/core/mixins/_button.scss
@@ -43,11 +43,13 @@
         color: $color--focus;
     }
 
-    &:hover {
-        background-color: $background-color--hover;
-        border-color: $border-color--hover;
-        box-shadow: $shadow--hover;
-        color: $color--hover;
+    @media (hover: hover) {
+        &:hover {
+            background-color: $background-color--hover;
+            border-color: $border-color--hover;
+            box-shadow: $shadow--hover;
+            color: $color--hover;
+        }
     }
 
     &:active {

--- a/packages/design/src/internal-components/calendar/_calendar.scss
+++ b/packages/design/src/internal-components/calendar/_calendar.scss
@@ -19,9 +19,11 @@
 
             margin: 5px;
 
-            &.is-hover,
-            &:hover:not(&--highlight) {
-                @include listbox.option-hover;
+            @media (hover: hover) {
+                &.is-hover,
+                &:hover:not(&--highlight) {
+                    @include listbox.option-hover;
+                }
             }
 
             &--highlight {

--- a/packages/design/src/internal-components/popup-menu/_popup-menu.scss
+++ b/packages/design/src/internal-components/popup-menu/_popup-menu.scss
@@ -27,11 +27,13 @@
                 }
             }
 
-            a:hover {
-                color: $popupmenu-color-text-hover;
+            @media (hover: hover) {
+                a:hover {
+                    color: $popupmenu-color-text-hover;
 
-                @media (forced-colors: active) {
-                    color: LinkText;
+                    @media (forced-colors: active) {
+                        color: LinkText;
+                    }
                 }
             }
         }
@@ -46,9 +48,11 @@
             padding: size.$padding-075;
             display: block;
 
-            &:hover:not(.ipopupmenu__list__item--highlight) {
-                background-color: $popupmenu-color-background-hover;
-                @include forcedcolors.hover-indicator(outline, 2px);
+            @media (hover: hover) {
+                &:hover:not(.ipopupmenu__list__item--highlight) {
+                    background-color: $popupmenu-color-background-hover;
+                    @include forcedcolors.hover-indicator(outline, 2px);
+                }
             }
 
             &--highlight {

--- a/packages/vue/src/components/FDetailsPanel/FDetailsPanel.scss
+++ b/packages/vue/src/components/FDetailsPanel/FDetailsPanel.scss
@@ -60,8 +60,10 @@
     padding: 1rem;
     width: max-content;
 
-    &:hover {
-        background-color: $details-panel-icon-hover;
+    @media (hover: hover) {
+        &:hover {
+            background-color: $details-panel-icon-hover;
+        }
     }
 
     &:active {

--- a/packages/vue/src/components/FMinimizablePanel/_minimizable-panel.scss
+++ b/packages/vue/src/components/FMinimizablePanel/_minimizable-panel.scss
@@ -60,8 +60,10 @@
     padding: 1rem;
     width: max-content;
 
-    &:hover {
-        background-color: $minimizable-panel-icon-hover;
+    @media (hover: hover) {
+        &:hover {
+            background-color: $minimizable-panel-icon-hover;
+        }
     }
 
     &:active {

--- a/packages/vue/src/components/FResizePane/FResizePane.scss
+++ b/packages/vue/src/components/FResizePane/FResizePane.scss
@@ -171,8 +171,18 @@ $handle-offset: ($handle-size + $handle-expand) * 0.5;
         position: absolute;
     }
 
+    @media (hover: hover) {
+        &:hover::before {
+            background-color: $handle-highlight;
+            transition-delay: $transition-delay;
+
+            @media (forced-colors: active) {
+                background-color: Highlight;
+            }
+        }
+    }
+
     &:focus::before,
-    &:hover::before,
     &.drag::before {
         background-color: $handle-highlight;
         transition-delay: $transition-delay;


### PR DESCRIPTION
Under tidigare testning av interaktioner på mobil visade det sig att hover styling fastnar på touch tills dess att man rör nåt annat. Tydligen har detta varit ett problem och diskuterats online i över ett årtionde. Rekommenderad åtgärd i dagsläget ser ut att vara att man ska använda `@media (hover: hover)` (baseline sedan 2018) för att se till att hover-effekter inte aktiveras på enheter som egentligen inte har support för hover då de inte har en cursor. I vissa fall har `(cursor: fine)` också använts för att det bara ska appliceras på detaljstyrt pekdon, men det ser ut som att det räcker med `hover: hover` för att lösa detta problemet.

Har wrappat all vår hover-relaterade styling med `@media (hover: hover) { ... }`, vilket innebär att `@extend` inte kan användas och har ersatts. 