### PR TITLE
fix(vscode): fix html-validate issue when resolving paths

### DIFF
--- a/packages/vue/htmlvalidate/configs/recommended.mjs
+++ b/packages/vue/htmlvalidate/configs/recommended.mjs
@@ -1,12 +1,21 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "html-validate";
+
+/**
+ * @param {string} specifier
+ * @returns {string}
+ */
+function resolve(specifier) {
+    return fileURLToPath(import.meta.resolve(specifier));
+}
 
 export default defineConfig({
     plugins: ["html-validate-vue"],
     elements: [
         "html5",
-        import.meta.resolve("../elements/overrides.mjs"),
-        import.meta.resolve("../elements/components.mjs"),
-        import.meta.resolve("../elements/internal-components.mjs"),
+        resolve("../elements/overrides.mjs"),
+        resolve("../elements/components.mjs"),
+        resolve("../elements/internal-components.mjs"),
     ],
     rules: {
         "fkui/button-group": "error",


### PR DESCRIPTION
Trasigt sen 22 aug, ingen som sagt något :disappointed: 

1. Öppna detta repot, eller ett repo som använder `@fkui/vue`. Typ valfritt template-repo. Eller codespace.
2. Öppna en vue-fil

<img width="478" height="345" alt="image" src="https://github.com/user-attachments/assets/99071e82-4eb9-4574-ab97-001bc9bc6a07" />

> ```
> 2026-09-10 11:34:31.322 [error] node:internal/modules/cjs/loader:1524
> 2026-09-10 11:34:31.322 [error]   const err = new Error(message);
> 2026-09-10 11:34:31.322 [error]               ^
> 2026-09-10 11:34:31.322 [error] 
> 2026-09-10 11:34:31.322 [error] Error: Cannot find module 'file:///home/ext/workspace/forsakringskassan/designsystem/packages/vue/htmlvalidate/elements/overrides.mjs'
> 2026-09-10 11:34:31.322 [error] Require stack:
> 2026-09-10 11:34:31.322 [error] - /home/ext/workspace/forsakringskassan/designsystem/node_modules/html-validate/dist/cjs/core-nodejs.js
> 2026-09-10 11:34:31.322 [error] - /home/ext/workspace/forsakringskassan/designsystem/node_modules/html-validate/dist/cjs/index.js
> 2026-09-10 11:34:31.322 [error] - /home/ext/.vscode/extensions/html-validate.vscode-html-validate-2.17.12/server/out/server.mjs
> 2026-09-10 11:34:31.322 [error]     at Module._resolveFilename (node:internal/modules/cjs/loader:1524:15)
> 2026-09-10 11:34:31.322 [error]     at wrapResolveFilename (node:internal/modules/cjs/loader:1078:27)
> 2026-09-10 11:34:31.322 [error]     at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1129:12)
> 2026-09-10 11:34:31.322 [error]     at require.resolve (node:internal/modules/helpers:171:31)
> 2026-09-10 11:34:31.322 [error]     at importResolve (/home/ext/workspace/forsakringskassan/designsystem/node_modules/html-validate/dist/cjs/core-nodejs.js:45:43)
> 2026-09-10 11:34:31.322 [error]     at getModuleName (/home/ext/workspace/forsakringskassan/designsystem/node_modules/html-validate/dist/cjs/core-nodejs.js:163:64)
> 2026-09-10 11:34:31.322 [error]     at internalImport (/home/ext/workspace/forsakringskassan/designsystem/node_modules/html-validate/dist/cjs/core-nodejs.js:183:23)
> 2026-09-10 11:34:31.322 [error]     at Object.resolveElements (/home/ext/workspace/forsakringskassan/designsystem/node_modules/html-validate/dist/cjs/core-nodejs.js:209:14)
> 2026-09-10 11:34:31.322 [error]     at resolveElements (/home/ext/workspace/forsakringskassan/designsystem/node_modules/html-validate/dist/cjs/core.js:12734:31)
> 2026-09-10 11:34:31.322 [error]     at Config.getElementsFromEntry (/home/ext/workspace/forsakringskassan/designsystem/node_modules/html-validate/dist/cjs/core.js:13129:19) {
> 2026-09-10 11:34:31.322 [error]   code: 'MODULE_NOT_FOUND',
> 2026-09-10 11:34:31.322 [error]   requireStack: [
> 2026-09-10 11:34:31.322 [error]     '/home/ext/workspace/forsakringskassan/designsystem/node_modules/html-validate/dist/cjs/core-nodejs.js',
> 2026-09-10 11:34:31.322 [error]     '/home/ext/workspace/forsakringskassan/designsystem/node_modules/html-validate/dist/cjs/index.js',
> 2026-09-10 11:34:31.322 [error]     '/home/ext/.vscode/extensions/html-validate.vscode-html-validate-2.17.12/server/out/server.mjs'
> 2026-09-10 11:34:31.322 [error]   ]
> 2026-09-10 11:34:31.323 [error] }
> 2026-09-10 11:34:31.323 [error] 
> 2026-09-10 11:34:31.323 [error] Node.js v24.18.1
> 2026-09-10 11:34:31.323 [error] Server process exited with code 1.
> 2026-09-10 11:34:31.330 [error] Client HTML-Validate: connection to server is erroring.
> ```

Det fungerar i ESM (så CLI, Vitest osv är ok) men vscode verkar hamna i en CJS-snurra (enligt stacktrace iaf) och `require()` klarar inte av `file://` urlar. Det är väl en senare huvudvärk kanske men tänker att våran konfiguration bör fungera oavsett.